### PR TITLE
ifaces: remove unnecesary loop when gathering info

### DIFF
--- a/src/lib/ifaces/ifaces.rs
+++ b/src/lib/ifaces/ifaces.rs
@@ -64,8 +64,6 @@ async fn _get_ifaces() -> Result<HashMap<String, Iface>, Error> {
                             _ => IfaceType::Unknown,
                         };
                     }
-                }
-                for info in infos {
                     if let nlas::Info::Data(d) = info {
                         match iface_state.iface_type {
                             IfaceType::Bond => {


### PR DESCRIPTION
Nispor is looping over all the `infos` in order to retrieve the
interface type, then it iterates over them again to get the interface
information. That could be done in the same iteration.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>