### PR TITLE
routes: do not panic if multipath route found

### DIFF
--- a/src/lib/route.rs
+++ b/src/lib/route.rs
@@ -438,7 +438,10 @@ fn get_route(
                 rt.metric = Some(*d);
             }
             Nla::MultiPath(_) => {
-                todo!("netlink-rust does not support parsing this yet");
+                eprintln!(
+                    "netlink-rust does not support parsing
+                    multipath routes yet"
+                );
             }
             Nla::Pref(d) => {
                 rt.perf = Some(d[0]);


### PR DESCRIPTION
If a multipath route is found when querying, Nispor is panicking. It
should show the message and ignore the route.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>