### PR TITLE
NisporError: Eliminate the duplicate memory copy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ $(CLI_EXEC_RELEASE) $(VARLINK_SRV_EXEC_RELEASE) $(CLIB_SO_DEV_RELEASE):
 
 check:
 	cargo test -- --test-threads=1 --show-output;
-	if [ "CHK$(TRAVIS)" != "CHKtrue" ]; then \
+	if [ "CHK$(CI)" != "CHKtrue" ]; then \
 		cargo test -- --test-threads=1 --show-output --ignored; \
 	fi
 	make check -C test/clib

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -24,22 +24,22 @@ pub struct NisporError {
 }
 
 impl NisporError {
-    pub fn bug(message: &str) -> NisporError {
+    pub(crate) fn bug(message: String) -> NisporError {
         NisporError {
             kind: ErrorKind::NisporBug,
-            msg: message.to_string(),
+            msg: message,
         }
     }
-    pub fn permission_deny(message: &str) -> NisporError {
+    pub(crate) fn permission_deny(message: String) -> NisporError {
         NisporError {
             kind: ErrorKind::PermissionDeny,
-            msg: message.to_string(),
+            msg: message,
         }
     }
-    pub fn invalid_argument(message: &str) -> NisporError {
+    pub(crate) fn invalid_argument(message: String) -> NisporError {
         NisporError {
             kind: ErrorKind::InvalidArgument,
-            msg: message.to_string(),
+            msg: message,
         }
     }
 }

--- a/src/lib/ifaces/sriov.rs
+++ b/src/lib/ifaces/sriov.rs
@@ -118,7 +118,7 @@ pub(crate) fn get_sriov_info(
                     vf_info.id = parse_as_u32(nla.value())?;
                     vf_info.mac = parse_vf_mac(
                         &nla.value().get(4..).ok_or(NisporError::bug(
-                            "invalid index into nla",
+                            "invalid index into nla".into(),
                         ))?,
                         mac_len,
                     )?;
@@ -126,60 +126,56 @@ pub(crate) fn get_sriov_info(
                 IFLA_VF_VLAN => {
                     vf_info.vlan_id =
                         parse_as_u32(&nla.value().get(4..).ok_or(
-                            NisporError::bug("invalid index into nla"),
+                            NisporError::bug("invalid index into nla".into()),
                         )?)?;
-                    vf_info.qos =
-                        parse_as_u32(&nla.value().get(8..).ok_or(
-                            NisporError::bug("invalid index into nla"),
-                        )?)?;
+                    vf_info.qos = parse_as_u32(&nla.value().get(8..).ok_or(
+                        NisporError::bug("invalid index into nla".into()),
+                    )?)?;
                 }
                 IFLA_VF_TX_RATE => {
                     vf_info.tx_rate =
                         parse_as_u32(&nla.value().get(4..).ok_or(
-                            NisporError::bug("invalid index into nla"),
+                            NisporError::bug("invalid index into nla".into()),
                         )?)?;
                 }
                 IFLA_VF_SPOOFCHK => {
-                    let d =
-                        parse_as_u32(&nla.value().get(4..).ok_or(
-                            NisporError::bug("invalid index into nla"),
-                        )?)?;
+                    let d = parse_as_u32(&nla.value().get(4..).ok_or(
+                        NisporError::bug("invalid index into nla".into()),
+                    )?)?;
                     vf_info.spoof_check = d > 0 && d != std::u32::MAX;
                 }
                 IFLA_VF_LINK_STATE => {
                     vf_info.link_state =
                         parse_as_u32(&nla.value().get(4..).ok_or(
-                            NisporError::bug("invalid index into nla"),
+                            NisporError::bug("invalid index into nla".into()),
                         )?)?
                         .into();
                 }
                 IFLA_VF_RATE => {
                     vf_info.min_tx_rate =
                         parse_as_u32(&nla.value().get(4..).ok_or(
-                            NisporError::bug("invalid index into nla"),
+                            NisporError::bug("invalid index into nla".into()),
                         )?)?
                         .into();
                     vf_info.max_tx_rate =
                         parse_as_u32(&nla.value().get(8..).ok_or(
-                            NisporError::bug("invalid index into nla"),
+                            NisporError::bug("invalid index into nla".into()),
                         )?)?
                         .into();
                 }
                 IFLA_VF_RSS_QUERY_EN => {
-                    let d =
-                        parse_as_u32(&nla.value().get(4..).ok_or(
-                            NisporError::bug("invalid index into nla"),
-                        )?)?;
+                    let d = parse_as_u32(&nla.value().get(4..).ok_or(
+                        NisporError::bug("invalid index into nla".into()),
+                    )?)?;
                     vf_info.query_rss = d > 0 && d != std::u32::MAX;
                 }
                 IFLA_VF_STATS => {
                     vf_info.state = parse_vf_stats(nla.value())?;
                 }
                 IFLA_VF_TRUST => {
-                    let d =
-                        parse_as_u32(&nla.value().get(4..).ok_or(
-                            NisporError::bug("invalid index into nla"),
-                        )?)?;
+                    let d = parse_as_u32(&nla.value().get(4..).ok_or(
+                        NisporError::bug("invalid index into nla".into()),
+                    )?)?;
                     vf_info.trust = d > 0 && d != std::u32::MAX;
                 }
                 IFLA_VF_IB_NODE_GUID => {

--- a/src/lib/mac.rs
+++ b/src/lib/mac.rs
@@ -10,7 +10,7 @@ pub(crate) fn parse_as_mac(
             "{:02x}",
             *data
                 .get(i)
-                .ok_or(NisporError::bug("wrong index at mac parsing"))?
+                .ok_or(NisporError::bug("wrong index at mac parsing".into()))?
         ));
         if i != mac_len - 1 {
             rt.push_str(":");

--- a/src/lib/net_conf.rs
+++ b/src/lib/net_conf.rs
@@ -19,7 +19,7 @@ impl NetConf {
                     Runtime::new()?.block_on(iface.apply(&cur_iface))?
                 } else {
                     // TODO: Create new interface
-                    return Err(NisporError::invalid_argument(&format!(
+                    return Err(NisporError::invalid_argument(format!(
                         "Interface {} not found!",
                         iface.name
                     )));

--- a/src/lib/netlink/bond.rs
+++ b/src/lib/netlink/bond.rs
@@ -35,9 +35,9 @@ fn ipv4_addr_array_to_string(
 ) -> Result<String, NisporError> {
     let mut rt = String::new();
     for i in 0..(addrs.len()) {
-        let addr = &addrs
-            .get(i)
-            .ok_or(NisporError::bug("wrong index at parsing ipv4 as string"))?;
+        let addr = &addrs.get(i).ok_or(NisporError::bug(
+            "wrong index at parsing ipv4 as string".into(),
+        ))?;
         rt.push_str(&addr.to_string());
         if i != addrs.len() - 1 {
             rt.push_str(",");

--- a/src/lib/netlink/bridge.rs
+++ b/src/lib/netlink/bridge.rs
@@ -115,12 +115,12 @@ fn parse_bridge_id(
     let priority_bytes = priority.to_ne_bytes();
     Ok(format!(
         "{:02x}{:02x}.{}",
-        priority_bytes
-            .get(0)
-            .ok_or(NisporError::bug("wrong index at bridge_id parsing"))?,
-        priority_bytes
-            .get(1)
-            .ok_or(NisporError::bug("wrong index at bridge_id parsing"))?,
+        priority_bytes.get(0).ok_or(NisporError::bug(
+            "wrong index at bridge_id parsing".into()
+        ))?,
+        priority_bytes.get(1).ok_or(NisporError::bug(
+            "wrong index at bridge_id parsing".into()
+        ))?,
         parse_as_mac(ETH_ALEN, mac)
             .expect("error when parsing mac address in bridge_id")
             .to_lowercase()

--- a/src/lib/netlink/bridge_port.rs
+++ b/src/lib/netlink/bridge_port.rs
@@ -342,13 +342,13 @@ fn parse_as_bridge_id(data: &[u8]) -> Result<String, NisporError> {
     let err_msg = "wrong index at bridge_id parsing";
     Ok(format!(
         "{:02x}{:02x}.{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
-        data.get(0).ok_or(NisporError::bug(err_msg))?,
-        data.get(1).ok_or(NisporError::bug(err_msg))?,
-        data.get(2).ok_or(NisporError::bug(err_msg))?,
-        data.get(3).ok_or(NisporError::bug(err_msg))?,
-        data.get(4).ok_or(NisporError::bug(err_msg))?,
-        data.get(5).ok_or(NisporError::bug(err_msg))?,
-        data.get(6).ok_or(NisporError::bug(err_msg))?,
-        data.get(7).ok_or(NisporError::bug(err_msg))?,
+        data.get(0).ok_or(NisporError::bug(err_msg.into()))?,
+        data.get(1).ok_or(NisporError::bug(err_msg.into()))?,
+        data.get(2).ok_or(NisporError::bug(err_msg.into()))?,
+        data.get(3).ok_or(NisporError::bug(err_msg.into()))?,
+        data.get(4).ok_or(NisporError::bug(err_msg.into()))?,
+        data.get(5).ok_or(NisporError::bug(err_msg.into()))?,
+        data.get(6).ok_or(NisporError::bug(err_msg.into()))?,
+        data.get(7).ok_or(NisporError::bug(err_msg.into()))?,
     ))
 }

--- a/src/lib/netlink/bridge_vlan.rs
+++ b/src/lib/netlink/bridge_vlan.rs
@@ -63,18 +63,18 @@ fn parse_vlan_info(
         let flags = u16::from_ne_bytes([
             *data
                 .get(0)
-                .ok_or(NisporError::bug("wrong index at vlan flags"))?,
+                .ok_or(NisporError::bug("wrong index at vlan flags".into()))?,
             *data
                 .get(1)
-                .ok_or(NisporError::bug("wrong index at vlan flags"))?,
+                .ok_or(NisporError::bug("wrong index at vlan flags".into()))?,
         ]);
         let vid = u16::from_ne_bytes([
             *data
                 .get(2)
-                .ok_or(NisporError::bug("wrong index at vlan id"))?,
+                .ok_or(NisporError::bug("wrong index at vlan id".into()))?,
             *data
                 .get(3)
-                .ok_or(NisporError::bug("wrong index at vlan id"))?,
+                .ok_or(NisporError::bug("wrong index at vlan id".into()))?,
         ]);
         let mut entry = KernelBridgeVlanEntry {
             vid: vid,

--- a/src/lib/netlink/error.rs
+++ b/src/lib/netlink/error.rs
@@ -6,12 +6,12 @@ pub(crate) fn parse_apply_netlink_error(
     netlink_err: &ErrorMessage,
 ) -> NisporError {
     match netlink_err.code.abs() {
-        EEXIST => NisporError::bug(&format!(
+        EEXIST => NisporError::bug(format!(
             "Got netlink EEXIST error: {}",
             netlink_err
         )),
-        EPERM => NisporError::permission_deny(&format!("{}", netlink_err,)),
-        _ => NisporError::bug(&format!(
+        EPERM => NisporError::permission_deny(format!("{}", netlink_err,)),
+        _ => NisporError::bug(format!(
             "Got netlink unknown error: code {}, msg: {}",
             netlink_err.code, netlink_err,
         )),

--- a/src/lib/netlink/ip.rs
+++ b/src/lib/netlink/ip.rs
@@ -138,16 +138,32 @@ fn parse_cache_info(
         let err_msg = "wrong index at cache_info_raw parsing";
         Ok(IfaCacheInfo {
             ifa_prefered: u32::from_ne_bytes([
-                *cache_info_raw.get(0).ok_or(NisporError::bug(err_msg))?,
-                *cache_info_raw.get(1).ok_or(NisporError::bug(err_msg))?,
-                *cache_info_raw.get(2).ok_or(NisporError::bug(err_msg))?,
-                *cache_info_raw.get(3).ok_or(NisporError::bug(err_msg))?,
+                *cache_info_raw
+                    .get(0)
+                    .ok_or(NisporError::bug(err_msg.into()))?,
+                *cache_info_raw
+                    .get(1)
+                    .ok_or(NisporError::bug(err_msg.into()))?,
+                *cache_info_raw
+                    .get(2)
+                    .ok_or(NisporError::bug(err_msg.into()))?,
+                *cache_info_raw
+                    .get(3)
+                    .ok_or(NisporError::bug(err_msg.into()))?,
             ]),
             ifa_valid: u32::from_ne_bytes([
-                *cache_info_raw.get(4).ok_or(NisporError::bug(err_msg))?,
-                *cache_info_raw.get(5).ok_or(NisporError::bug(err_msg))?,
-                *cache_info_raw.get(6).ok_or(NisporError::bug(err_msg))?,
-                *cache_info_raw.get(7).ok_or(NisporError::bug(err_msg))?,
+                *cache_info_raw
+                    .get(4)
+                    .ok_or(NisporError::bug(err_msg.into()))?,
+                *cache_info_raw
+                    .get(5)
+                    .ok_or(NisporError::bug(err_msg.into()))?,
+                *cache_info_raw
+                    .get(6)
+                    .ok_or(NisporError::bug(err_msg.into()))?,
+                *cache_info_raw
+                    .get(7)
+                    .ok_or(NisporError::bug(err_msg.into()))?,
             ]),
         })
     }

--- a/src/lib/netlink/nla.rs
+++ b/src/lib/netlink/nla.rs
@@ -6,66 +6,66 @@ use std::net::Ipv6Addr;
 pub(crate) fn parse_as_u8(data: &[u8]) -> Result<u8, NisporError> {
     Ok(*data
         .get(0)
-        .ok_or(NisporError::bug("wrong index when parsing as u8"))?)
+        .ok_or(NisporError::bug("wrong index when parsing as u8".into()))?)
 }
 
 pub(crate) fn parse_as_u16(data: &[u8]) -> Result<u16, NisporError> {
     let err_msg = "wrong index when parsing as u16";
     Ok(u16::from_ne_bytes([
-        *data.get(0).ok_or(NisporError::bug(err_msg))?,
-        *data.get(1).ok_or(NisporError::bug(err_msg))?,
+        *data.get(0).ok_or(NisporError::bug(err_msg.into()))?,
+        *data.get(1).ok_or(NisporError::bug(err_msg.into()))?,
     ]))
 }
 
 pub(crate) fn parse_as_be16(data: &[u8]) -> Result<u16, NisporError> {
     let err_msg = "wrong index when parsing as be16";
     Ok(u16::from_be_bytes([
-        *data.get(0).ok_or(NisporError::bug(err_msg))?,
-        *data.get(1).ok_or(NisporError::bug(err_msg))?,
+        *data.get(0).ok_or(NisporError::bug(err_msg.into()))?,
+        *data.get(1).ok_or(NisporError::bug(err_msg.into()))?,
     ]))
 }
 
 pub(crate) fn parse_as_i32(data: &[u8]) -> Result<i32, NisporError> {
     let err_msg = "wrong index when parsing as i32";
     Ok(i32::from_ne_bytes([
-        *data.get(0).ok_or(NisporError::bug(err_msg))?,
-        *data.get(1).ok_or(NisporError::bug(err_msg))?,
-        *data.get(2).ok_or(NisporError::bug(err_msg))?,
-        *data.get(3).ok_or(NisporError::bug(err_msg))?,
+        *data.get(0).ok_or(NisporError::bug(err_msg.into()))?,
+        *data.get(1).ok_or(NisporError::bug(err_msg.into()))?,
+        *data.get(2).ok_or(NisporError::bug(err_msg.into()))?,
+        *data.get(3).ok_or(NisporError::bug(err_msg.into()))?,
     ]))
 }
 
 pub(crate) fn parse_as_u32(data: &[u8]) -> Result<u32, NisporError> {
     let err_msg = "wrong index when parsing as u32";
     Ok(u32::from_ne_bytes([
-        *data.get(0).ok_or(NisporError::bug(err_msg))?,
-        *data.get(1).ok_or(NisporError::bug(err_msg))?,
-        *data.get(2).ok_or(NisporError::bug(err_msg))?,
-        *data.get(3).ok_or(NisporError::bug(err_msg))?,
+        *data.get(0).ok_or(NisporError::bug(err_msg.into()))?,
+        *data.get(1).ok_or(NisporError::bug(err_msg.into()))?,
+        *data.get(2).ok_or(NisporError::bug(err_msg.into()))?,
+        *data.get(3).ok_or(NisporError::bug(err_msg.into()))?,
     ]))
 }
 
 pub(crate) fn parse_as_be32(data: &[u8]) -> Result<u32, NisporError> {
     let err_msg = "wrong index when parsing as be32";
     Ok(u32::from_be_bytes([
-        *data.get(0).ok_or(NisporError::bug(err_msg))?,
-        *data.get(1).ok_or(NisporError::bug(err_msg))?,
-        *data.get(2).ok_or(NisporError::bug(err_msg))?,
-        *data.get(3).ok_or(NisporError::bug(err_msg))?,
+        *data.get(0).ok_or(NisporError::bug(err_msg.into()))?,
+        *data.get(1).ok_or(NisporError::bug(err_msg.into()))?,
+        *data.get(2).ok_or(NisporError::bug(err_msg.into()))?,
+        *data.get(3).ok_or(NisporError::bug(err_msg.into()))?,
     ]))
 }
 
 pub(crate) fn parse_as_u64(data: &[u8]) -> Result<u64, NisporError> {
     let err_msg = "wrong index when parsing as u64";
     Ok(u64::from_ne_bytes([
-        *data.get(0).ok_or(NisporError::bug(err_msg))?,
-        *data.get(1).ok_or(NisporError::bug(err_msg))?,
-        *data.get(2).ok_or(NisporError::bug(err_msg))?,
-        *data.get(3).ok_or(NisporError::bug(err_msg))?,
-        *data.get(4).ok_or(NisporError::bug(err_msg))?,
-        *data.get(5).ok_or(NisporError::bug(err_msg))?,
-        *data.get(6).ok_or(NisporError::bug(err_msg))?,
-        *data.get(7).ok_or(NisporError::bug(err_msg))?,
+        *data.get(0).ok_or(NisporError::bug(err_msg.into()))?,
+        *data.get(1).ok_or(NisporError::bug(err_msg.into()))?,
+        *data.get(2).ok_or(NisporError::bug(err_msg.into()))?,
+        *data.get(3).ok_or(NisporError::bug(err_msg.into()))?,
+        *data.get(4).ok_or(NisporError::bug(err_msg.into()))?,
+        *data.get(5).ok_or(NisporError::bug(err_msg.into()))?,
+        *data.get(6).ok_or(NisporError::bug(err_msg.into()))?,
+        *data.get(7).ok_or(NisporError::bug(err_msg.into()))?,
     ]))
 }
 

--- a/src/lib/route.rs
+++ b/src/lib/route.rs
@@ -547,10 +547,10 @@ fn get_route(
                 while (i < len) && (len - i > SIZE_OF_RTNEXTHOP) {
                     let nex_hop_len = parse_as_u16(&[
                         *d.get(i).ok_or(NisporError::bug(
-                            "wrong index at multipath next_hop_len",
+                            "wrong index at multipath next_hop_len".into(),
                         ))?,
                         *d.get(i + 1).ok_or(NisporError::bug(
-                            "wrong index at multipath next_hop_len",
+                            "wrong index at multipath next_hop_len".into(),
                         ))?,
                     ])?;
                     let nla = NlaBuffer::new(
@@ -578,7 +578,7 @@ fn get_route(
                     };
                     let iface_index = parse_as_i32(
                         &d.get(i + 4..i + 8).ok_or(NisporError::bug(
-                            "wrong index at multipath iface_index",
+                            "wrong index at multipath iface_index".into(),
                         ))?,
                     )?;
                     let iface = if let Some(iface_name) =
@@ -589,9 +589,9 @@ fn get_route(
                         format!("{}", iface_index)
                     };
                     let mut flags = Vec::new();
-                    let flags_raw = d
-                        .get(i + 2)
-                        .ok_or(NisporError::bug("wrong index at flags raw"))?;
+                    let flags_raw = d.get(i + 2).ok_or(NisporError::bug(
+                        "wrong index at flags raw".into(),
+                    ))?;
                     //TODO: Need better way to handle the bitmap.
                     if (flags_raw & RTNH_F_DEAD) > 0 {
                         flags.push(MultipathRouteFlags::Dead);
@@ -609,10 +609,9 @@ fn get_route(
 
                     let next_hop = MultipathRoute {
                         flags: flags,
-                        weight: *d
-                            .get(i + 3)
-                            .ok_or(NisporError::bug("wrong index at weight"))?
-                            as u16
+                        weight: *d.get(i + 3).ok_or(NisporError::bug(
+                            "wrong index at weight".into(),
+                        ))? as u16
                             + 1,
                         iface: iface,
                         via: via,


### PR DESCRIPTION
Changed the `NisporError::bug` and etc functions to take `String` as
argument, so the we don't do duplicate memory copy like:

    (&format("{}", a)).to_string()

Also changed these functions to crate use only.