### PR TITLE
gitignore: add vendor/ folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ src/python/nispor.egg-info
 src/python/build
 src/python/dist
 test/clib/nispor_test
+vendor/


### PR DESCRIPTION
When generating the vendor usign "cargo vendor" it should be ignored by
git.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>