### PR TITLE
enum: All enum serialized to lower case

### DIFF
--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -3,6 +3,7 @@ use rtnetlink;
 use serde_derive::Serialize;
 
 #[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ErrorKind {
     NetlinkError,
     NisporBug,

--- a/src/lib/ifaces/bond.rs
+++ b/src/lib/ifaces/bond.rs
@@ -16,6 +16,7 @@ const BOND_MODE_TLB: u8 = 5;
 const BOND_MODE_ALB: u8 = 6;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum BondMode {
     #[serde(rename = "balance-rr")]
     BalanceRoundRobin,
@@ -335,6 +336,7 @@ pub struct BondInfo {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum BondSubordinateState {
     Active,
     Backup,
@@ -356,6 +358,7 @@ impl From<u8> for BondSubordinateState {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum BondMiiStatus {
     LinkUp,
     LinkFail,

--- a/src/lib/ifaces/bridge.rs
+++ b/src/lib/ifaces/bridge.rs
@@ -8,6 +8,7 @@ use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum BridgeStpState {
     Disabled,
     KernelStp,
@@ -32,6 +33,7 @@ impl From<u32> for BridgeStpState {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum BridgeVlanProtocol {
     #[serde(rename = "802.1Q")]
     Ieee8021Q,
@@ -148,6 +150,7 @@ pub struct BridgeInfo {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum BridgePortStpState {
     Disabled,
     Listening,
@@ -184,6 +187,7 @@ impl From<u8> for BridgePortStpState {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum BridgePortMulticastRouterType {
     Disabled,
     TempQuery,

--- a/src/lib/ifaces/iface.rs
+++ b/src/lib/ifaces/iface.rs
@@ -40,6 +40,7 @@ use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum IfaceType {
     Bond,
     Veth,
@@ -65,6 +66,7 @@ impl Default for IfaceType {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum IfaceState {
     Up,
     Dormant,
@@ -81,6 +83,7 @@ impl Default for IfaceState {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum IfaceFlags {
     AllMulti,
     AutoMedia,
@@ -110,6 +113,7 @@ impl Default for IfaceFlags {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum ControllerType {
     Bond,
     Bridge,

--- a/src/lib/ifaces/sriov.rs
+++ b/src/lib/ifaces/sriov.rs
@@ -34,6 +34,7 @@ const IFLA_VF_STATS_RX_DROPPED: u16 = 7;
 const IFLA_VF_STATS_TX_DROPPED: u16 = 8;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum VfLinkState {
     Auto,
     Enable,

--- a/src/lib/ifaces/tun.rs
+++ b/src/lib/ifaces/tun.rs
@@ -36,6 +36,7 @@ pub struct TunInfo {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum TunMode {
     Tun,
     Tap,

--- a/src/lib/ifaces/vlan.rs
+++ b/src/lib/ifaces/vlan.rs
@@ -9,6 +9,7 @@ const ETH_P_8021Q: u16 = 0x8100;
 const ETH_P_8021AD: u16 = 0x88A8;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum VlanProtocol {
     #[serde(rename = "802.1Q")]
     Ieee8021Q,

--- a/src/lib/route_rule.rs
+++ b/src/lib/route_rule.rs
@@ -22,6 +22,7 @@ const FR_ACT_PROHIBIT: u8 = 128;
 const RT_TABLE_UNSPEC: u8 = 0;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum RuleAction {
     /* Pass to fixed table */
     Table,


### PR DESCRIPTION
Used serde to rename all variants to lowercase.

Signed-off-by: Víctor Javier Díaz Garrido <vicdigar@hotmail.com>