### PR TITLE
feature: add route rule support

### DIFF
--- a/src/cli/npc.rs
+++ b/src/cli/npc.rs
@@ -19,6 +19,12 @@ fn main() {
                                 serde_json::to_string_pretty(&state.routes)
                                     .unwrap()
                             );
+                        } else if argv[1] == "rule" {
+                            println!(
+                                "{}",
+                                serde_json::to_string_pretty(&state.rules)
+                                    .unwrap()
+                            );
                         } else {
                             eprintln!("Interface '{}' not found", argv[1]);
                         }

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -5,6 +5,7 @@ mod mac;
 mod net_state;
 mod netlink;
 mod route;
+mod route_rule;
 
 pub use crate::error::NisporError;
 pub use crate::ifaces::BondAdInfo;
@@ -37,3 +38,4 @@ pub use crate::ip::Ipv6Info;
 pub(crate) use crate::mac::parse_as_mac;
 pub use crate::net_state::NetState;
 pub use crate::route::Route;
+pub use crate::route_rule::RouteRule;

--- a/src/lib/net_state.rs
+++ b/src/lib/net_state.rs
@@ -3,6 +3,8 @@ use crate::ifaces::get_ifaces;
 use crate::ifaces::Iface;
 use crate::route::get_routes;
 use crate::route::Route;
+use crate::route_rule::get_route_rules;
+use crate::route_rule::RouteRule;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -10,12 +12,18 @@ use std::collections::HashMap;
 pub struct NetState {
     pub ifaces: HashMap<String, Iface>,
     pub routes: Vec<Route>,
+    pub rules: Vec<RouteRule>,
 }
 
 impl NetState {
     pub fn retrieve() -> Result<NetState, NisporError> {
         let ifaces = get_ifaces()?;
         let routes = get_routes(&ifaces)?;
-        Ok(NetState { ifaces, routes })
+        let rules = get_route_rules()?;
+        Ok(NetState {
+            ifaces,
+            routes,
+            rules,
+        })
     }
 }

