### PR TITLE
README.md: update supported features

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ varlink call unix:/run/nispor/nispor.so/info.nispor.Get
  * Veth
  * VRF(Virtual Routing and Forwarding)
  * SR-IOV
+ * MacVlan
+ * MacVtap
 
 ## TODO:
  * Error handling instead of `unwrap()/panic!/etc`


### PR DESCRIPTION
MacVlan and MacVtap interfaces support were missing from README.md
"supported features" section.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>