### PR TITLE
cli: use clap for cmdline arg parsing

### DIFF
--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -9,5 +9,8 @@ name = "npc"
 path = "npc.rs"
 
 [dependencies]
+serde = "1.0"
 serde_json = "1.0"
+serde_derive = "1.0"
+clap = "2.33.3"
 nispor = { path = "../lib" }

--- a/src/cli/npc.rs
+++ b/src/cli/npc.rs
@@ -1,41 +1,92 @@
-use nispor::NetState;
+use clap::{clap_app, crate_authors, crate_version};
+use nispor::{Iface, NetState, NisporError, Route, RouteRule};
+use serde_derive::Serialize;
 use serde_json;
-use std::env::args;
+use std::fmt::{Display, Formatter, Result};
+use std::process;
+
+#[derive(Serialize)]
+pub struct CliError {
+    pub msg: String,
+}
+
+impl Display for CliError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "{}", self.msg)
+    }
+}
+
+#[derive(Serialize)]
+enum CliResult {
+    Full(NetState),
+    Ifaces(Vec<Iface>),
+    Routes(Vec<Route>),
+    RouteRules(Vec<RouteRule>),
+    Error(CliError),
+    NisporError(NisporError),
+}
 
 fn main() {
-    let argv: Vec<String> = args().collect();
-    match NetState::retrieve() {
-        Ok(state) => {
-            if argv.len() > 1 {
-                match &state.ifaces.get(&argv[1]) {
-                    Some(iface) => println!(
-                        "{}",
-                        serde_json::to_string_pretty(iface).unwrap()
-                    ),
-                    None => {
-                        if argv[1] == "route" {
-                            println!(
-                                "{}",
-                                serde_json::to_string_pretty(&state.routes)
-                                    .unwrap()
-                            );
-                        } else if argv[1] == "rule" {
-                            println!(
-                                "{}",
-                                serde_json::to_string_pretty(&state.rules)
-                                    .unwrap()
-                            );
-                        } else {
-                            eprintln!("Interface '{}' not found", argv[1]);
-                        }
-                    }
+    let matches = clap_app!(npc =>
+        (version: crate_version!())
+        (author: crate_authors!())
+        (about: "Nispor CLI")
+        (@arg ifname: [INTERFACE_NAME] "interface name")
+        (@subcommand route =>
+            (about: "Show routes")
+        )
+        (@subcommand rule =>
+            (about: "Show routes rules")
+        )
+    )
+    .get_matches();
+
+    let result = match NetState::retrieve() {
+        Ok(mut state) => {
+            if let Some(ifname) = matches.value_of("ifname") {
+                if let Some(iface) = state.ifaces.remove(ifname) {
+                    CliResult::Ifaces(vec![iface])
+                } else {
+                    CliResult::Error(CliError {
+                        msg: format!("Interface '{}' not found", ifname),
+                    })
                 }
+            } else if let Some(_) = matches.subcommand_matches("route") {
+                CliResult::Routes(state.routes)
+            } else if let Some(_) = matches.subcommand_matches("rule") {
+                CliResult::RouteRules(state.rules)
             } else {
-                println!("{}", serde_json::to_string_pretty(&state).unwrap());
+                /* Show everything if no cmdline arg has been supplied */
+                CliResult::Full(state)
             }
         }
-        Err(e) => {
-            eprintln!("{}", e);
+        Err(e) => CliResult::NisporError(e),
+    };
+
+    match result {
+        CliResult::Full(netstate) => {
+            println!("{}", serde_json::to_string_pretty(&netstate).unwrap());
+            process::exit(0);
+        }
+        CliResult::Ifaces(ifaces) => {
+            println!("{}", serde_json::to_string_pretty(&ifaces).unwrap());
+            process::exit(0);
+        }
+        CliResult::Routes(routes) => {
+            println!("{}", serde_json::to_string_pretty(&routes).unwrap());
+            process::exit(0);
+        }
+        CliResult::RouteRules(rules) => {
+            println!("{}", serde_json::to_string_pretty(&rules).unwrap());
+            process::exit(0);
+        }
+        CliResult::NisporError(e) => {
+            eprintln!("{}", serde_json::to_string_pretty(&e).unwrap());
+            process::exit(1);
+        }
+        CliResult::Error(e) => {
+            eprintln!("{}", serde_json::to_string_pretty(&e).unwrap());
+            process::exit(1);
         }
     }
 }

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -1,7 +1,8 @@
 use netlink_packet_utils::DecodeError;
 use rtnetlink;
+use serde_derive::Serialize;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub enum ErrorKind {
     NetlinkError,
     NisporBug,
@@ -13,7 +14,7 @@ impl std::fmt::Display for ErrorKind {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct NisporError {
     pub kind: ErrorKind,
     pub msg: String,


### PR DESCRIPTION
Now you have subcommands 'link', 'route', 'help' and '-V' and '-h' switches.

By using clap you also easily get a usage message and everything else
you would expect from a cli app.

Signed-off-by: Antonio Cardace <acardace@redhat.com>