### PR TITLE
lib: update netlink dependencies

### DIFF
--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -19,9 +19,9 @@ crate-type = ["lib"]
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-rtnetlink = "0.4"
-netlink-packet-route = "0.4"
+rtnetlink = "0.5"
+netlink-packet-route = "0.5"
 netlink-sys = "0.4"
-netlink-packet-utils = "0.2"
+netlink-packet-utils = "0.3"
 tokio = { version = "0.2.6", features = ["macros", "rt-core"] }
 futures = "0.3"


### PR DESCRIPTION
The dependencies are needed for route rule support and others.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>