### PR TITLE
python: return None if SR-IOV is not present

### DIFF
--- a/src/python/nispor/base_iface.py
+++ b/src/python/nispor/base_iface.py
@@ -21,6 +21,7 @@ class NisporBaseIface:
     def __init__(self, info):
         self._info = info
         self._sub_state = None
+        self._sr_iov = None
         if "sriov" in self._info:
             self._sr_iov = NisporSriov(self._info["sriov"])
 


### PR DESCRIPTION
When checking if the interface has SR-IOV available using
`NisporBaseIface.sr_iov` Nispor is raising the following exception:

```
self = <nispor.veth.NisporVeth object at 0x7f19be534438>

    @property
    def sr_iov(self):
>       return self._sr_iov
E       AttributeError: 'NisporVeth' object has no attribute '_sr_iov'
```

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>