### PR TITLE
log: introduce logging instead of using eprintln macro

### DIFF
--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -25,6 +25,7 @@ netlink-sys = "0.4"
 netlink-packet-utils = "0.3"
 tokio = { version = "0.2.6", features = ["macros", "rt-core"] }
 futures = "0.3"
+log = "0.4"
 
 [dev-dependencies]
 serde_yaml = "0.8"

--- a/src/lib/ifaces/iface.rs
+++ b/src/lib/ifaces/iface.rs
@@ -37,6 +37,7 @@ use netlink_packet_route::rtnl::{
     IFF_SLAVE, IFF_UP,
 };
 
+use log::warn;
 use rtnetlink::packet::rtnl::link::nlas::Nla;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -260,7 +261,7 @@ pub(crate) fn parse_nl_msg_to_iface(
                                 iface_state.tun = Some(info);
                             }
                             Err(e) => {
-                                eprintln!("Error parsing TUN info: {}", e);
+                                warn!("Error parsing TUN info: {}", e);
                             }
                         },
                         IfaceType::Vlan => iface_state.vlan = get_vlan_info(&d),
@@ -274,7 +275,7 @@ pub(crate) fn parse_nl_msg_to_iface(
                         IfaceType::MacVtap => {
                             iface_state.mac_vtap = get_mac_vtap_info(&d)?
                         }
-                        _ => eprintln!(
+                        _ => warn!(
                             "Unhandled IFLA_INFO_DATA for iface type {:?}",
                             iface_state.iface_type
                         ),
@@ -307,7 +308,7 @@ pub(crate) fn parse_nl_msg_to_iface(
                                 iface_state.vrf_subordinate =
                                     get_vrf_subordinate_info(&d)?;
                             }
-                            _ => eprintln!(
+                            _ => warn!(
                                 "Unknown controller type {:?}",
                                 controller_type
                             ),

--- a/src/lib/ifaces/mac_vlan.rs
+++ b/src/lib/ifaces/mac_vlan.rs
@@ -4,6 +4,7 @@ use crate::netlink::parse_as_u32;
 use crate::Iface;
 use crate::IfaceType;
 use crate::NisporError;
+use log::warn;
 use netlink_packet_route::rtnl::link::nlas;
 use netlink_packet_route::rtnl::nlas::NlasIterator;
 use serde_derive::{Deserialize, Serialize};
@@ -94,7 +95,7 @@ pub(crate) fn get_mac_vlan_info(
                             Some(parse_mac_addr_data(nla.value())?);
                     }
                     _ => {
-                        eprintln!(
+                        warn!(
                             "Unhandled MAC VLAN IFLA_INFO_DATA: {} {:?}",
                             nla.kind(),
                             nla.value()
@@ -102,7 +103,7 @@ pub(crate) fn get_mac_vlan_info(
                     }
                 },
                 Err(e) => {
-                    eprintln!(
+                    warn!(
                         "MAC VLAN IFLA_INFO_DATA NlasIterator failure: {}",
                         e
                     );
@@ -125,7 +126,7 @@ fn parse_mac_addr_data(raw: &[u8]) -> Result<Vec<String>, NisporError> {
                     addrs.push(parse_as_mac(ETH_ALEN, nla.value())?);
                 }
                 _ => {
-                    eprintln!(
+                    warn!(
                         "Unhanlded IFLA_MACVLAN_MACADDR_DATA: {} {:?}",
                         nla.kind(),
                         nla.value()
@@ -133,10 +134,7 @@ fn parse_mac_addr_data(raw: &[u8]) -> Result<Vec<String>, NisporError> {
                 }
             },
             Err(e) => {
-                eprintln!(
-                    "IFLA_MACVLAN_MACADDR_DATA NlasIterator failure: {}",
-                    e
-                );
+                warn!("IFLA_MACVLAN_MACADDR_DATA NlasIterator failure: {}", e);
             }
         }
     }

--- a/src/lib/ifaces/sriov.rs
+++ b/src/lib/ifaces/sriov.rs
@@ -2,6 +2,7 @@ use crate::netlink::parse_as_u32;
 use crate::netlink::parse_as_u64;
 use crate::parse_as_mac;
 use crate::NisporError;
+use log::warn;
 use netlink_packet_route::rtnl::nlas::NlasIterator;
 use serde_derive::{Deserialize, Serialize};
 
@@ -200,7 +201,7 @@ pub(crate) fn get_sriov_info(
                     vf_info.broadcast = parse_vf_mac(nla.value(), mac_len)?;
                 }
                 _ => {
-                    eprintln!(
+                    warn!(
                         "Unhandled SRIOV NLA {} {:?}",
                         nla.kind(),
                         nla.value()
@@ -253,7 +254,7 @@ fn parse_vf_stats(raw: &[u8]) -> Result<VfState, NisporError> {
             IFLA_VF_STATS_TX_DROPPED => {
                 state.tx_dropped = parse_as_u64(nla.value())?;
             }
-            _ => eprintln!(
+            _ => warn!(
                 "Unhandled IFLA_VF_STATS {}, {:?}",
                 nla.kind(),
                 nla.value()

--- a/src/lib/ifaces/tun.rs
+++ b/src/lib/ifaces/tun.rs
@@ -1,6 +1,7 @@
 use crate::netlink::parse_as_u32;
 use crate::netlink::parse_as_u8;
 use crate::NisporError;
+use log::warn;
 use netlink_packet_route::rtnl::link::nlas::InfoData;
 use netlink_packet_route::rtnl::nlas::NlasIterator;
 use serde_derive::{Deserialize, Serialize};
@@ -55,7 +56,7 @@ impl From<u8> for TunMode {
             IFF_TUN => TunMode::Tun,
             IFF_TAP => TunMode::Tap,
             _ => {
-                eprintln!("Unhandled TUN mode {}", d);
+                warn!("Unhandled TUN mode {}", d);
                 TunMode::Unknown
             }
         }
@@ -98,11 +99,7 @@ pub(crate) fn get_tun_info(data: &InfoData) -> Result<TunInfo, NisporError> {
                         Some(parse_as_u32(nla.value())?);
                 }
                 _ => {
-                    eprintln!(
-                        "Unhandled TUN NLA {} {:?}",
-                        nla.kind(),
-                        nla.value()
-                    );
+                    warn!("Unhandled TUN NLA {} {:?}", nla.kind(), nla.value());
                 }
             }
         }

--- a/src/lib/ifaces/vlan.rs
+++ b/src/lib/ifaces/vlan.rs
@@ -1,5 +1,6 @@
 use crate::Iface;
 use crate::IfaceType;
+use log::warn;
 use netlink_packet_route::rtnl::link::nlas::InfoData;
 use netlink_packet_route::rtnl::link::nlas::InfoVlan;
 use serde_derive::{Deserialize, Serialize};
@@ -78,7 +79,7 @@ pub(crate) fn get_vlan_info(data: &InfoData) -> Option<VlanInfo> {
                     vlan_info.is_bridge_binding = true
                 }
             } else {
-                eprintln!("Unknown VLAN info: {:?}", info);
+                warn!("Unknown VLAN info: {:?}", info);
             }
         }
         Some(vlan_info)

--- a/src/lib/netlink/bond.rs
+++ b/src/lib/netlink/bond.rs
@@ -10,6 +10,7 @@ use crate::BondMode;
 use crate::BondSubordinateInfo;
 use crate::BondSubordinateState;
 use crate::NisporError;
+use log::warn;
 use netlink_packet_route::rtnl::nlas::NlasIterator;
 use std::net::Ipv4Addr;
 
@@ -23,7 +24,7 @@ fn parse_as_nested_ipv4_addr(raw: &[u8]) -> Vec<Ipv4Addr> {
         match nla {
             Ok(nla) => addresses.push(parse_as_ipv4(nla.value())),
             Err(e) => {
-                eprintln!("{}", e);
+                warn!("{}", e);
             }
         }
     }
@@ -78,7 +79,7 @@ fn parse_ad_info(raw: &[u8]) -> Result<BondAdInfo, NisporError> {
                     ad_info.partner_mac = parse_as_48_bits_mac(nla.value())?;
                 }
                 _ => {
-                    eprintln!(
+                    warn!(
                         "unknown nla kind {} value: {:?}",
                         nla.kind(),
                         nla.value()
@@ -86,7 +87,7 @@ fn parse_ad_info(raw: &[u8]) -> Result<BondAdInfo, NisporError> {
                 }
             },
             Err(e) => {
-                eprintln!("{}", e);
+                warn!("{}", e);
             }
         }
     }
@@ -104,11 +105,11 @@ fn get_bond_mode(raw: &[u8]) -> Result<BondMode, NisporError> {
                 _ => (),
             },
             Err(e) => {
-                eprintln!("{}", e);
+                warn!("{}", e);
             }
         }
     }
-    eprintln!("Failed to parse bond mode from NLAS: {:?}", nlas);
+    warn!("Failed to parse bond mode from NLAS: {:?}", nlas);
     Ok(BondMode::Unknown)
 }
 
@@ -423,7 +424,7 @@ pub(crate) fn parse_bond_info(raw: &[u8]) -> Result<BondInfo, NisporError> {
                 } else if nla.kind() == IFLA_BOND_AD_INFO {
                     bond_info.ad_info = Some(parse_ad_info(nla.value())?);
                 } else {
-                    eprintln!(
+                    warn!(
                         "Failed to parse IFLA_LINKINFO for bond: {:?} {:?}",
                         nla.kind(),
                         nla.value()
@@ -431,7 +432,7 @@ pub(crate) fn parse_bond_info(raw: &[u8]) -> Result<BondInfo, NisporError> {
                 }
             }
             Err(e) => {
-                eprintln!("Failed to parse IFLA_LINKINFO {:?}", e);
+                warn!("Failed to parse IFLA_LINKINFO {:?}", e);
             }
         }
     }
@@ -489,7 +490,7 @@ pub(crate) fn parse_bond_subordinate_info(
                         Some(parse_as_u16(nla.value())?);
                 }
                 _ => {
-                    eprintln!(
+                    warn!(
                         "unknown nla kind {} value: {:?}",
                         nla.kind(),
                         nla.value()
@@ -497,7 +498,7 @@ pub(crate) fn parse_bond_subordinate_info(
                 }
             },
             Err(e) => {
-                eprintln!("{}", e);
+                warn!("{}", e);
             }
         }
     }

--- a/src/lib/netlink/bridge.rs
+++ b/src/lib/netlink/bridge.rs
@@ -1,6 +1,7 @@
 use crate::parse_as_mac;
 use crate::BridgeInfo;
 use crate::NisporError;
+use log::warn;
 use netlink_packet_route::rtnl::link::nlas::InfoBridge;
 
 const ETH_ALEN: usize = 6;
@@ -101,7 +102,7 @@ pub(crate) fn parse_bridge_info(
         } else if let InfoBridge::MultiBoolOpt(d) = info {
             bridge_info.multi_bool_opt = Some(*d);
         } else {
-            eprintln!("Unknown NLA {:?}", &info);
+            warn!("Unknown NLA {:?}", &info);
         }
     }
     Ok(bridge_info)

--- a/src/lib/netlink/bridge_port.rs
+++ b/src/lib/netlink/bridge_port.rs
@@ -4,6 +4,7 @@ use crate::netlink::nla::parse_as_u64;
 use crate::netlink::nla::parse_as_u8;
 use crate::BridgePortInfo;
 use crate::NisporError;
+use log::warn;
 use netlink_packet_route::rtnl::nlas::NlasIterator;
 
 fn parse_void_port_info(
@@ -323,7 +324,7 @@ pub(crate) fn parse_bridge_port_info(
                 {
                     func(nla.value(), &mut port_info)?;
                 } else {
-                    eprintln!(
+                    warn!(
                         "Unhandled BRIDGE_PORT_INFO {} {:?}",
                         nla.kind(),
                         nla.value()
@@ -331,7 +332,7 @@ pub(crate) fn parse_bridge_port_info(
                 }
             }
             Err(e) => {
-                eprintln!("{}", e);
+                warn!("{}", e);
             }
         }
     }

--- a/src/lib/netlink/bridge_vlan.rs
+++ b/src/lib/netlink/bridge_vlan.rs
@@ -1,5 +1,6 @@
 use crate::BridgeVlanEntry;
 use crate::NisporError;
+use log::warn;
 use netlink_packet_route::rtnl::nlas::NlasIterator;
 
 const IFLA_BRIDGE_VLAN_INFO: u16 = 2;
@@ -30,14 +31,14 @@ pub(crate) fn parse_af_spec_bridge_info(
                     }
                 }
                 _ => {
-                    eprintln!(
+                    warn!(
                         "Unhandled AF_SPEC_BRIDGE_INFO: {} {:?}",
                         nla.kind(),
                         nla.value()
                     );
                 }
             },
-            Err(e) => eprintln!("{}", e),
+            Err(e) => warn!("{}", e),
         }
     }
     if vlans.len() > 0 {
@@ -86,7 +87,7 @@ fn parse_vlan_info(
         entry.is_range_end = (flags & BRIDGE_VLAN_INFO_RANGE_END) > 0;
         Ok(Some(entry))
     } else {
-        eprintln!(
+        warn!(
             "Invalid kernel bridge vlan info: {:?}, should be [u8;4]",
             data
         );
@@ -114,7 +115,7 @@ fn merge_vlan_range(
                         is_egress_untagged: k_vlan.is_egress_untagged,
                     })
                 } else {
-                    eprintln!(
+                    warn!(
                         "Invalid kernel bridge vlan information: \
                         missing start VLAN for {}",
                         k_vlan.vid

--- a/src/lib/netlink/vxlan.rs
+++ b/src/lib/netlink/vxlan.rs
@@ -6,6 +6,7 @@ use crate::netlink::nla::parse_as_ipv6;
 use crate::netlink::nla::parse_as_u32;
 use crate::netlink::nla::parse_as_u8;
 use crate::NisporError;
+use log::warn;
 use netlink_packet_route::rtnl::nlas::NlasIterator;
 
 const IFLA_VXLAN_ID: u16 = 1;
@@ -133,13 +134,13 @@ pub(crate) fn parse_vxlan_info(raw: &[u8]) -> Result<VxlanInfo, NisporError> {
                 IFLA_VXLAN_DF => {
                     info.df = parse_as_u8(nla.value())?;
                 }
-                _ => eprintln!(
+                _ => warn!(
                     "Unhandled VxLAN IFLA_INFO_DATA: {}, {:?}",
                     nla.kind(),
                     nla.value()
                 ),
             },
-            Err(e) => eprintln!("{}", e),
+            Err(e) => warn!("{}", e),
         }
     }
     Ok(info)

--- a/src/lib/route.rs
+++ b/src/lib/route.rs
@@ -8,6 +8,7 @@ use crate::netlink::AF_INET;
 use crate::netlink::AF_INET6;
 use crate::NisporError;
 use futures::stream::TryStreamExt;
+use log::warn;
 use netlink_packet_route::rtnl::nlas::route::CacheInfo;
 use netlink_packet_route::rtnl::nlas::route::CacheInfoBuffer;
 use netlink_packet_route::rtnl::nlas::route::Metrics;
@@ -502,10 +503,7 @@ fn get_route(
                             rt.fastopen_no_cookie = Some(d);
                         }
                         _ => {
-                            eprintln!(
-                                "Unknown RTA_METRICS message {:?}",
-                                metric
-                            );
+                            warn!("Unknown RTA_METRICS message {:?}", metric);
                         }
                     }
                 }
@@ -561,14 +559,14 @@ fn get_route(
                         RTA_VIA => {
                             // Kernel will use RTA_VIA when gateway family does
                             // not match nexthop family
-                            eprintln!(
+                            warn!(
                                 "dual stack(RTA_VIA) multipath route next hop
                                  is not supported by nispor yet"
                             );
                             continue;
                         }
                         _ => {
-                            eprintln!(
+                            warn!(
                                 "Got unexpected RTA_MULTIPATH NLA {} {:?}",
                                 nla.kind(),
                                 nla.value()
@@ -625,7 +623,7 @@ fn get_route(
             Nla::Pref(d) => {
                 rt.perf = Some(d[0]);
             }
-            _ => eprintln!("Unknown NLA message for route {:?}", nla),
+            _ => warn!("Unknown NLA message for route {:?}", nla),
         }
     }
 

--- a/src/lib/route_rule.rs
+++ b/src/lib/route_rule.rs
@@ -5,6 +5,7 @@ use crate::route::AddressFamily;
 use crate::route::RouteProtocol;
 use crate::NisporError;
 use futures::stream::TryStreamExt;
+use log::warn;
 use netlink_packet_route::rtnl::rule::nlas::Nla;
 use netlink_packet_route::RuleMessage;
 use rtnetlink::new_connection;
@@ -202,7 +203,7 @@ fn get_rule(rule_msg: RuleMessage) -> Result<RouteRule, NisporError> {
             Nla::L3MDev(ref d) => {
                 rl.l3mdev = Some(*d > 0);
             }
-            _ => eprintln!("Unknown NLA message for route rule {:?}", nla),
+            _ => warn!("Unknown NLA message for route rule {:?}", nla),
         }
     }
 


### PR DESCRIPTION
As library nispor should not print any line on stdout. Therefore, this
patch is introducing logging using the log crate. For all the unhandle
data or wrong format, nispor is logging it as warning using the warn
macro.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>