--- a/src/lib/route_rule.rs
+++ b/src/lib/route_rule.rs
@@ -1,0 +1,218 @@
+use crate::error::ErrorKind;
+use crate::netlink::parse_as_ipv4;
+use crate::netlink::parse_as_ipv6;
+use crate::route::AddressFamily;
+use crate::route::RouteProtocol;
+use crate::NisporError;
+use futures::stream::TryStreamExt;
+use netlink_packet_route::rtnl::rule::nlas::Nla;
+use netlink_packet_route::RuleMessage;
+use rtnetlink::new_connection;
+use rtnetlink::IpVersion;
+use serde_derive::{Deserialize, Serialize};
+use tokio::runtime::Runtime;
+
+const FR_ACT_TO_TBL: u8 = 1;
+const FR_ACT_GOTO: u8 = 2;
+const FR_ACT_NOP: u8 = 4;
+const FR_ACT_BLACKHOLE: u8 = 32;
+const FR_ACT_UNREACHABLE: u8 = 64;
+const FR_ACT_PROHIBIT: u8 = 128;
+
+const RT_TABLE_UNSPEC: u8 = 0;
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub enum RuleAction {
+    /* Pass to fixed table */
+    Table,
+    /* Jump to another rule */
+    Goto,
+    /* No operation */
+    Nop,
+    /* Drop without notification */
+    Blackhole,
+    /* Drop with ENETUNREACH */
+    Unreachable,
+    /* Drop with EACCES */
+    Prohibit,
+    Other(u8),
+    Unknown,
+}
+
+impl From<u8> for RuleAction {
+    fn from(d: u8) -> Self {
+        match d {
+            FR_ACT_TO_TBL => Self::Table,
+            FR_ACT_GOTO => Self::Goto,
+            FR_ACT_NOP => Self::Nop,
+            FR_ACT_BLACKHOLE => Self::Blackhole,
+            FR_ACT_UNREACHABLE => Self::Unreachable,
+            FR_ACT_PROHIBIT => Self::Prohibit,
+            _ => Self::Other(d),
+        }
+    }
+}
+
+impl Default for RuleAction {
+    fn default() -> Self {
+        Self::Unknown
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+pub struct RouteRule {
+    pub action: RuleAction,
+    pub address_family: AddressFamily,
+    pub flags: u32,
+    pub tos: u8,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub table: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dst: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub src: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub iif: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oif: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub goto: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fw_mark: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fw_mask: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mask: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub flow: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tun_id: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub suppress_ifgroup: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub suppress_prefix_len: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub protocol: Option<RouteProtocol>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ip_proto: Option<AddressFamily>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub src_port_range: Option<Vec<u8>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dst_port_range: Option<Vec<u8>>,
+}
+
+pub(crate) fn get_route_rules() -> Result<Vec<RouteRule>, NisporError> {
+    Ok(Runtime::new()?.block_on(_get_route_rules())?)
+}
+
+async fn _get_route_rules() -> Result<Vec<RouteRule>, NisporError> {
+    let mut rules = Vec::new();
+    let (connection, handle, _) = new_connection()?;
+    tokio::spawn(connection);
+
+    let mut links = handle.rule().get(IpVersion::V6).execute();
+    while let Some(rt_msg) = links.try_next().await? {
+        rules.push(get_rule(rt_msg)?);
+    }
+    let mut links = handle.rule().get(IpVersion::V4).execute();
+    while let Some(rt_msg) = links.try_next().await? {
+        rules.push(get_rule(rt_msg)?);
+    }
+    Ok(rules)
+}
+
+fn get_rule(rule_msg: RuleMessage) -> Result<RouteRule, NisporError> {
+    let mut rl = RouteRule::default();
+    let header = &rule_msg.header;
+    rl.address_family = header.family.into();
+    let src_prefix_len = header.src_len;
+    let dst_prefix_len = header.dst_len;
+    rl.tos = header.tos;
+    rl.action = header.action.into();
+    if header.table > RT_TABLE_UNSPEC {
+        rl.table = Some(header.table.into());
+    }
+    let family = &rl.address_family;
+    for nla in &rule_msg.nlas {
+        match nla {
+            Nla::Destination(ref d) => {
+                rl.dst = Some(format!(
+                    "{}/{}",
+                    _addr_to_string(d, family)?,
+                    dst_prefix_len,
+                ));
+            }
+            Nla::Source(ref d) => {
+                rl.src = Some(format!(
+                    "{}/{}",
+                    _addr_to_string(d, family)?,
+                    src_prefix_len,
+                ));
+            }
+            Nla::Iifname(ref d) => {
+                rl.iif = Some(d.clone().to_string());
+            }
+            Nla::OifName(ref d) => {
+                rl.oif = Some(d.clone().to_string());
+            }
+            Nla::Goto(ref d) => {
+                rl.goto = Some(*d);
+            }
+            Nla::Priority(ref d) => {
+                rl.priority = Some(*d);
+            }
+            Nla::FwMark(ref d) => {
+                rl.fw_mark = Some(*d);
+            }
+            Nla::FwMask(ref d) => {
+                rl.fw_mask = Some(*d);
+            }
+            Nla::Flow(ref d) => {
+                rl.flow = Some(*d);
+            }
+            Nla::TunId(ref d) => {
+                rl.tun_id = Some(*d);
+            }
+            Nla::SuppressIfGroup(ref d) => {
+                if *d != std::u32::MAX {
+                    rl.suppress_ifgroup = Some(*d);
+                }
+            }
+            Nla::SuppressPrefixLen(ref d) => {
+                if *d != std::u32::MAX {
+                    rl.suppress_prefix_len = Some(*d);
+                }
+            }
+            Nla::Table(ref d) => {
+                if *d > RT_TABLE_UNSPEC.into() {
+                    rl.table = Some(*d);
+                }
+            }
+            Nla::Protocol(ref d) => {
+                rl.protocol = Some(d.clone().into());
+            }
+            Nla::IpProto(ref d) => {
+                rl.ip_proto = Some(d.clone().into());
+            }
+            _ => eprintln!("Unknown NLA message for roule {:?}", nla),
+        }
+    }
+
+    Ok(rl)
+}
+
+fn _addr_to_string(
+    data: &[u8],
+    family: &AddressFamily,
+) -> Result<String, NisporError> {
+    match family {
+        AddressFamily::IPv4 => Ok(parse_as_ipv4(data)),
+        AddressFamily::IPv6 => Ok(parse_as_ipv6(data)),
+        _ => Err(NisporError {
+            kind: ErrorKind::NisporBug,
+            msg: "The rule is not a valid IPv4 and IPv6 rule".to_string(),
+        }),
+    }
+}

--- a/tools/test_env
+++ b/tools/test_env
@@ -91,6 +91,9 @@ elif [ "CHK$1" == "CHKmacvtap" ];then
     sudo ip link set link dev macvtap0 type macvtap macaddr add 00:22:22:22:22:22
     sudo ip link set eth1 up
     sudo ip link set macvtap0 up
+elif [ "CHK$1" == "CHKrule" ];then
+    create_nics
+    sudo ip rule add from 192.0.2.1 to 192.0.2.2 tos 10 protocol kernel table 100 iif eth1 oif eth2
 elif [ "CHK$1" == "CHKrm" ];then
     sudo ip link del mac0
     sudo ip link del macvtap0
@@ -103,5 +106,6 @@ elif [ "CHK$1" == "CHKrm" ];then
     sudo ip link del vrf0
     sudo ip netns del tmp
     sudo ip link del tun1
+    sudo ip rule del from 192.0.2.1 to 192.0.2.2 tos 10 protocol kernel table 100 iif eth1 oif eth2
     sudo modprobe -r netdevsim
 fi


### PR DESCRIPTION
Example output for `npc rule`.

```
[
  {
    "action": "Table",
    "address_family": "IPv4",
    "flags": 0,
    "table": 254,
    "tos": 16,
    "dst": "192.0.2.2/32",
    "src": "192.0.2.1/32",
    "iif": "eth1",
    "oif": "eth2",
    "priority": 32762,
    "suppress_prefix_len": 4294967295,
    "protocol": "Kernel"
  },
]
```

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>