### PR TITLE
CI: Use Ubuntu 20.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,28 +18,38 @@ jobs:
           - rust_version: "beta"
 
     name: CI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
 
+
     - name: Install Rust ${{ matrix.rust_version }}
-      run: |
-        rustc -vV
-        rustup update ${{ matrix.rust_version }}
-        rustup default ${{ matrix.rust_version }}
-        rustup component add rustfmt
-        rustc -vV
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: ${{ matrix.rust_version }}
+          override: true
+          components: rustfmt
 
     - name: Install valgrind
-      run: |
-        sudo apt-get update
-        sudo apt-get -y install valgrind
+      if: matrix.rust_version == 'stable'
+      run: sudo apt-get -y install valgrind
 
     - name: Check fmt
       if: matrix.rust_version == 'stable'
       run: cargo fmt -- --check
+
+    - name: Instruct cargo to use sudo as runner
+      run: |
+        echo "[target.x86_64-unknown-linux-gnu]" >> .cargo/config.toml
+        echo "runner = 'sudo -E'" >> .cargo/config.toml
+
     - name: Build
-      run: sudo env PATH=$PATH cargo build --verbose --all
-    - name: Run tests
-      run: sudo env PATH=$PATH make check
+      run: cargo build --verbose --all
+
+    - name: Run cargo tests
+      run: cargo test -- --test-threads=1 --show-output
+
+    - name: Run clib test
+      if: matrix.rust_version == 'stable'
+      run: sudo make check -C test/clib

--- a/src/lib/tests/vrf.rs
+++ b/src/lib/tests/vrf.rs
@@ -18,7 +18,6 @@ const EXPECTED_IFACE_STATE: &str = r#"---
     - no_arp
     - running
     - up
-  mac_address: "00:23:45:67:89:1c"
   vrf:
     table_id: 10
     subordinates:
@@ -26,11 +25,14 @@ const EXPECTED_IFACE_STATE: &str = r#"---
       - eth2"#;
 
 #[test]
-#[ignore] // Travis CI does not support VRF yet
+#[ignore] // Github Action does not have VRF kernel module
 fn test_get_vrf_iface_yaml() {
     with_vrf_iface(|| {
         let state = NetState::retrieve().unwrap();
-        let iface = &state.ifaces[IFACE_NAME];
+        let mut iface = state.ifaces[IFACE_NAME].clone();
+        // RHEL/CentOS 8 and Ubuntu 20.04 does not support changing mac
+        // address of VRF interface
+        iface.mac_address = "".into();
         assert_eq!(iface.iface_type, nispor::IfaceType::Vrf);
         assert_eq!(
             serde_yaml::to_string(&vec![iface]).unwrap(),


### PR DESCRIPTION
Changes:
 * Switch to Ubuntu 20.04 LTS.
 * Use actions-rs/toolchain@v1 to install rust.
 * Use `.cargo/config.toml` to instruct `cargo test` to use sudo.
 * Only run memory check on rust stable matrix.