### PR TITLE
npc: Change default output format to YAML

### DIFF
--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -14,3 +14,4 @@ serde_json = "1.0"
 serde_derive = "1.0"
 clap = "2.33.3"
 nispor = { path = "../lib" }
+serde_yaml = "0.8"

--- a/src/cli/npc.rs
+++ b/src/cli/npc.rs
@@ -2,6 +2,7 @@ use clap::{clap_app, crate_authors, crate_version};
 use nispor::{Iface, NetState, NisporError, Route, RouteRule};
 use serde_derive::Serialize;
 use serde_json;
+use serde_yaml;
 use std::fmt::{Display, Formatter, Result};
 use std::process;
 
@@ -16,7 +17,6 @@ impl Display for CliError {
     }
 }
 
-#[derive(Serialize)]
 enum CliResult {
     Full(NetState),
     Ifaces(Vec<Iface>),
@@ -26,20 +26,75 @@ enum CliResult {
     NisporError(NisporError),
 }
 
+enum CliOutputType {
+    Json,
+    Yaml,
+}
+
+macro_rules! npc_print {
+    ($display_func:expr, $data: expr) => {
+        match $data {
+            CliResult::Full(netstate) => {
+                println!("{}", $display_func(&netstate).unwrap());
+                process::exit(0);
+            }
+            CliResult::Ifaces(ifaces) => {
+                println!("{}", $display_func(&ifaces).unwrap());
+                process::exit(0);
+            }
+            CliResult::Routes(routes) => {
+                println!("{}", $display_func(&routes).unwrap());
+                process::exit(0);
+            }
+            CliResult::RouteRules(rules) => {
+                println!("{}", $display_func(&rules).unwrap());
+                process::exit(0);
+            }
+            CliResult::NisporError(e) => {
+                eprintln!("{}", $display_func(&e).unwrap());
+                process::exit(1);
+            }
+            CliResult::Error(e) => {
+                eprintln!("{}", $display_func(&e).unwrap());
+                process::exit(1);
+            }
+        }
+    };
+}
+
+fn print_result(result: &CliResult, output_type: CliOutputType) {
+    match output_type {
+        CliOutputType::Json => npc_print!(serde_json::to_string_pretty, result),
+        CliOutputType::Yaml => npc_print!(serde_yaml::to_string, result),
+    }
+}
+
+fn parse_arg_output_format(matches: &clap::ArgMatches) -> CliOutputType {
+    match matches.is_present("json") {
+        true => CliOutputType::Json,
+        false => CliOutputType::Yaml,
+    }
+}
+
 fn main() {
     let matches = clap_app!(npc =>
         (version: crate_version!())
         (author: crate_authors!())
         (about: "Nispor CLI")
         (@arg ifname: [INTERFACE_NAME] "interface name")
+        (@arg json: -j --json "Show in json format")
         (@subcommand route =>
+            (@arg json: -j --json "Show in json format")
             (about: "Show routes")
         )
         (@subcommand rule =>
+            (@arg json: -j --json "Show in json format")
             (about: "Show routes rules")
         )
     )
     .get_matches();
+
+    let mut output_format = parse_arg_output_format(&matches);
 
     let result = match NetState::retrieve() {
         Ok(mut state) => {
@@ -51,9 +106,11 @@ fn main() {
                         msg: format!("Interface '{}' not found", ifname),
                     })
                 }
-            } else if let Some(_) = matches.subcommand_matches("route") {
+            } else if let Some(m) = matches.subcommand_matches("route") {
+                output_format = parse_arg_output_format(m);
                 CliResult::Routes(state.routes)
-            } else if let Some(_) = matches.subcommand_matches("rule") {
+            } else if let Some(m) = matches.subcommand_matches("rule") {
+                output_format = parse_arg_output_format(m);
                 CliResult::RouteRules(state.rules)
             } else {
                 /* Show everything if no cmdline arg has been supplied */
@@ -62,31 +119,5 @@ fn main() {
         }
         Err(e) => CliResult::NisporError(e),
     };
-
-    match result {
-        CliResult::Full(netstate) => {
-            println!("{}", serde_json::to_string_pretty(&netstate).unwrap());
-            process::exit(0);
-        }
-        CliResult::Ifaces(ifaces) => {
-            println!("{}", serde_json::to_string_pretty(&ifaces).unwrap());
-            process::exit(0);
-        }
-        CliResult::Routes(routes) => {
-            println!("{}", serde_json::to_string_pretty(&routes).unwrap());
-            process::exit(0);
-        }
-        CliResult::RouteRules(rules) => {
-            println!("{}", serde_json::to_string_pretty(&rules).unwrap());
-            process::exit(0);
-        }
-        CliResult::NisporError(e) => {
-            eprintln!("{}", serde_json::to_string_pretty(&e).unwrap());
-            process::exit(1);
-        }
-        CliResult::Error(e) => {
-            eprintln!("{}", serde_json::to_string_pretty(&e).unwrap());
-            process::exit(1);
-        }
-    }
+    print_result(&result, output_format);
 }


### PR DESCRIPTION
The json output format is not human friendly.
Changing output format to YAML by default, and user can use `-j` or
`--json` to change back to json output.