### PR TITLE
clib: Fix unsound free usage

### DIFF
--- a/src/clib/lib.rs
+++ b/src/clib/lib.rs
@@ -37,15 +37,15 @@ pub extern "C" fn nispor_state_get(
 
 #[no_mangle]
 pub extern "C" fn nispor_state_free(state: *mut c_char) {
-    unsafe { libc::free(state as *mut libc::c_void) }
+    unsafe { CString::from_raw(state) };
 }
 
 #[no_mangle]
 pub extern "C" fn nispor_err_kind_free(err_kind: *mut c_char) {
-    unsafe { libc::free(err_kind as *mut libc::c_void) }
+    unsafe { CString::from_raw(err_kind) };
 }
 
 #[no_mangle]
 pub extern "C" fn nispor_err_msg_free(err_msg: *mut c_char) {
-    unsafe { libc::free(err_msg as *mut libc::c_void) }
+    unsafe { CString::from_raw(err_msg) };
 }


### PR DESCRIPTION
CString should not be freed by ordinary libc free
but by using CString drop function. This will prevent
issues on systems that use custom allocators.

`The pointer which this function returns must be returned to Rust and reconstituted using from_raw to be properly deallocated. Specifically, one should not use the standard C free() function to deallocate this string.` from [0].

[0] https://doc.rust-lang.org/std/ffi/struct.CString.html#method.into_raw