### PR TITLE
test: Don't ignore failure of `NetState::retrieve()`

### DIFF
--- a/src/lib/tests/bond.rs
+++ b/src/lib/tests/bond.rs
@@ -9,7 +9,7 @@ const IFACE_NAME: &str = "bond99";
 const PORT1_NAME: &str = "eth1";
 const PORT2_NAME: &str = "eth2";
 
-const EXPECTED_IFACE_NAME: &str = r#"---
+const EXPECTED_IFACE_STATE: &str = r#"---
 - name: bond99
   iface_type: bond
   state: up
@@ -91,22 +91,21 @@ const EXPECTED_IFACE_NAME: &str = r#"---
 #[test]
 fn test_get_iface_bond_yaml() {
     with_bond_iface(|| {
-        if let Ok(ref mut state) = NetState::retrieve() {
-            let iface = state.ifaces.get_mut(IFACE_NAME).unwrap();
-            // The peer_notif_delay is supported by kernel 5.3 and not
-            // supported by Travis CI Ubuntu 18.04 kernel 4.15.
-            if let Some(ref mut bond_info) = iface.bond {
-                bond_info.peer_notif_delay = None;
-            }
-            let iface = &state.ifaces[IFACE_NAME];
-            let port1 = &state.ifaces[PORT1_NAME];
-            let port2 = &state.ifaces[PORT2_NAME];
-            assert_eq!(&iface.iface_type, &nispor::IfaceType::Bond);
-            assert_eq!(
-                serde_yaml::to_string(&vec![iface, port1, port2]).unwrap(),
-                EXPECTED_IFACE_NAME
-            );
+        let mut state = NetState::retrieve().unwrap();
+        let iface = state.ifaces.get_mut(IFACE_NAME).unwrap();
+        // The peer_notif_delay is supported by kernel 5.3 and not
+        // supported by Travis CI Ubuntu 18.04 kernel 4.15.
+        if let Some(ref mut bond_info) = iface.bond {
+            bond_info.peer_notif_delay = None;
         }
+        let iface = &state.ifaces[IFACE_NAME];
+        let port1 = &state.ifaces[PORT1_NAME];
+        let port2 = &state.ifaces[PORT2_NAME];
+        assert_eq!(&iface.iface_type, &nispor::IfaceType::Bond);
+        assert_eq!(
+            serde_yaml::to_string(&vec![iface, port1, port2]).unwrap(),
+            EXPECTED_IFACE_STATE
+        );
     });
 }
 

--- a/src/lib/tests/bridge.rs
+++ b/src/lib/tests/bridge.rs
@@ -9,7 +9,7 @@ const IFACE_NAME: &str = "br0";
 const PORT1_NAME: &str = "eth1";
 const PORT2_NAME: &str = "eth2";
 
-const EXPECTED_IFACE_NAME: &str = r#"---
+const EXPECTED_IFACE_STATE: &str = r#"---
 - name: br0
   iface_type: bridge
   state: up
@@ -185,36 +185,35 @@ const EXPECTED_IFACE_NAME: &str = r#"---
 #[test]
 fn test_get_br_iface_yaml() {
     with_br_iface(|| {
-        if let Ok(ref mut state) = NetState::retrieve() {
-            let iface = state.ifaces.get_mut(IFACE_NAME).unwrap();
-            if let Some(ref mut bridge_info) = iface.bridge {
-                bridge_info.gc_timer = None;
-                // Below are not support by Travis CI kernel
-                bridge_info.vlan_stats_per_host = None;
-                bridge_info.multi_bool_opt = None;
-                // Below are diffent value between Travis CI and RHEL/CentOS 8
-                bridge_info.multicast_hash_elasticity = None;
-                bridge_info.multicast_hash_max = None;
-                bridge_info.multicast_startup_query_interval = None;
-            }
-            let port1 = state.ifaces.get_mut(PORT1_NAME).unwrap();
-            if let Some(ref mut port_info) = port1.bridge_port {
-                port_info.forward_delay_timer = 0;
-            }
-            let port2 = state.ifaces.get_mut(PORT2_NAME).unwrap();
-            if let Some(ref mut port_info) = port2.bridge_port {
-                port_info.forward_delay_timer = 0;
-            }
-
-            let iface = &state.ifaces[IFACE_NAME];
-            let port1 = &state.ifaces[PORT1_NAME];
-            let port2 = &state.ifaces[PORT2_NAME];
-            assert_eq!(iface.iface_type, nispor::IfaceType::Bridge);
-            assert_eq!(
-                serde_yaml::to_string(&vec![iface, port1, port2]).unwrap(),
-                EXPECTED_IFACE_NAME
-            );
+        let mut state = NetState::retrieve().unwrap();
+        let iface = state.ifaces.get_mut(IFACE_NAME).unwrap();
+        if let Some(ref mut bridge_info) = iface.bridge {
+            bridge_info.gc_timer = None;
+            // Below are not support by Travis CI kernel
+            bridge_info.vlan_stats_per_host = None;
+            bridge_info.multi_bool_opt = None;
+            // Below are diffent value between Travis CI and RHEL/CentOS 8
+            bridge_info.multicast_hash_elasticity = None;
+            bridge_info.multicast_hash_max = None;
+            bridge_info.multicast_startup_query_interval = None;
         }
+        let port1 = state.ifaces.get_mut(PORT1_NAME).unwrap();
+        if let Some(ref mut port_info) = port1.bridge_port {
+            port_info.forward_delay_timer = 0;
+        }
+        let port2 = state.ifaces.get_mut(PORT2_NAME).unwrap();
+        if let Some(ref mut port_info) = port2.bridge_port {
+            port_info.forward_delay_timer = 0;
+        }
+
+        let iface = &state.ifaces[IFACE_NAME];
+        let port1 = &state.ifaces[PORT1_NAME];
+        let port2 = &state.ifaces[PORT2_NAME];
+        assert_eq!(iface.iface_type, nispor::IfaceType::Bridge);
+        assert_eq!(
+            serde_yaml::to_string(&vec![iface, port1, port2]).unwrap(),
+            EXPECTED_IFACE_STATE
+        );
     });
 }
 

--- a/src/lib/tests/bridge_vlan_filter.rs
+++ b/src/lib/tests/bridge_vlan_filter.rs
@@ -9,7 +9,7 @@ const IFACE_NAME: &str = "br0";
 const PORT1_NAME: &str = "eth1";
 const PORT2_NAME: &str = "eth2";
 
-const EXPECTED_IFACE_NAME: &str = r#"---
+const EXPECTED_IFACE_STATE: &str = r#"---
 - name: eth1
   iface_type: veth
   state: up
@@ -134,27 +134,26 @@ const EXPECTED_IFACE_NAME: &str = r#"---
 #[test]
 fn test_get_br_iface_yaml() {
     with_br_with_vlan_filter_iface(|| {
-        if let Ok(ref mut state) = NetState::retrieve() {
-            let port1 = state.ifaces.get_mut(PORT1_NAME).unwrap();
-            if let Some(ref mut port_info) = port1.bridge_port {
-                port_info.forward_delay_timer = 0;
-            }
-            let port2 = state.ifaces.get_mut(PORT2_NAME).unwrap();
-            if let Some(ref mut port_info) = port2.bridge_port {
-                port_info.forward_delay_timer = 0;
-            }
-            let iface = state.ifaces.get(IFACE_NAME).unwrap();
-            if let Some(bridge_info) = &iface.bridge {
-                assert_eq!(bridge_info.vlan_filtering, Some(true))
-            }
-
-            let port1 = &state.ifaces[PORT1_NAME];
-            let port2 = &state.ifaces[PORT2_NAME];
-            assert_eq!(
-                serde_yaml::to_string(&vec![port1, port2]).unwrap(),
-                EXPECTED_IFACE_NAME
-            );
+        let mut state = NetState::retrieve().unwrap();
+        let port1 = state.ifaces.get_mut(PORT1_NAME).unwrap();
+        if let Some(ref mut port_info) = port1.bridge_port {
+            port_info.forward_delay_timer = 0;
         }
+        let port2 = state.ifaces.get_mut(PORT2_NAME).unwrap();
+        if let Some(ref mut port_info) = port2.bridge_port {
+            port_info.forward_delay_timer = 0;
+        }
+        let iface = state.ifaces.get(IFACE_NAME).unwrap();
+        if let Some(bridge_info) = &iface.bridge {
+            assert_eq!(bridge_info.vlan_filtering, Some(true))
+        }
+
+        let port1 = &state.ifaces[PORT1_NAME];
+        let port2 = &state.ifaces[PORT2_NAME];
+        assert_eq!(
+            serde_yaml::to_string(&vec![port1, port2]).unwrap(),
+            EXPECTED_IFACE_STATE
+        );
     });
 }
 

--- a/src/lib/tests/dummy.rs
+++ b/src/lib/tests/dummy.rs
@@ -7,7 +7,7 @@ mod utils;
 
 const IFACE_NAME: &str = "dummy1";
 
-const EXPECTED_IFACE_NAME: &str = r#"---
+const EXPECTED_IFACE_STATE: &str = r#"---
 - name: dummy1
   iface_type: dummy
   state: unknown
@@ -29,15 +29,14 @@ const EXPECTED_IFACE_NAME: &str = r#"---
 #[test]
 fn test_get_iface_dummy_yaml() {
     with_dummy_iface(|| {
-        if let Ok(state) = NetState::retrieve() {
-            let iface = &state.ifaces[IFACE_NAME];
-            let iface_type = &iface.iface_type;
-            assert_eq!(iface_type, &nispor::IfaceType::Dummy);
-            assert_eq!(
-                serde_yaml::to_string(&vec![iface]).unwrap(),
-                EXPECTED_IFACE_NAME
-            );
-        }
+        let state = NetState::retrieve().unwrap();
+        let iface = &state.ifaces[IFACE_NAME];
+        let iface_type = &iface.iface_type;
+        assert_eq!(iface_type, &nispor::IfaceType::Dummy);
+        assert_eq!(
+            serde_yaml::to_string(&vec![iface]).unwrap(),
+            EXPECTED_IFACE_STATE
+        );
     });
 }
 

--- a/src/lib/tests/mac_vlan.rs
+++ b/src/lib/tests/mac_vlan.rs
@@ -7,7 +7,7 @@ mod utils;
 
 const IFACE_NAME: &str = "mac0";
 
-const EXPECTED_IFACE_NAME: &str = r#"---
+const EXPECTED_IFACE_STATE: &str = r#"---
 - name: mac0
   iface_type: mac_vlan
   state: up
@@ -36,14 +36,13 @@ const EXPECTED_IFACE_NAME: &str = r#"---
 #[test]
 fn test_get_macvlan_iface_yaml() {
     with_macvlan_iface(|| {
-        if let Ok(state) = NetState::retrieve() {
-            let iface = &state.ifaces[IFACE_NAME];
-            assert_eq!(iface.iface_type, nispor::IfaceType::MacVlan);
-            assert_eq!(
-                serde_yaml::to_string(&vec![iface]).unwrap(),
-                EXPECTED_IFACE_NAME
-            );
-        }
+        let state = NetState::retrieve().unwrap();
+        let iface = &state.ifaces[IFACE_NAME];
+        assert_eq!(iface.iface_type, nispor::IfaceType::MacVlan);
+        assert_eq!(
+            serde_yaml::to_string(&vec![iface]).unwrap(),
+            EXPECTED_IFACE_STATE
+        );
     });
 }
 

--- a/src/lib/tests/mac_vtap.rs
+++ b/src/lib/tests/mac_vtap.rs
@@ -7,7 +7,7 @@ mod utils;
 
 const IFACE_NAME: &str = "macvtap0";
 
-const EXPECTED_IFACE_NAME: &str = r#"---
+const EXPECTED_IFACE_STATE: &str = r#"---
 - name: macvtap0
   iface_type: mac_vtap
   state: up
@@ -36,14 +36,13 @@ const EXPECTED_IFACE_NAME: &str = r#"---
 #[test]
 fn test_get_macvtap_iface_yaml() {
     with_macvtap_iface(|| {
-        if let Ok(state) = NetState::retrieve() {
-            let iface = &state.ifaces[IFACE_NAME];
-            assert_eq!(iface.iface_type, nispor::IfaceType::MacVtap);
-            assert_eq!(
-                serde_yaml::to_string(&vec![iface]).unwrap(),
-                EXPECTED_IFACE_NAME
-            );
-        }
+        let state = NetState::retrieve().unwrap();
+        let iface = &state.ifaces[IFACE_NAME];
+        assert_eq!(iface.iface_type, nispor::IfaceType::MacVtap);
+        assert_eq!(
+            serde_yaml::to_string(&vec![iface]).unwrap(),
+            EXPECTED_IFACE_STATE
+        );
     });
 }
 

--- a/src/lib/tests/route.rs
+++ b/src/lib/tests/route.rs
@@ -62,20 +62,19 @@ const EXPECTED_YAML_OUTPUT: &str = r#"---
 #[ignore] // Travis CI Ubuntu 18.04 has bug on IPv6 multipath route weight
 fn test_get_route_yaml() {
     with_route_test_iface(|| {
-        if let Ok(state) = NetState::retrieve() {
-            let mut expected_routes = Vec::new();
-            for route in state.routes {
-                if Some(TEST_ROUTE_DST_V4.into()) == route.dst {
-                    expected_routes.push(route)
-                } else if Some(TEST_ROUTE_DST_V6.into()) == route.dst {
-                    expected_routes.push(route)
-                }
+        let state = NetState::retrieve().unwrap();
+        let mut expected_routes = Vec::new();
+        for route in state.routes {
+            if Some(TEST_ROUTE_DST_V4.into()) == route.dst {
+                expected_routes.push(route)
+            } else if Some(TEST_ROUTE_DST_V6.into()) == route.dst {
+                expected_routes.push(route)
             }
-            assert_eq!(
-                serde_yaml::to_string(&expected_routes).unwrap(),
-                EXPECTED_YAML_OUTPUT
-            );
         }
+        assert_eq!(
+            serde_yaml::to_string(&expected_routes).unwrap(),
+            EXPECTED_YAML_OUTPUT
+        );
     });
 }
 

--- a/src/lib/tests/route_rule.rs
+++ b/src/lib/tests/route_rule.rs
@@ -32,20 +32,19 @@ const EXPECTED_YAML_OUTPUT: &str = r#"---
 #[test]
 fn test_get_route_rule_yaml() {
     with_route_rule_test_iface(|| {
-        if let Ok(state) = NetState::retrieve() {
-            let mut expected_rules = Vec::new();
-            for mut rule in state.rules {
-                if Some(TEST_TABLE_ID) == rule.table {
-                    // Travis CI Ubuntu 18.04 does not support protocol.
-                    rule.protocol = None;
-                    expected_rules.push(rule)
-                }
+        let state = NetState::retrieve().unwrap();
+        let mut expected_rules = Vec::new();
+        for mut rule in state.rules {
+            if Some(TEST_TABLE_ID) == rule.table {
+                // Travis CI Ubuntu 18.04 does not support protocol.
+                rule.protocol = None;
+                expected_rules.push(rule)
             }
-            assert_eq!(
-                serde_yaml::to_string(&expected_rules).unwrap(),
-                EXPECTED_YAML_OUTPUT
-            );
         }
+        assert_eq!(
+            serde_yaml::to_string(&expected_rules).unwrap(),
+            EXPECTED_YAML_OUTPUT
+        );
     });
 }
 

--- a/src/lib/tests/tap.rs
+++ b/src/lib/tests/tap.rs
@@ -7,7 +7,7 @@ mod utils;
 
 const IFACE_NAME: &str = "tap1";
 
-const EXPECTED_IFACE_NAME: &str = r#"---
+const EXPECTED_IFACE_STATE: &str = r#"---
 - name: tap1
   iface_type: tun
   state: down
@@ -32,14 +32,13 @@ const EXPECTED_IFACE_NAME: &str = r#"---
 #[ignore] // Travis CI does not support TUN/TAP IFLA_INFO_DATA yet
 fn test_get_tap_iface_yaml() {
     with_tap_iface(|| {
-        if let Ok(state) = NetState::retrieve() {
-            let iface = &state.ifaces[IFACE_NAME];
-            assert_eq!(iface.iface_type, nispor::IfaceType::Tun);
-            assert_eq!(
-                serde_yaml::to_string(&vec![iface]).unwrap(),
-                EXPECTED_IFACE_NAME
-            );
-        }
+        let state = NetState::retrieve().unwrap();
+        let iface = &state.ifaces[IFACE_NAME];
+        assert_eq!(iface.iface_type, nispor::IfaceType::Tun);
+        assert_eq!(
+            serde_yaml::to_string(&vec![iface]).unwrap(),
+            EXPECTED_IFACE_STATE
+        );
     });
 }
 

--- a/src/lib/tests/tun.rs
+++ b/src/lib/tests/tun.rs
@@ -7,7 +7,7 @@ mod utils;
 
 const IFACE_NAME: &str = "tun1";
 
-const EXPECTED_IFACE_NAME: &str = r#"---
+const EXPECTED_IFACE_STATE: &str = r#"---
 - name: tun1
   iface_type: tun
   state: down
@@ -32,14 +32,13 @@ const EXPECTED_IFACE_NAME: &str = r#"---
 #[ignore] // Travis CI does not support TUN/TAP IFLA_INFO_DATA yet
 fn test_get_tun_iface_yaml() {
     with_tun_iface(|| {
-        if let Ok(state) = NetState::retrieve() {
-            let iface = &state.ifaces[IFACE_NAME];
-            assert_eq!(iface.iface_type, nispor::IfaceType::Tun);
-            assert_eq!(
-                serde_yaml::to_string(&vec![iface]).unwrap(),
-                EXPECTED_IFACE_NAME
-            );
-        }
+        let state = NetState::retrieve().unwrap();
+        let iface = &state.ifaces[IFACE_NAME];
+        assert_eq!(iface.iface_type, nispor::IfaceType::Tun);
+        assert_eq!(
+            serde_yaml::to_string(&vec![iface]).unwrap(),
+            EXPECTED_IFACE_STATE
+        );
     });
 }
 

--- a/src/lib/tests/veth.rs
+++ b/src/lib/tests/veth.rs
@@ -7,7 +7,7 @@ mod utils;
 
 const IFACE_NAME: &str = "veth1";
 
-const EXPECTED_IFACE_NAME: &str = r#"---
+const EXPECTED_IFACE_STATE: &str = r#"---
 - name: veth1
   iface_type: veth
   state: up
@@ -31,15 +31,14 @@ const EXPECTED_IFACE_NAME: &str = r#"---
 #[test]
 fn test_get_veth_iface_yaml() {
     with_veth_iface(|| {
-        if let Ok(state) = NetState::retrieve() {
-            let iface = &state.ifaces[IFACE_NAME];
-            let iface_type = &iface.iface_type;
-            assert_eq!(iface_type, &nispor::IfaceType::Veth);
-            assert_eq!(
-                serde_yaml::to_string(&vec![iface]).unwrap(),
-                EXPECTED_IFACE_NAME
-            );
-        }
+        let state = NetState::retrieve().unwrap();
+        let iface = &state.ifaces[IFACE_NAME];
+        let iface_type = &iface.iface_type;
+        assert_eq!(iface_type, &nispor::IfaceType::Veth);
+        assert_eq!(
+            serde_yaml::to_string(&vec![iface]).unwrap(),
+            EXPECTED_IFACE_STATE
+        );
     });
 }
 

--- a/src/lib/tests/vlan.rs
+++ b/src/lib/tests/vlan.rs
@@ -7,7 +7,7 @@ mod utils;
 
 const IFACE_NAME: &str = "eth1.101";
 
-const EXPECTED_IFACE_NAME: &str = r#"---
+const EXPECTED_IFACE_STATE: &str = r#"---
 - name: eth1.101
   iface_type: vlan
   state: up
@@ -38,14 +38,13 @@ const EXPECTED_IFACE_NAME: &str = r#"---
 #[test]
 fn test_get_vlan_iface_yaml() {
     with_vlan_iface(|| {
-        if let Ok(state) = NetState::retrieve() {
-            let iface = &state.ifaces[IFACE_NAME];
-            assert_eq!(iface.iface_type, nispor::IfaceType::Vlan);
-            assert_eq!(
-                serde_yaml::to_string(&vec![iface]).unwrap(),
-                EXPECTED_IFACE_NAME
-            );
-        }
+        let state = NetState::retrieve().unwrap();
+        let iface = &state.ifaces[IFACE_NAME];
+        assert_eq!(iface.iface_type, nispor::IfaceType::Vlan);
+        assert_eq!(
+            serde_yaml::to_string(&vec![iface]).unwrap(),
+            EXPECTED_IFACE_STATE
+        );
     });
 }
 

--- a/src/lib/tests/vrf.rs
+++ b/src/lib/tests/vrf.rs
@@ -7,7 +7,7 @@ mod utils;
 
 const IFACE_NAME: &str = "vrf0";
 
-const EXPECTED_IFACE_NAME: &str = r#"---
+const EXPECTED_IFACE_STATE: &str = r#"---
 - name: vrf0
   iface_type: vrf
   state: up
@@ -29,14 +29,13 @@ const EXPECTED_IFACE_NAME: &str = r#"---
 #[ignore] // Travis CI does not support VRF yet
 fn test_get_vrf_iface_yaml() {
     with_vrf_iface(|| {
-        if let Ok(state) = NetState::retrieve() {
-            let iface = &state.ifaces[IFACE_NAME];
-            assert_eq!(iface.iface_type, nispor::IfaceType::Vrf);
-            assert_eq!(
-                serde_yaml::to_string(&vec![iface]).unwrap(),
-                EXPECTED_IFACE_NAME
-            );
-        }
+        let state = NetState::retrieve().unwrap();
+        let iface = &state.ifaces[IFACE_NAME];
+        assert_eq!(iface.iface_type, nispor::IfaceType::Vrf);
+        assert_eq!(
+            serde_yaml::to_string(&vec![iface]).unwrap(),
+            EXPECTED_IFACE_STATE
+        );
     });
 }
 

--- a/src/lib/tests/vxlan.rs
+++ b/src/lib/tests/vxlan.rs
@@ -7,7 +7,7 @@ mod utils;
 
 const IFACE_NAME: &str = "vxlan0";
 
-const EXPECTED_IFACE_NAME: &str = r#"---
+const EXPECTED_IFACE_STATE: &str = r#"---
 - name: vxlan0
   iface_type: vxlan
   state: unknown
@@ -58,14 +58,13 @@ const EXPECTED_IFACE_NAME: &str = r#"---
 #[test]
 fn test_get_vxlan_iface_yaml() {
     with_vxlan_iface(|| {
-        if let Ok(state) = NetState::retrieve() {
-            let iface = &state.ifaces[IFACE_NAME];
-            assert_eq!(iface.iface_type, nispor::IfaceType::Vxlan);
-            assert_eq!(
-                serde_yaml::to_string(&vec![iface]).unwrap(),
-                EXPECTED_IFACE_NAME
-            );
-        }
+        let state = NetState::retrieve().unwrap();
+        let iface = &state.ifaces[IFACE_NAME];
+        assert_eq!(iface.iface_type, nispor::IfaceType::Vxlan);
+        assert_eq!(
+            serde_yaml::to_string(&vec![iface]).unwrap(),
+            EXPECTED_IFACE_STATE
+        );
     });
 }
 


### PR DESCRIPTION
We should panic when `NetState::retrieve()` failed in test.