### PR TITLE
Add scope option to the route subcommand

### DIFF
--- a/src/cli/npc.rs
+++ b/src/cli/npc.rs
@@ -319,6 +319,14 @@ fn get_routes(state: &NetState, matches: &clap::ArgMatches) -> CliResult {
             .filter(|route| _is_route_to_specified_dev(route, iface_name))
             .collect();
     }
+    if let Some(scope) = matches.value_of("scope") {
+        if scope != "a" && scope != "all" {
+            routes = routes
+                .into_iter()
+                .filter(|route| route.scope == scope.into())
+                .collect();
+        }
+    }
 
     CliResult::Routes(routes)
 }
@@ -360,11 +368,26 @@ fn main() {
                         .help("Delete the specified interface"),
                 ),
         )
-        .subcommand(clap::Command::new("route").about("Show route").arg(
-            clap::Arg::new("dev").short('d').takes_value(true).help(
-                "Show only route entries output to the specified interface",
-            ),
-        ))
+        .subcommand(
+            clap::Command::new("route")
+                .about("Show route")
+                .arg(clap::Arg::new("dev").short('d').takes_value(true).help(
+                    "Show only route entries output \
+                    to the specified interface",
+                ))
+                .arg(
+                    clap::Arg::new("scope")
+                        .short('s')
+                        .long("scope")
+                        .takes_value(true)
+                        .help("Show only route entries with specified scope")
+                        .possible_values([
+                            "a", "all", "u", "universe", "g", "global", "s",
+                            "site", "l", "link", "h", "host", "n", "nowhere",
+                            "no_where",
+                        ]),
+                ),
+        )
         .subcommand(clap::Command::new("rule").about("Show route route"))
         .subcommand(
             clap::Command::new("set")

--- a/src/clib/Cargo.toml
+++ b/src/clib/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 name = "nispor"
 path = "lib.rs"
 crate-type = ["cdylib"]
+doc = false
 
 [dependencies]
 nispor = { path = "../lib", version="1.0" }

--- a/src/lib/route.rs
+++ b/src/lib/route.rs
@@ -327,6 +327,33 @@ impl Default for RouteScope {
     }
 }
 
+impl std::fmt::Display for RouteScope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Universe => write!(f, "universe"),
+            Self::Site => write!(f, "site"),
+            Self::Link => write!(f, "link"),
+            Self::Host => write!(f, "host"),
+            Self::NoWhere => write!(f, "no_where"),
+            Self::Unknown => write!(f, "unknown"),
+            Self::Other(s) => write!(f, "{}", s),
+        }
+    }
+}
+
+impl From<&str> for RouteScope {
+    fn from(v: &str) -> Self {
+        match v {
+            "u" | "universe" | "g" | "global" => RouteScope::Universe,
+            "s" | "site" => RouteScope::Site,
+            "l" | "link" => RouteScope::Link,
+            "h" | "host" => RouteScope::Host,
+            "n" | "nowhere" | "no_where" => RouteScope::NoWhere,
+            _ => RouteScope::Unknown,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum RouteType {


### PR DESCRIPTION
This PR solves #80.

### Changes

- Added `-s` | `--scope <SCOPE>` option to `npc`. Allowing users to filter routes according the scope provided.

### Notes

- In order to use the `possible_values` function when defining a `clap::Arg` the `routes` subcommand had to be defined outside of the main definition of the CLI because the `clap_app!` macro syntax does not have support for that function. This function is used to perform validation of the values passed to the argument and to expand the information provided in the `--help`.