### PR TITLE
all: rename NetState::get_state() to ::retrieve()

### DIFF
--- a/src/cli/npc.rs
+++ b/src/cli/npc.rs
@@ -1,10 +1,10 @@
-use nispor::get_state;
+use nispor::NetState;
 use serde_json;
 use std::env::args;
 
 fn main() {
     let argv: Vec<String> = args().collect();
-    match get_state() {
+    match NetState::retrieve() {
         Ok(state) => {
             if argv.len() > 1 {
                 match &state.ifaces.get(&argv[1]) {

--- a/src/clib/lib.rs
+++ b/src/clib/lib.rs
@@ -4,7 +4,7 @@ use serde_json;
 use std::ffi::CString;
 
 #[no_mangle]
-pub extern "C" fn nispor_state_get(
+pub extern "C" fn nispor_net_state_retrieve(
     state: *mut *mut c_char,
     err_kind: *mut *mut c_char,
     err_msg: *mut *mut c_char,
@@ -19,7 +19,7 @@ pub extern "C" fn nispor_state_get(
         *err_msg = std::ptr::null_mut();
     }
 
-    match nispor::get_state() {
+    match nispor::NetState::retrieve() {
         Ok(s) => unsafe {
             *state = CString::new(serde_json::to_string(&s).unwrap())
                 .unwrap()
@@ -36,7 +36,7 @@ pub extern "C" fn nispor_state_get(
 }
 
 #[no_mangle]
-pub extern "C" fn nispor_state_free(state: *mut c_char) {
+pub extern "C" fn nispor_net_state_free(state: *mut c_char) {
     unsafe {
         if state != std::ptr::null_mut() {
             CString::from_raw(state);

--- a/src/clib/nispor.h.in
+++ b/src/clib/nispor.h.in
@@ -34,17 +34,17 @@ extern "C" {
 #define NISPOR_FAIL                 1
 
 /**
- * nispor_state_get - Get network state
+ * nispor_net_state_retrieve - Retrieve network state
  *
  * Version:
  *      0.2
  *
  * Description:
- *      Get network state in the format of JSON.
+ *      Retrieve network state in the format of JSON.
  *
  * @state:
  *      Output pointer of char array for network state in json format.
- *      The memory should be freed by nispor_state_free().
+ *      The memory should be freed by nispor_net_state_free().
  * @err_kind:
  *      Output pointer of char array for error kind.
  *      The memory should be freed by nispor_err_kind_free().
@@ -59,9 +59,9 @@ extern "C" {
  *          * NISPOR_FAIL
  *              On failure.
  */
-int nispor_state_get(char **state, char **err_kind, char **err_msg);
+int nispor_net_state_retrieve(char **state, char **err_kind, char **err_msg);
 
-void nispor_state_free(char *state);
+void nispor_net_state_free(char *state);
 
 void nispor_err_msg_free(char *err_msg);
 

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -25,6 +25,5 @@ pub use crate::ip::Ipv4Info;
 pub use crate::ip::Ipv6AddrInfo;
 pub use crate::ip::Ipv6Info;
 pub(crate) use crate::mac::parse_as_mac;
-pub use crate::net_state::get_state;
 pub use crate::net_state::NetState;
 pub use crate::route::Route;

--- a/src/lib/net_state.rs
+++ b/src/lib/net_state.rs
@@ -12,8 +12,10 @@ pub struct NetState {
     pub routes: Vec<Route>,
 }
 
-pub fn get_state() -> Result<NetState, NisporError> {
-    let ifaces = get_ifaces()?;
-    let routes = get_routes(&ifaces)?;
-    Ok(NetState { ifaces, routes })
+impl NetState {
+    pub fn retrieve() -> Result<NetState, NisporError> {
+        let ifaces = get_ifaces()?;
+        let routes = get_routes(&ifaces)?;
+        Ok(NetState { ifaces, routes })
+    }
 }

--- a/src/lib/tests/dummy.rs
+++ b/src/lib/tests/dummy.rs
@@ -1,4 +1,4 @@
-extern crate nispor;
+use nispor::NetState;
 
 use std::panic;
 
@@ -9,7 +9,7 @@ const IFACE_STATE: &str = "dummy1";
 #[test]
 fn test_get_iface_dummy_type() {
     with_dummy1_iface(|| {
-        if let Ok(state) = nispor::get_state() {
+        if let Ok(state) = NetState::retrieve() {
             let iface = &state.ifaces[IFACE_STATE];
             let iface_type = &iface.iface_type;
             assert_eq!(iface_type, &nispor::IfaceType::Dummy)

--- a/src/lib/tests/iface_common.rs
+++ b/src/lib/tests/iface_common.rs
@@ -1,4 +1,4 @@
-extern crate nispor;
+use nispor::NetState;
 
 use std::panic;
 use std::thread::sleep;
@@ -12,7 +12,7 @@ const IFACE_MAC_TEST: &str = "AA:BB:CC:DD:EE:FF";
 #[test]
 fn test_get_iface_name() {
     with_eth1_iface(|| {
-        if let Ok(state) = nispor::get_state() {
+        if let Ok(state) = NetState::retrieve() {
             let iface = &state.ifaces[IFACE_TEST];
             let iface_name = &iface.name;
             assert_eq!(iface_name, IFACE_TEST);
@@ -27,7 +27,7 @@ fn test_get_iface_mtu() {
             "ip",
             vec!["link", "set", "dev", IFACE_TEST, "mtu", "1000"],
         );
-        if let Ok(state) = nispor::get_state() {
+        if let Ok(state) = NetState::retrieve() {
             let iface = &state.ifaces[IFACE_TEST];
             let mtu = iface.mtu;
             assert_eq!(mtu, 1000);
@@ -38,7 +38,7 @@ fn test_get_iface_mtu() {
 #[test]
 fn test_get_iface_type() {
     with_eth1_iface(|| {
-        if let Ok(state) = nispor::get_state() {
+        if let Ok(state) = NetState::retrieve() {
             let iface = &state.ifaces[IFACE_TEST];
             let iface_type = &iface.iface_type;
             assert_eq!(iface_type, &nispor::IfaceType::Veth);
@@ -54,7 +54,7 @@ fn test_get_iface_mac() {
             vec!["link", "set", "dev", IFACE_TEST, "address", IFACE_MAC_TEST],
         );
         sleep(time::Duration::from_millis(2000));
-        if let Ok(state) = nispor::get_state() {
+        if let Ok(state) = NetState::retrieve() {
             let iface = &state.ifaces[IFACE_TEST];
             let mac = &iface.mac_address;
             assert_eq!(mac, IFACE_MAC_TEST);
@@ -65,7 +65,7 @@ fn test_get_iface_mac() {
 #[test]
 fn test_get_iface_state_down() {
     with_eth1_iface(|| {
-        if let Ok(net_state) = nispor::get_state() {
+        if let Ok(net_state) = NetState::retrieve() {
             let iface = &net_state.ifaces[IFACE_TEST];
             let state = &iface.state;
             assert_eq!(state, &nispor::IfaceState::Down);
@@ -76,11 +76,8 @@ fn test_get_iface_state_down() {
 #[test]
 fn test_get_iface_state_up() {
     with_eth1_iface(|| {
-        utils::cmd_exec(
-            "ip",
-            vec!["link", "set", IFACE_TEST, "up"],
-        );
-        if let Ok(net_state) = nispor::get_state() {
+        utils::cmd_exec("ip", vec!["link", "set", IFACE_TEST, "up"]);
+        if let Ok(net_state) = NetState::retrieve() {
             let iface = &net_state.ifaces[IFACE_TEST];
             let state = &iface.state;
             assert_eq!(state, &nispor::IfaceState::Up);

--- a/src/python/nispor/__init__.py
+++ b/src/python/nispor/__init__.py
@@ -18,10 +18,10 @@ from .bond import NisporBondSubordinate
 from .bridge import NisporBridge
 from .bridge import NisporBridgePort
 from .clib_wrapper import NisporError
-from .clib_wrapper import get_state_json
+from .clib_wrapper import retrieve_net_state_json
 from .iface import NisporIfaceState
 from .route import NisporRouteState
-from .state import get_state
+from .state import NisporNetState
 from .veth import NisporVeth
 from .vlan import NisporVlan
 from .vxlan import NisporVxlan

--- a/src/python/nispor/clib_wrapper.py
+++ b/src/python/nispor/clib_wrapper.py
@@ -18,14 +18,14 @@ from ctypes.util import find_library
 
 lib = ctypes.cdll.LoadLibrary(find_library("nispor"))
 
-lib.nispor_state_get.restype = c_int
-lib.nispor_state_get.argtypes = (
+lib.nispor_net_state_retrieve.restype = c_int
+lib.nispor_net_state_retrieve.argtypes = (
     POINTER(c_char_p),
     POINTER(c_char_p),
     POINTER(c_char_p),
 )
-lib.nispor_state_free.restype = None
-lib.nispor_state_free.argtypes = (c_char_p,)
+lib.nispor_net_state_free.restype = None
+lib.nispor_net_state_free.argtypes = (c_char_p,)
 lib.nispor_err_kind_free.restype = None
 lib.nispor_err_kind_free.argtypes = (c_char_p,)
 lib.nispor_err_msg_free.restype = None
@@ -39,17 +39,17 @@ class NisporError(Exception):
         super().__init__(f"{kind}: {msg}")
 
 
-def get_state_json():
+def retrieve_net_state_json():
     c_err_msg = c_char_p()
     c_err_kind = c_char_p()
     c_state = c_char_p()
-    rc = lib.nispor_state_get(
+    rc = lib.nispor_net_state_retrieve(
         byref(c_state), byref(c_err_kind), byref(c_err_msg)
     )
     state = c_state.value
     err_msg = c_err_msg.value
     err_kind = c_err_kind.value
-    lib.nispor_state_free(c_state)
+    lib.nispor_net_state_free(c_state)
     lib.nispor_err_kind_free(c_err_kind)
     lib.nispor_err_msg_free(c_err_msg)
     if rc != 0:

--- a/src/python/nispor/state.py
+++ b/src/python/nispor/state.py
@@ -14,12 +14,12 @@
 
 import json
 
-from .clib_wrapper import get_state_json
+from .clib_wrapper import retrieve_net_state_json
 from .iface import NisporIfaceState
 from .route import NisporRouteState
 
 
-class NisporState:
+class NisporNetState:
     def __str__(self):
         return f"{self._info}"
 
@@ -36,6 +36,6 @@ class NisporState:
     def routes(self):
         return self._routes
 
-
-def get_state():
-    return NisporState(json.loads(get_state_json()))
+    @staticmethod
+    def retrieve():
+        return NisporNetState(json.loads(retrieve_net_state_json()))

--- a/src/varlink/npd.rs
+++ b/src/varlink/npd.rs
@@ -1,5 +1,5 @@
 use libc::umask;
-use nispor::get_state;
+use nispor::NetState;
 use std::process::exit;
 use varlink::{ListenConfig, VarlinkService};
 
@@ -25,7 +25,7 @@ struct MyInfoGrisgeNispor {}
 
 impl VarlinkInterface for MyInfoGrisgeNispor {
     fn get(&self, call: &mut dyn Call_Get) -> varlink::Result<()> {
-        match get_state() {
+        match NetState::retrieve() {
             Ok(s) => call.reply(s),
             Err(e) => call.fail(&e.msg),
         }


### PR DESCRIPTION
Use a retrieve() function with an impl block with is more rust idiomatic.

Signed-off-by: Antonio Cardace <acardace@redhat.com>