### PR TITLE
vlan: Use 'ref mut' instaed of clone

### DIFF
--- a/src/lib/ifaces/bridge.rs
+++ b/src/lib/ifaces/bridge.rs
@@ -299,12 +299,9 @@ fn gen_port_list_of_controller(iface_states: &mut HashMap<String, Iface>) {
     }
     for (controller, ports) in controller_ports.iter_mut() {
         if let Some(controller_iface) = iface_states.get_mut(controller) {
-            if let Some(old_bridge_info) = &controller_iface.bridge {
-                // TODO: Need better way to update this port list.
-                let mut new_bridge_info = old_bridge_info.clone();
+            if let Some(ref mut bridge_info) = controller_iface.bridge {
                 ports.sort();
-                new_bridge_info.ports = ports.clone();
-                controller_iface.bridge = Some(new_bridge_info);
+                bridge_info.ports = ports.clone();
             }
         }
     }
@@ -319,15 +316,11 @@ fn convert_back_port_index_to_name(iface_states: &mut HashMap<String, Iface>) {
         if iface.controller_type != Some(ControllerType::Bridge) {
             continue;
         }
-        if let Some(old_port_info) = &iface.bridge_port {
-            let index = &old_port_info.backup_port;
+        if let Some(ref mut port_info) = iface.bridge_port {
+            let index = &port_info.backup_port;
             if index != "" {
                 if let Some(iface_name) = index_to_name.get(index) {
-                    // TODO: Find a way to update old_port_info instaed of
-                    // clone()
-                    let mut new_port_info = old_port_info.clone();
-                    new_port_info.backup_port = iface_name.into();
-                    iface.bridge_port = Some(new_port_info);
+                    port_info.backup_port = iface_name.into();
                 }
             }
         }
@@ -348,11 +341,8 @@ pub(crate) fn parse_bridge_vlan_info(
     iface_state: &mut Iface,
     data: &[u8],
 ) -> Result<(), NisporError> {
-    if let Some(old_port_info) = &iface_state.bridge_port {
-        // TODO: shoule update in place instead of clone
-        let mut new_port_info = old_port_info.clone();
-        new_port_info.vlans = parse_af_spec_bridge_info(data)?;
-        iface_state.bridge_port = Some(new_port_info);
+    if let Some(ref mut port_info) = iface_state.bridge_port {
+        port_info.vlans = parse_af_spec_bridge_info(data)?;
     }
     Ok(())
 }

--- a/src/lib/ifaces/iface.rs
+++ b/src/lib/ifaces/iface.rs
@@ -328,11 +328,9 @@ pub(crate) fn parse_nl_msg_to_iface(
             // println!("{} {:?}", name, nla);
         }
     }
-    if let Some(old_vlan_info) = &iface_state.vlan {
+    if let Some(ref mut vlan_info) = iface_state.vlan {
         if let Some(base_iface_index) = link {
-            let mut new_vlan_info = old_vlan_info.clone();
-            new_vlan_info.base_iface = format!("{}", base_iface_index);
-            iface_state.vlan = Some(new_vlan_info);
+            vlan_info.base_iface = format!("{}", base_iface_index);
         }
     }
     if let Some(iface_index) = link {

--- a/src/lib/ifaces/vlan.rs
+++ b/src/lib/ifaces/vlan.rs
@@ -100,13 +100,11 @@ fn convert_base_iface_index_to_name(iface_states: &mut HashMap<String, Iface>) {
         if iface.iface_type != IfaceType::Vlan {
             continue;
         }
-        if let Some(old_vlan_info) = &iface.vlan {
+        if let Some(ref mut vlan_info) = iface.vlan {
             if let Some(base_iface_name) =
-                index_to_name.get(&old_vlan_info.base_iface)
+                index_to_name.get(&vlan_info.base_iface)
             {
-                let mut new_vlan_info = old_vlan_info.clone();
-                new_vlan_info.base_iface = base_iface_name.clone();
-                iface.vlan = Some(new_vlan_info);
+                vlan_info.base_iface = base_iface_name.clone();
             }
         }
     }

--- a/src/lib/ifaces/vrf.rs
+++ b/src/lib/ifaces/vrf.rs
@@ -76,12 +76,9 @@ fn gen_subordinate_list_of_controller(
     }
     for (controller, subordinates) in controller_subordinates.iter_mut() {
         if let Some(controller_iface) = iface_states.get_mut(controller) {
-            if let Some(old_vrf_info) = &controller_iface.vrf {
-                // TODO: Need better way to update this subordinate list.
-                let mut new_vrf_info = old_vrf_info.clone();
+            if let Some(ref mut vrf_info) = controller_iface.vrf {
                 subordinates.sort();
-                new_vrf_info.subordinates = subordinates.clone();
-                controller_iface.vrf = Some(new_vrf_info);
+                vrf_info.subordinates = subordinates.clone();
             }
         }
     }

--- a/src/lib/ifaces/vxlan.rs
+++ b/src/lib/ifaces/vxlan.rs
@@ -126,13 +126,11 @@ fn convert_base_iface_index_to_name(iface_states: &mut HashMap<String, Iface>) {
         if iface.iface_type != IfaceType::Vxlan {
             continue;
         }
-        if let Some(old_vxlan_info) = &iface.vxlan {
+        if let Some(ref mut vxlan_info) = iface.vxlan {
             if let Some(base_iface_name) =
-                index_to_name.get(&old_vxlan_info.base_iface)
+                index_to_name.get(&vxlan_info.base_iface)
             {
-                let mut new_vxlan_info = old_vxlan_info.clone();
-                new_vxlan_info.base_iface = base_iface_name.clone();
-                iface.vxlan = Some(new_vxlan_info);
+                vxlan_info.base_iface = base_iface_name.clone();
             }
         }
     }


### PR DESCRIPTION
With clone one has to make a new copy and story it back to the member,
we can use ref mut so we use a mutable reference to the field and we
don't have to copy and assign it again.

Closes #34 

Signed-off-by: Quique Llorente <ellorent@redhat.com>