### PR TITLE
ethtool: Add ethtool PAUSE support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,6 @@ members = [
     "src/lib",
     "src/cli",
     "src/clib",
+    "src/netlink-generic",
+    "src/netlink-ethtool",
 ]

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -23,6 +23,8 @@ rtnetlink = "0.7"
 netlink-packet-route = "0.7"
 netlink-sys = "0.6"
 netlink-packet-utils = "0.4"
+netlink-ethtool = {path ="../netlink-ethtool"}
+netlink-generic = {path ="../netlink-generic"}
 tokio = { version = "1.0.1", features = ["macros", "rt"] }
 futures = "0.3"
 libc = "0.2.74"

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -1,3 +1,5 @@
+use netlink_ethtool::EthtoolError;
+use netlink_generic::GenericNetlinkError;
 use netlink_packet_utils::DecodeError;
 use rtnetlink;
 use serde_derive::Serialize;
@@ -56,6 +58,24 @@ impl std::error::Error for NisporError {
 
 impl std::convert::From<rtnetlink::Error> for NisporError {
     fn from(e: rtnetlink::Error) -> Self {
+        NisporError {
+            kind: ErrorKind::NetlinkError,
+            msg: e.to_string(),
+        }
+    }
+}
+
+impl std::convert::From<GenericNetlinkError> for NisporError {
+    fn from(e: GenericNetlinkError) -> Self {
+        NisporError {
+            kind: ErrorKind::NetlinkError,
+            msg: e.to_string(),
+        }
+    }
+}
+
+impl std::convert::From<EthtoolError> for NisporError {
+    fn from(e: EthtoolError) -> Self {
         NisporError {
             kind: ErrorKind::NetlinkError,
             msg: e.to_string(),

--- a/src/lib/ifaces/ethtool.rs
+++ b/src/lib/ifaces/ethtool.rs
@@ -1,0 +1,77 @@
+use std::collections::HashMap;
+
+use futures::stream::TryStreamExt;
+use netlink_ethtool::{self, EthoolAttr, EthtoolHeader, PauseAttr};
+use netlink_generic;
+use serde_derive::{Deserialize, Serialize};
+
+use crate::NisporError;
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default)]
+pub struct EthtoolPauseInfo {
+    rx: bool,
+    tx: bool,
+    auto_negotiate: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default)]
+pub struct EthtoolInfo {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pause: Option<EthtoolPauseInfo>,
+}
+
+pub(crate) async fn get_ethtool_infos(
+) -> Result<HashMap<String, EthtoolInfo>, NisporError> {
+    let mut infos: HashMap<String, EthtoolInfo> = HashMap::new();
+
+    let family_id = get_family_id().await?;
+
+    let (connection, mut handle, _) =
+        netlink_ethtool::new_connection(family_id).unwrap();
+    tokio::spawn(connection);
+
+    for ethtool_msg in handle.pause().get(None).execute().try_next().await? {
+        let EthoolAttr::Pause(nlas) = ethtool_msg.nlas;
+        let mut iface_name = None;
+        let mut pause_info = EthtoolPauseInfo::default();
+
+        for nla in &nlas {
+            if let PauseAttr::Header(hdrs) = nla {
+                iface_name = get_iface_name_from_header(&hdrs);
+            } else if let PauseAttr::AutoNeg(v) = nla {
+                pause_info.auto_negotiate = *v
+            } else if let PauseAttr::Rx(v) = nla {
+                pause_info.rx = *v
+            } else if let PauseAttr::Tx(v) = nla {
+                pause_info.tx = *v
+            }
+        }
+        if let Some(i) = iface_name {
+            infos.insert(
+                i.to_string(),
+                EthtoolInfo {
+                    pause: Some(pause_info),
+                },
+            );
+        }
+    }
+
+    Ok(infos)
+}
+
+async fn get_family_id() -> Result<u16, NisporError> {
+    let (connection, mut handle, _) =
+        netlink_generic::new_connection().unwrap();
+    tokio::spawn(connection);
+
+    Ok(handle.resolve_family_name("ethtool").await?)
+}
+
+fn get_iface_name_from_header(hdrs: &[EthtoolHeader]) -> Option<&str> {
+    for hdr in hdrs {
+        if let EthtoolHeader::DevName(iface_name) = hdr {
+            return Some(iface_name.as_str());
+        }
+    }
+    None
+}

--- a/src/lib/ifaces/iface.rs
+++ b/src/lib/ifaces/iface.rs
@@ -7,6 +7,7 @@ use crate::ifaces::bridge::get_bridge_port_info;
 use crate::ifaces::bridge::parse_bridge_vlan_info;
 use crate::ifaces::bridge::BridgeInfo;
 use crate::ifaces::bridge::BridgePortInfo;
+use crate::ifaces::ethtool::EthtoolInfo;
 use crate::ifaces::mac_vlan::get_mac_vlan_info;
 use crate::ifaces::mac_vlan::MacVlanInfo;
 use crate::ifaces::mac_vtap::get_mac_vtap_info;
@@ -158,6 +159,8 @@ pub struct Iface {
     pub controller: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub controller_type: Option<ControllerType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ethtool: Option<EthtoolInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bond: Option<BondInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/lib/ifaces/mod.rs
+++ b/src/lib/ifaces/mod.rs
@@ -1,5 +1,6 @@
 mod bond;
 mod bridge;
+mod ethtool;
 mod iface;
 mod ifaces;
 mod mac_vlan;
@@ -28,6 +29,7 @@ pub use crate::ifaces::bond::BondXmitHashPolicy;
 pub use crate::ifaces::bridge::BridgeInfo;
 pub use crate::ifaces::bridge::BridgePortInfo;
 pub use crate::ifaces::bridge::BridgeVlanEntry;
+pub use crate::ifaces::ethtool::{EthtoolInfo, EthtoolPauseInfo};
 pub(crate) use crate::ifaces::iface::get_iface_name_by_index;
 pub use crate::ifaces::iface::ControllerType;
 pub use crate::ifaces::iface::Iface;

--- a/src/lib/tests/ethtool.rs
+++ b/src/lib/tests/ethtool.rs
@@ -1,0 +1,54 @@
+use nispor::NetState;
+use pretty_assertions::assert_eq;
+use serde_yaml;
+use std::panic;
+
+mod utils;
+
+const IFACE_NAME: &str = "sim0";
+
+const EXPECTED_IFACE_STATE: &str = r#"---
+- name: sim0
+  iface_type: ethernet
+  state: down
+  mtu: 1500
+  flags:
+    - broadcast
+    - no_arp
+  mac_address: "00:23:45:67:89:20"
+  ethtool:
+    pause:
+      rx: true
+      tx: true
+      auto_negotiate: false
+  sriov:
+    vfs: []"#;
+
+#[test]
+#[ignore] // CI does not have netdevsim kernel module yet
+fn test_get_ethtool_pause_yaml() {
+    with_ethtool_iface(|| {
+        let state = NetState::retrieve().unwrap();
+        let iface = &state.ifaces[IFACE_NAME];
+        let iface_type = &iface.iface_type;
+        assert_eq!(iface_type, &nispor::IfaceType::Ethernet);
+        assert_eq!(
+            serde_yaml::to_string(&vec![iface]).unwrap().trim(),
+            EXPECTED_IFACE_STATE
+        );
+    });
+}
+
+fn with_ethtool_iface<T>(test: T) -> ()
+where
+    T: FnOnce() -> () + panic::UnwindSafe,
+{
+    utils::set_network_environment("ethtool");
+
+    let result = panic::catch_unwind(|| {
+        test();
+    });
+
+    utils::clear_network_environment();
+    assert!(result.is_ok())
+}

--- a/src/netlink-ethtool/Cargo.toml
+++ b/src/netlink-ethtool/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "netlink-ethtool"
+version = "1.0.1"
+authors = ["Gris Ge <cnfourt@gmail.com>"]
+license = "MIT"
+edition = "2018"
+description = "Linux Ethtool Communication Library"
+keywords = ["network"]
+categories = ["network-programming", "os"]
+
+[lib]
+name = "netlink_ethtool"
+path = "lib.rs"
+crate-type = ["lib"]
+
+[dependencies]
+netlink-sys = "0.6"
+netlink-packet-utils = "0.4"
+netlink-packet-core = "0.2.4"
+netlink-proto = "0.6"
+netlink-generic = {path ="../netlink-generic"}
+futures = "0.3.11"
+anyhow = "1.0.31"
+thiserror = "1"
+byteorder = "1.3.2"
+
+[dev-dependencies]
+tokio = { version = "1.0.1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/src/netlink-ethtool/connection.rs
+++ b/src/netlink-ethtool/connection.rs
@@ -1,0 +1,21 @@
+use std::io;
+
+use futures::channel::mpsc::UnboundedReceiver;
+use netlink_packet_core::NetlinkMessage;
+use netlink_proto::{self, Connection};
+use netlink_sys::{constants::NETLINK_GENERIC, SocketAddr};
+
+use crate::{EthtoolHandle, EthtoolMessage};
+
+#[allow(clippy::type_complexity)]
+pub fn new_connection(
+    family_id: u16,
+) -> io::Result<(
+    Connection<EthtoolMessage>,
+    EthtoolHandle,
+    UnboundedReceiver<(NetlinkMessage<EthtoolMessage>, SocketAddr)>,
+)> {
+    let (conn, handle, messages) =
+        netlink_proto::new_connection(NETLINK_GENERIC)?;
+    Ok((conn, EthtoolHandle::new(handle, family_id), messages))
+}

--- a/src/netlink-ethtool/error.rs
+++ b/src/netlink-ethtool/error.rs
@@ -1,0 +1,17 @@
+use thiserror::Error;
+
+use netlink_packet_core::{ErrorMessage, NetlinkMessage};
+
+use crate::EthtoolMessage;
+
+#[derive(Clone, Eq, PartialEq, Debug, Error)]
+pub enum EthtoolError {
+    #[error("Received an unexpected message {0:?}")]
+    UnexpectedMessage(NetlinkMessage<EthtoolMessage>),
+
+    #[error("Received a netlink error message {0}")]
+    NetlinkError(ErrorMessage),
+
+    #[error("A netlink request failed")]
+    RequestFailed(String),
+}

--- a/src/netlink-ethtool/examples/dump_pause.rs
+++ b/src/netlink-ethtool/examples/dump_pause.rs
@@ -1,0 +1,38 @@
+use futures::stream::TryStreamExt;
+use netlink_ethtool;
+use netlink_generic;
+use tokio;
+
+// Once we find a way to load netsimdev kernel module in CI, we can convert this
+// to a test
+fn main() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()
+        .unwrap();
+    let family_id = rt.block_on(genl_ctrl_resolve_ethtool());
+    rt.block_on(get_pause(family_id, None));
+}
+
+async fn genl_ctrl_resolve_ethtool() -> u16 {
+    let (connection, mut handle, _) =
+        netlink_generic::new_connection().unwrap();
+    tokio::spawn(connection);
+
+    let family_id = handle.resolve_family_name("ethtool").await.unwrap();
+    println!("Family ID of ethtool is {}", family_id);
+    family_id
+}
+
+async fn get_pause(family_id: u16, iface_name: Option<&str>) {
+    let (connection, mut handle, _) =
+        netlink_ethtool::new_connection(family_id).unwrap();
+    tokio::spawn(connection);
+
+    let mut msgs = Vec::new();
+    for msg in handle.pause().get(iface_name).execute().try_next().await {
+        msgs.push(msg.unwrap());
+    }
+    assert!(msgs.len() > 0);
+    println!("{:?}", msgs);
+}

--- a/src/netlink-ethtool/handle.rs
+++ b/src/netlink-ethtool/handle.rs
@@ -1,0 +1,39 @@
+use futures::Stream;
+use netlink_packet_core::NetlinkMessage;
+use netlink_proto::{sys::SocketAddr, ConnectionHandle};
+
+use crate::{EthtoolError, EthtoolMessage, PauseHandle};
+
+#[derive(Clone, Debug)]
+pub struct EthtoolHandle {
+    pub family_id: u16,
+    pub handle: ConnectionHandle<EthtoolMessage>,
+}
+
+impl EthtoolHandle {
+    pub(crate) fn new(
+        handle: ConnectionHandle<EthtoolMessage>,
+        family_id: u16,
+    ) -> Self {
+        EthtoolHandle { family_id, handle }
+    }
+
+    pub fn pause(&mut self) -> PauseHandle {
+        PauseHandle::new(self.clone())
+    }
+
+    pub fn request(
+        &mut self,
+        message: NetlinkMessage<EthtoolMessage>,
+    ) -> Result<impl Stream<Item = NetlinkMessage<EthtoolMessage>>, EthtoolError>
+    {
+        self.handle
+            .request(message, SocketAddr::new(0, 0))
+            .map_err(|e| {
+                EthtoolError::RequestFailed(format!(
+                    "BUG: Request failed with {}",
+                    e
+                ))
+            })
+    }
+}

--- a/src/netlink-ethtool/header.rs
+++ b/src/netlink-ethtool/header.rs
@@ -1,0 +1,100 @@
+use std::ffi::CString;
+
+use anyhow::Context;
+use byteorder::{ByteOrder, NativeEndian};
+use netlink_packet_utils::{
+    nla::{self, DefaultNla, NlaBuffer},
+    parsers::{parse_string, parse_u32},
+    DecodeError, Parseable,
+};
+
+const ALTIFNAMSIZ: usize = 128;
+const ETHTOOL_A_HEADER_DEV_INDEX: u16 = 1;
+const ETHTOOL_A_HEADER_DEV_NAME: u16 = 2;
+const ETHTOOL_A_HEADER_FLAGS: u16 = 3;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum EthtoolHeader {
+    DevIndex(u32),
+    DevName(String),
+    Flags(u32),
+    Other(DefaultNla),
+}
+
+impl nla::Nla for EthtoolHeader {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::DevIndex(_) | Self::Flags(_) => 4,
+            Self::DevName(s) => {
+                if s.len() + 1 > ALTIFNAMSIZ {
+                    ALTIFNAMSIZ
+                } else {
+                    s.len() + 1
+                }
+            }
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::DevIndex(_) => ETHTOOL_A_HEADER_DEV_INDEX,
+            Self::DevName(_) => ETHTOOL_A_HEADER_DEV_NAME,
+            Self::Flags(_) => ETHTOOL_A_HEADER_FLAGS,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::DevIndex(value) | Self::Flags(value) => {
+                NativeEndian::write_u32(buffer, *value)
+            }
+            Self::DevName(s) => {
+                str_to_zero_ended_u8_array(&s, buffer, ALTIFNAMSIZ)
+            }
+            Self::Other(ref attr) => attr.emit_value(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
+    for EthtoolHeader
+{
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            ETHTOOL_A_HEADER_DEV_INDEX => Self::DevIndex(
+                parse_u32(payload)
+                    .context("invalid ETHTOOL_A_HEADER_DEV_INDEX value")?,
+            ),
+            ETHTOOL_A_HEADER_FLAGS => Self::Flags(
+                parse_u32(payload)
+                    .context("invalid ETHTOOL_A_HEADER_FLAGS value")?,
+            ),
+            ETHTOOL_A_HEADER_DEV_NAME => Self::DevName(
+                parse_string(payload)
+                    .context("invalid ETHTOOL_A_HEADER_DEV_NAME value")?,
+            ),
+            _ => Self::Other(
+                DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?,
+            ),
+        })
+    }
+}
+
+fn str_to_zero_ended_u8_array(
+    src_str: &str,
+    buffer: &mut [u8],
+    max_size: usize,
+) {
+    if let Ok(src_cstring) = CString::new(src_str.as_bytes()) {
+        let src_null_ended_str = src_cstring.into_bytes_with_nul();
+        if src_null_ended_str.len() > max_size {
+            buffer[..max_size].clone_from_slice(&src_null_ended_str[..max_size])
+        } else {
+            buffer[..src_null_ended_str.len()]
+                .clone_from_slice(&src_null_ended_str)
+        }
+    }
+}

--- a/src/netlink-ethtool/lib.rs
+++ b/src/netlink-ethtool/lib.rs
@@ -1,0 +1,14 @@
+mod connection;
+mod error;
+mod handle;
+mod header;
+mod macros;
+mod message;
+mod pause;
+
+pub use connection::new_connection;
+pub use error::EthtoolError;
+pub use handle::EthtoolHandle;
+pub use header::EthtoolHeader;
+pub use message::{EthoolAttr, EthtoolMessage};
+pub use pause::{PauseAttr, PauseGetRequest, PauseHandle};

--- a/src/netlink-ethtool/macros.rs
+++ b/src/netlink-ethtool/macros.rs
@@ -1,0 +1,20 @@
+#[macro_export]
+macro_rules! try_ethtool {
+    ($msg: expr) => {{
+        use netlink_packet_core::{NetlinkMessage, NetlinkPayload};
+        use $crate::EthtoolError;
+
+        let (header, payload) = $msg.into_parts();
+        match payload {
+            NetlinkPayload::InnerMessage(msg) => msg,
+            NetlinkPayload::Error(err) => {
+                return Err(EthtoolError::NetlinkError(err))
+            }
+            _ => {
+                return Err(EthtoolError::UnexpectedMessage(
+                    NetlinkMessage::new(header, payload),
+                ))
+            }
+        }
+    }};
+}

--- a/src/netlink-ethtool/message.rs
+++ b/src/netlink-ethtool/message.rs
@@ -1,0 +1,118 @@
+use anyhow::Context;
+use netlink_generic::{GenericNetlinkHeader, GenericNetlinkMessageBuffer};
+use netlink_packet_core::{
+    DecodeError, NetlinkDeserializable, NetlinkHeader, NetlinkPayload,
+    NetlinkSerializable,
+};
+use netlink_packet_utils::{nla::NlasIterator, Emitable, Parseable};
+
+use crate::{EthtoolHeader, PauseAttr};
+
+const ETHTOOL_MSG_PAUSE_GET: u8 = 21;
+const ETHTOOL_MSG_PAUSE_GET_REPLY: u8 = 22;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum EthoolAttr {
+    Pause(Vec<PauseAttr>),
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct EthtoolMessage {
+    pub message_type: u16,
+    pub header: GenericNetlinkHeader,
+    pub nlas: EthoolAttr,
+}
+
+impl EthtoolMessage {
+    pub fn new_pause_get(message_type: u16, iface_name: Option<&str>) -> Self {
+        let nlas = match iface_name {
+            Some(s) => EthoolAttr::Pause(vec![PauseAttr::Header(vec![
+                EthtoolHeader::DevName(s.to_string()),
+            ])]),
+            None => EthoolAttr::Pause(vec![PauseAttr::Header(vec![])]),
+        };
+        EthtoolMessage {
+            message_type,
+            header: GenericNetlinkHeader {
+                cmd: ETHTOOL_MSG_PAUSE_GET,
+                version: 1, // No idea the correct version.
+            },
+            nlas,
+        }
+    }
+    fn message_type(&self) -> u16 {
+        self.message_type
+    }
+}
+
+impl Emitable for EthtoolMessage {
+    fn buffer_len(&self) -> usize {
+        self.header.buffer_len()
+            + match &self.nlas {
+                EthoolAttr::Pause(nlas) => nlas.as_slice().buffer_len(),
+            }
+    }
+
+    fn emit(&self, buffer: &mut [u8]) {
+        self.header.emit(buffer);
+        match &self.nlas {
+            EthoolAttr::Pause(nlas) => nlas
+                .as_slice()
+                .emit(&mut buffer[self.header.buffer_len()..]),
+        };
+    }
+}
+
+impl NetlinkSerializable<EthtoolMessage> for EthtoolMessage {
+    fn message_type(&self) -> u16 {
+        self.message_type()
+    }
+
+    fn buffer_len(&self) -> usize {
+        <Self as Emitable>::buffer_len(self)
+    }
+
+    fn serialize(&self, buffer: &mut [u8]) {
+        self.emit(buffer)
+    }
+}
+
+impl NetlinkDeserializable<EthtoolMessage> for EthtoolMessage {
+    type Error = DecodeError;
+    fn deserialize(
+        nl_header: &NetlinkHeader,
+        payload: &[u8],
+    ) -> Result<Self, Self::Error> {
+        let buf = GenericNetlinkMessageBuffer::new(payload);
+        let header = GenericNetlinkHeader::parse(&buf)
+            .context("failed to parse generic netlink message header")?;
+
+        let nlas = match header.cmd {
+            ETHTOOL_MSG_PAUSE_GET_REPLY => {
+                let mut nlas = Vec::new();
+                let error_msg = "failed to parse ethtool message attributes";
+                for nla in NlasIterator::new(buf.payload()) {
+                    let nla = &nla.context(error_msg)?;
+                    let parsed = PauseAttr::parse(nla).context(error_msg)?;
+                    nlas.push(parsed);
+                }
+                EthoolAttr::Pause(nlas)
+            }
+            _ => {
+                return Err(format!("Unknown command {}", header.cmd).into());
+            }
+        };
+
+        Ok(EthtoolMessage {
+            message_type: nl_header.message_type,
+            header,
+            nlas,
+        })
+    }
+}
+
+impl From<EthtoolMessage> for NetlinkPayload<EthtoolMessage> {
+    fn from(message: EthtoolMessage) -> Self {
+        NetlinkPayload::InnerMessage(message)
+    }
+}

--- a/src/netlink-ethtool/pause/attr.rs
+++ b/src/netlink-ethtool/pause/attr.rs
@@ -1,0 +1,163 @@
+use anyhow::Context;
+use byteorder::{ByteOrder, NativeEndian};
+use netlink_packet_utils::{
+    nla::{self, DefaultNla, NlaBuffer, NlasIterator, NLA_F_NESTED},
+    parsers::{parse_u64, parse_u8},
+    DecodeError, Emitable, Parseable,
+};
+
+use crate::EthtoolHeader;
+
+const ETHTOOL_A_PAUSE_HEADER: u16 = 1;
+const ETHTOOL_A_PAUSE_AUTONEG: u16 = 2;
+const ETHTOOL_A_PAUSE_RX: u16 = 3;
+const ETHTOOL_A_PAUSE_TX: u16 = 4;
+const ETHTOOL_A_PAUSE_STATS: u16 = 5;
+
+const ETHTOOL_A_PAUSE_STAT_TX_FRAMES: u16 = 2;
+const ETHTOOL_A_PAUSE_STAT_RX_FRAMES: u16 = 3;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum PauseStatAttr {
+    Rx(u64),
+    Tx(u64),
+    Other(DefaultNla),
+}
+
+impl nla::Nla for PauseStatAttr {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::Rx(_) | Self::Tx(_) => 8,
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::Rx(_) => ETHTOOL_A_PAUSE_STAT_RX_FRAMES,
+            Self::Tx(_) => ETHTOOL_A_PAUSE_STAT_RX_FRAMES,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::Rx(value) | Self::Tx(value) => {
+                NativeEndian::write_u64(buffer, *value)
+            }
+            Self::Other(ref attr) => attr.emit_value(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
+    for PauseStatAttr
+{
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            ETHTOOL_A_PAUSE_STAT_TX_FRAMES => Self::Tx(
+                parse_u64(payload)
+                    .context("invalid ETHTOOL_A_PAUSE_STAT_TX_FRAMES value")?,
+            ),
+            ETHTOOL_A_PAUSE_STAT_RX_FRAMES => Self::Rx(
+                parse_u64(payload)
+                    .context("invalid ETHTOOL_A_PAUSE_STAT_RX_FRAMES value")?,
+            ),
+            _ => Self::Other(
+                DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?,
+            ),
+        })
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum PauseAttr {
+    Header(Vec<EthtoolHeader>),
+    AutoNeg(bool),
+    Rx(bool),
+    Tx(bool),
+    Stats(Vec<PauseStatAttr>),
+    Other(DefaultNla),
+}
+
+impl nla::Nla for PauseAttr {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::Header(hdrs) => hdrs.as_slice().buffer_len(),
+            Self::AutoNeg(_) | Self::Rx(_) | Self::Tx(_) => 1,
+            Self::Stats(ref nlas) => nlas.as_slice().buffer_len(),
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::Header(_) => ETHTOOL_A_PAUSE_HEADER | NLA_F_NESTED,
+            Self::AutoNeg(_) => ETHTOOL_A_PAUSE_AUTONEG,
+            Self::Rx(_) => ETHTOOL_A_PAUSE_RX,
+            Self::Tx(_) => ETHTOOL_A_PAUSE_TX,
+            Self::Stats(_) => ETHTOOL_A_PAUSE_STATS | NLA_F_NESTED,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::Header(ref nlas) => nlas.as_slice().emit(buffer),
+            Self::AutoNeg(value) | Self::Rx(value) | Self::Tx(value) => {
+                buffer[0] = *value as u8
+            }
+            Self::Stats(ref nlas) => nlas.as_slice().emit(buffer),
+            Self::Other(ref attr) => attr.emit(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for PauseAttr {
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            ETHTOOL_A_PAUSE_HEADER => {
+                let mut nlas = Vec::new();
+                let error_msg = "failed to parse pause header attributes";
+                for nla in NlasIterator::new(payload) {
+                    let nla = &nla.context(error_msg)?;
+                    let parsed =
+                        EthtoolHeader::parse(nla).context(error_msg)?;
+                    nlas.push(parsed);
+                }
+                Self::Header(nlas)
+            }
+            ETHTOOL_A_PAUSE_AUTONEG => Self::AutoNeg(
+                parse_u8(payload)
+                    .context("invalid ETHTOOL_A_PAUSE_AUTONEG value")?
+                    == 1,
+            ),
+            ETHTOOL_A_PAUSE_RX => Self::Rx(
+                parse_u8(payload)
+                    .context("invalid ETHTOOL_A_PAUSE_RX value")?
+                    == 1,
+            ),
+            ETHTOOL_A_PAUSE_TX => Self::Tx(
+                parse_u8(payload)
+                    .context("invalid ETHTOOL_A_PAUSE_TX value")?
+                    == 1,
+            ),
+            ETHTOOL_A_PAUSE_STATS => {
+                let mut nlas = Vec::new();
+                let error_msg = "failed to parse pause stats attributes";
+                for nla in NlasIterator::new(payload) {
+                    let nla = &nla.context(error_msg)?;
+                    let parsed =
+                        PauseStatAttr::parse(nla).context(error_msg)?;
+                    nlas.push(parsed);
+                }
+                Self::Stats(nlas)
+            }
+            _ => Self::Other(
+                DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?,
+            ),
+        })
+    }
+}

--- a/src/netlink-ethtool/pause/get.rs
+++ b/src/netlink-ethtool/pause/get.rs
@@ -1,0 +1,51 @@
+use futures::{self, future::Either, FutureExt, StreamExt, TryStream};
+use netlink_packet_core::{NetlinkMessage, NLM_F_DUMP, NLM_F_REQUEST};
+
+use crate::{try_ethtool, EthtoolError, EthtoolHandle, EthtoolMessage};
+
+pub struct PauseGetRequest {
+    handle: EthtoolHandle,
+    iface_name: Option<String>,
+}
+
+impl PauseGetRequest {
+    pub(crate) fn new(handle: EthtoolHandle, iface_name: Option<&str>) -> Self {
+        PauseGetRequest {
+            handle,
+            iface_name: iface_name.map(|i| i.to_string()),
+        }
+    }
+
+    pub fn execute(
+        self,
+    ) -> impl TryStream<Ok = EthtoolMessage, Error = EthtoolError> {
+        let PauseGetRequest {
+            mut handle,
+            iface_name,
+        } = self;
+
+        let nl_header_flags = match iface_name {
+            None => NLM_F_DUMP | NLM_F_REQUEST,
+            Some(_) => NLM_F_REQUEST,
+        };
+
+        let ethtool_msg = EthtoolMessage::new_pause_get(
+            handle.family_id,
+            iface_name.as_deref(),
+        );
+
+        let mut nl_msg = NetlinkMessage::from(ethtool_msg);
+
+        nl_msg.header.flags = nl_header_flags;
+
+        match handle.request(nl_msg) {
+            Ok(response) => {
+                Either::Left(response.map(move |msg| Ok(try_ethtool!(msg))))
+            }
+            Err(e) => Either::Right(
+                futures::future::err::<EthtoolMessage, EthtoolError>(e)
+                    .into_stream(),
+            ),
+        }
+    }
+}

--- a/src/netlink-ethtool/pause/handle.rs
+++ b/src/netlink-ethtool/pause/handle.rs
@@ -1,0 +1,14 @@
+use crate::{EthtoolHandle, PauseGetRequest};
+
+pub struct PauseHandle(EthtoolHandle);
+
+impl PauseHandle {
+    pub fn new(handle: EthtoolHandle) -> Self {
+        PauseHandle(handle)
+    }
+
+    /// Retrieve the pause setting of a interface (equivalent to `ethtool -a eth1`)
+    pub fn get(&mut self, iface_name: Option<&str>) -> PauseGetRequest {
+        PauseGetRequest::new(self.0.clone(), iface_name)
+    }
+}

--- a/src/netlink-ethtool/pause/mod.rs
+++ b/src/netlink-ethtool/pause/mod.rs
@@ -1,0 +1,7 @@
+mod attr;
+mod get;
+mod handle;
+
+pub use attr::PauseAttr;
+pub use get::PauseGetRequest;
+pub use handle::PauseHandle;

--- a/src/netlink-generic/Cargo.toml
+++ b/src/netlink-generic/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "netlink-generic"
+version = "0.1.0"
+authors = ["Gris Ge <cnfourt@gmail.com>"]
+license = "MIT"
+edition = "2018"
+description = "Linux Generic Netlink Communication Library"
+keywords = ["network"]
+categories = ["network-programming", "os"]
+
+[lib]
+name = "netlink_generic"
+path = "lib.rs"
+crate-type = ["lib"]
+
+[dependencies]
+netlink-sys = "0.6"
+netlink-packet-utils = "0.4"
+netlink-packet-core = "0.2.4"
+netlink-proto = "0.6"
+tokio = { version = "1.0.1", features = ["rt"], optional = true}
+futures = "0.3.11"
+anyhow = "1.0.31"
+thiserror = "1"
+byteorder = "1.3.2"
+
+[dev-dependencies]
+tokio = { version = "1.0.1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/src/netlink-generic/buffer.rs
+++ b/src/netlink-generic/buffer.rs
@@ -1,0 +1,14 @@
+use netlink_packet_utils::{
+    buffer, buffer_check_length, buffer_common, fields, getter, setter,
+    DecodeError,
+};
+
+pub(crate) const GENL_HEADER_LEN: usize = 4;
+pub const GENL_ID_CTRL: u16 = 0x10;
+
+buffer!(GenericNetlinkMessageBuffer(GENL_HEADER_LEN) {
+    cmd: (u8, 0),
+    version: (u8, 1),
+    reserve_1: (u8, 2),
+    payload: (slice, GENL_HEADER_LEN..),
+});

--- a/src/netlink-generic/connection.rs
+++ b/src/netlink-generic/connection.rs
@@ -1,0 +1,19 @@
+use std::io;
+
+use futures::channel::mpsc::UnboundedReceiver;
+use netlink_packet_core::NetlinkMessage;
+use netlink_proto::{self, Connection};
+use netlink_sys::{constants::NETLINK_GENERIC, SocketAddr};
+
+use crate::{GenericNetlinkHandle, GenericNetlinkMessage};
+
+#[allow(clippy::type_complexity)]
+pub fn new_connection() -> io::Result<(
+    Connection<GenericNetlinkMessage>,
+    GenericNetlinkHandle,
+    UnboundedReceiver<(NetlinkMessage<GenericNetlinkMessage>, SocketAddr)>,
+)> {
+    let (conn, handle, messages) =
+        netlink_proto::new_connection(NETLINK_GENERIC)?;
+    Ok((conn, GenericNetlinkHandle::new(handle), messages))
+}

--- a/src/netlink-generic/ctrl.rs
+++ b/src/netlink-generic/ctrl.rs
@@ -1,0 +1,313 @@
+use std::ffi::CString;
+
+use anyhow::Context;
+use byteorder::{ByteOrder, NativeEndian};
+use netlink_packet_utils::{
+    nla::{self, DefaultNla, NlaBuffer, NlasIterator},
+    parsers::{parse_string, parse_u16, parse_u32},
+    DecodeError, Emitable, Parseable,
+};
+
+const GENL_NAMSIZ: usize = 16;
+
+const CTRL_ATTR_UNSPEC: u16 = 0;
+const CTRL_ATTR_FAMILY_ID: u16 = 1;
+const CTRL_ATTR_FAMILY_NAME: u16 = 2;
+const CTRL_ATTR_VERSION: u16 = 3;
+const CTRL_ATTR_HDRSIZE: u16 = 4;
+const CTRL_ATTR_MAXATTR: u16 = 5;
+const CTRL_ATTR_OPS: u16 = 6;
+const CTRL_ATTR_MCAST_GROUPS: u16 = 7;
+// const CTRL_ATTR_POLICY: u16 = 8; TODO
+// const CTRL_ATTR_OP_POLICY: u16 = 9;
+// const CTRL_ATTR_OP: u16 = 10;
+
+const CTRL_ATTR_OP_UNSPEC: u16 = 0;
+const CTRL_ATTR_OP_ID: u16 = 1;
+const CTRL_ATTR_OP_FLAGS: u16 = 2;
+
+const CTRL_ATTR_MCAST_GRP_UNSPEC: u16 = 0;
+const CTRL_ATTR_MCAST_GRP_NAME: u16 = 1;
+const CTRL_ATTR_MCAST_GRP_ID: u16 = 2;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+// for kernel `struct genl_ops`
+pub enum GenericNetlinkOp {
+    Unspec(Vec<u8>),
+    Id(u32),
+    Flags(u32),
+    Other(DefaultNla),
+}
+
+impl nla::Nla for GenericNetlinkOp {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::Unspec(ref bytes) => bytes.len(),
+            Self::Id(_) | Self::Flags(_) => 4,
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::Unspec(_) => CTRL_ATTR_OP_UNSPEC,
+            Self::Id(_) => CTRL_ATTR_OP_ID,
+            Self::Flags(_) => CTRL_ATTR_OP_FLAGS,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::Unspec(ref bytes) => buffer.copy_from_slice(bytes.as_slice()),
+            Self::Id(value) | Self::Flags(value) => {
+                NativeEndian::write_u32(buffer, *value)
+            }
+            Self::Other(ref attr) => attr.emit_value(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
+    for GenericNetlinkOp
+{
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            CTRL_ATTR_OP_UNSPEC => Self::Unspec(payload.to_vec()),
+            CTRL_ATTR_OP_ID => Self::Id(
+                parse_u32(payload).context("invalid CTRL_ATTR_OP_ID value")?,
+            ),
+            CTRL_ATTR_OP_FLAGS => Self::Flags(
+                parse_u32(payload)
+                    .context("invalid CTRL_ATTR_OP_FLAGS value")?,
+            ),
+            _ => Self::Other(
+                DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?,
+            ),
+        })
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+// for kernel `struct genl_multicast_group`
+pub enum GenericNetlinkMulticastGroup {
+    Unspec(Vec<u8>),
+    Id(u32),
+    Name(String),
+    Other(DefaultNla),
+}
+
+impl nla::Nla for GenericNetlinkMulticastGroup {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::Unspec(ref bytes) => bytes.len(),
+            Self::Id(_) => 4,
+            Self::Name(_) => GENL_NAMSIZ,
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::Unspec(_) => CTRL_ATTR_MCAST_GRP_UNSPEC,
+            Self::Id(_) => CTRL_ATTR_MCAST_GRP_ID,
+            Self::Name(_) => CTRL_ATTR_MCAST_GRP_NAME,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::Unspec(ref bytes) => buffer.copy_from_slice(bytes.as_slice()),
+            Self::Id(value) => NativeEndian::write_u32(buffer, *value),
+            Self::Name(value) => {
+                str_to_zero_ended_u8_array(&value, buffer, GENL_NAMSIZ)
+            }
+            Self::Other(ref attr) => attr.emit_value(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
+    for GenericNetlinkMulticastGroup
+{
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            CTRL_ATTR_MCAST_GRP_UNSPEC => Self::Unspec(payload.to_vec()),
+            CTRL_ATTR_MCAST_GRP_NAME => Self::Name(
+                parse_string(payload)
+                    .context("invalid CTRL_ATTR_MCAST_GRP_NAME value")?,
+            ),
+            CTRL_ATTR_MCAST_GRP_ID => Self::Id(
+                parse_u32(payload)
+                    .context("invalid CTRL_ATTR_MCAST_GRP_ID value")?,
+            ),
+            _ => Self::Other(
+                DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?,
+            ),
+        })
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum CtrlAttr {
+    Unspec(Vec<u8>),
+    FamilyId(u16),
+    FamilyName(String),
+    Version(u32),
+    HeaderSize(u32),
+    MaxAttr(u32),
+    Ops(Vec<Vec<GenericNetlinkOp>>),
+    MulticastGroups(Vec<Vec<GenericNetlinkMulticastGroup>>),
+    Other(DefaultNla),
+}
+
+impl nla::Nla for CtrlAttr {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::Unspec(ref bytes) => bytes.len(),
+            Self::FamilyId(_) => 2,
+            Self::FamilyName(_) => GENL_NAMSIZ,
+            Self::Version(_) | Self::HeaderSize(_) | Self::MaxAttr(_) => 4,
+            Self::Ops(ref ops) => {
+                let mut len = 0;
+                for op in ops {
+                    len += op.as_slice().buffer_len()
+                }
+                len
+            }
+            Self::MulticastGroups(ref groups) => {
+                let mut len = 0;
+                for group in groups {
+                    len += group.as_slice().buffer_len()
+                }
+                len
+            }
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::Unspec(_) => CTRL_ATTR_UNSPEC,
+            Self::FamilyId(_) => CTRL_ATTR_FAMILY_ID,
+            Self::FamilyName(_) => CTRL_ATTR_FAMILY_NAME,
+            Self::Version(_) => CTRL_ATTR_VERSION,
+            Self::HeaderSize(_) => CTRL_ATTR_HDRSIZE,
+            Self::MaxAttr(_) => CTRL_ATTR_MAXATTR,
+            Self::Ops(_) => CTRL_ATTR_OPS,
+            Self::MulticastGroups(_) => CTRL_ATTR_MCAST_GROUPS,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::Unspec(ref bytes) => buffer.copy_from_slice(bytes.as_slice()),
+            Self::FamilyId(value) => NativeEndian::write_u16(buffer, *value),
+            Self::FamilyName(value) => {
+                str_to_zero_ended_u8_array(&value, buffer, GENL_NAMSIZ)
+            }
+            Self::Version(value)
+            | Self::HeaderSize(value)
+            | Self::MaxAttr(value) => NativeEndian::write_u32(buffer, *value),
+            Self::Ops(ref ops) => {
+                let mut len = 0;
+                for op in ops {
+                    op.as_slice().emit(&mut buffer[len..]);
+                    len += op.as_slice().buffer_len();
+                }
+            }
+            Self::MulticastGroups(ref groups) => {
+                let mut len = 0;
+                for group in groups {
+                    group.as_slice().emit(&mut buffer[len..]);
+                    len += group.as_slice().buffer_len();
+                }
+            }
+            Self::Other(attr) => attr.emit_value(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for CtrlAttr {
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            CTRL_ATTR_UNSPEC => Self::Unspec(payload.to_vec()),
+            CTRL_ATTR_FAMILY_ID => Self::FamilyId(
+                parse_u16(payload)
+                    .context("invalid CTRL_ATTR_FAMILY_ID value")?,
+            ),
+            CTRL_ATTR_FAMILY_NAME => Self::FamilyName(
+                parse_string(payload)
+                    .context("invalid CTRL_ATTR_FAMILY_NAME value")?,
+            ),
+            CTRL_ATTR_VERSION => Self::Version(
+                parse_u32(payload)
+                    .context("invalid CTRL_ATTR_VERSION value")?,
+            ),
+            CTRL_ATTR_HDRSIZE => Self::HeaderSize(
+                parse_u32(payload)
+                    .context("invalid CTRL_ATTR_HDRSIZE value")?,
+            ),
+            CTRL_ATTR_MAXATTR => Self::MaxAttr(
+                parse_u32(payload)
+                    .context("invalid CTRL_ATTR_MAXATTR value")?,
+            ),
+            CTRL_ATTR_OPS => {
+                let mut ops = Vec::new();
+                let error_msg = "failed to parse CTRL_ATTR_OPS";
+                for nlas in NlasIterator::new(payload) {
+                    let nlas = &nlas.context(error_msg)?;
+                    let mut op = Vec::new();
+                    for nla in NlasIterator::new(nlas.value()) {
+                        let nla = &nla.context(error_msg)?;
+                        let parsed =
+                            GenericNetlinkOp::parse(nla).context(error_msg)?;
+                        op.push(parsed);
+                    }
+                    ops.push(op);
+                }
+                Self::Ops(ops)
+            }
+            CTRL_ATTR_MCAST_GROUPS => {
+                let mut groups = Vec::new();
+                let error_msg = "failed to parse CTRL_ATTR_MCAST_GROUPS";
+                for nlas in NlasIterator::new(payload) {
+                    let nlas = &nlas.context(error_msg)?;
+                    let mut group = Vec::new();
+                    for nla in NlasIterator::new(nlas.value()) {
+                        let nla = &nla.context(error_msg)?;
+                        let parsed = GenericNetlinkMulticastGroup::parse(nla)
+                            .context(error_msg)?;
+                        group.push(parsed);
+                    }
+                    groups.push(group);
+                }
+                Self::MulticastGroups(groups)
+            }
+            _ => Self::Other(
+                DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?,
+            ),
+        })
+    }
+}
+
+fn str_to_zero_ended_u8_array(
+    src_str: &str,
+    buffer: &mut [u8],
+    max_size: usize,
+) {
+    if let Ok(src_cstring) = CString::new(src_str.as_bytes()) {
+        let src_null_ended_str = src_cstring.into_bytes_with_nul();
+        if src_null_ended_str.len() > max_size {
+            buffer[..max_size].clone_from_slice(&src_null_ended_str[..max_size])
+        } else {
+            buffer[..src_null_ended_str.len()]
+                .clone_from_slice(&src_null_ended_str)
+        }
+    }
+}

--- a/src/netlink-generic/error.rs
+++ b/src/netlink-generic/error.rs
@@ -1,0 +1,17 @@
+use thiserror::Error;
+
+use netlink_packet_core::{ErrorMessage, NetlinkMessage};
+
+use crate::GenericNetlinkMessage;
+
+#[derive(Clone, Eq, PartialEq, Debug, Error)]
+pub enum GenericNetlinkError {
+    #[error("Received an unexpected message {0:?}")]
+    UnexpectedMessage(NetlinkMessage<GenericNetlinkMessage>),
+
+    #[error("Received a netlink error message {0}")]
+    NetlinkError(ErrorMessage),
+
+    #[error("A netlink request failed")]
+    RequestFailed(String),
+}

--- a/src/netlink-generic/handle.rs
+++ b/src/netlink-generic/handle.rs
@@ -1,0 +1,106 @@
+use futures::{self, FutureExt, Stream, StreamExt};
+
+use netlink_packet_core::{NetlinkHeader, NetlinkMessage, NLM_F_REQUEST};
+use netlink_proto::{sys::SocketAddr, ConnectionHandle};
+
+use crate::{
+    try_genl, CtrlAttr, GenericNetlinkAttr, GenericNetlinkError,
+    GenericNetlinkHeader, GenericNetlinkMessage, GENL_ID_CTRL,
+};
+
+#[derive(Clone, Debug)]
+pub struct GenericNetlinkHandle(ConnectionHandle<GenericNetlinkMessage>);
+
+const CTRL_CMD_GETFAMILY: u8 = 3;
+// libnl is using hardcoded number 1 and kernel does not verify the version
+const CTRL_CMD_GETFAMILY_VERSION: u8 = 1;
+
+impl GenericNetlinkHandle {
+    pub(crate) fn new(conn: ConnectionHandle<GenericNetlinkMessage>) -> Self {
+        GenericNetlinkHandle(conn)
+    }
+
+    pub async fn resolve_family_name(
+        &mut self,
+        family_name: &str,
+    ) -> Result<u16, GenericNetlinkError> {
+        let nl_msg = NetlinkMessage {
+            header: NetlinkHeader {
+                message_type: GENL_ID_CTRL,
+                flags: NLM_F_REQUEST,
+                sequence_number: 0,
+                port_number: 0,
+                ..Default::default()
+            },
+            payload: GenericNetlinkMessage {
+                message_type: GENL_ID_CTRL,
+                header: GenericNetlinkHeader {
+                    cmd: CTRL_CMD_GETFAMILY,
+                    version: CTRL_CMD_GETFAMILY_VERSION,
+                },
+                nlas: GenericNetlinkAttr::Ctrl(vec![CtrlAttr::FamilyName(
+                    family_name.into(),
+                )]),
+            }
+            .into(),
+        };
+
+        let mut response = match self.0.request(nl_msg, SocketAddr::new(0, 0)) {
+            Ok(response) => futures::future::Either::Left(
+                response.map(move |msg| Ok(try_genl!(msg))),
+            ),
+            Err(e) => futures::future::Either::Right(
+                futures::future::err::<
+                    GenericNetlinkMessage,
+                    GenericNetlinkError,
+                >(GenericNetlinkError::RequestFailed(format!(
+                    "{}",
+                    e
+                )))
+                .into_stream(),
+            ),
+        };
+
+        match response.next().await {
+            Some(Ok(genl_msg)) => {
+                match &genl_msg.nlas {
+                    GenericNetlinkAttr::Ctrl(nlas) => {
+                        for nla in nlas {
+                            if let CtrlAttr::FamilyId(family_id) = nla {
+                                return Ok(*family_id);
+                            }
+                        }
+                    }
+                    _ => {
+                        return Err(GenericNetlinkError::RequestFailed(format!(
+                            "The NLA reply is not GenericNetlinkAttr::Ctrl: {:?}",
+                            &genl_msg
+                        )));
+                    }
+                };
+                Err(GenericNetlinkError::RequestFailed(format!(
+                    "The NLA reply is not GenericNetlinkAttr::Ctrl: {:?}",
+                    &genl_msg
+                )))
+            }
+            Some(Err(e)) => Err(e),
+            None => Err(GenericNetlinkError::RequestFailed(
+                "No reply got for CTRL_CMD_GETFAMILY".into(),
+            )),
+        }
+    }
+
+    pub fn request(
+        &mut self,
+        message: NetlinkMessage<GenericNetlinkMessage>,
+    ) -> Result<
+        impl Stream<Item = NetlinkMessage<GenericNetlinkMessage>>,
+        GenericNetlinkError,
+    > {
+        self.0.request(message, SocketAddr::new(0, 0)).map_err(|_| {
+            GenericNetlinkError::RequestFailed(
+                "Failed to send netlink request".into(),
+            )
+        })
+    }
+}

--- a/src/netlink-generic/header.rs
+++ b/src/netlink-generic/header.rs
@@ -1,0 +1,35 @@
+use netlink_packet_utils::{DecodeError, Emitable, Parseable};
+
+use crate::{buffer::GENL_HEADER_LEN, GenericNetlinkMessageBuffer};
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
+pub struct GenericNetlinkHeader {
+    pub cmd: u8,
+    pub version: u8,
+    // there is an u16 reserverd in kernel `struct genlmsghdr`
+}
+
+impl Emitable for GenericNetlinkHeader {
+    fn buffer_len(&self) -> usize {
+        GENL_HEADER_LEN
+    }
+
+    fn emit(&self, buffer: &mut [u8]) {
+        let mut packet = GenericNetlinkMessageBuffer::new(buffer);
+        packet.set_cmd(self.cmd);
+        packet.set_version(self.version);
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<GenericNetlinkMessageBuffer<&'a T>>
+    for GenericNetlinkHeader
+{
+    fn parse(
+        buf: &GenericNetlinkMessageBuffer<&'a T>,
+    ) -> Result<Self, DecodeError> {
+        Ok(GenericNetlinkHeader {
+            cmd: buf.cmd(),
+            version: buf.version(),
+        })
+    }
+}

--- a/src/netlink-generic/lib.rs
+++ b/src/netlink-generic/lib.rs
@@ -1,0 +1,16 @@
+mod buffer;
+mod connection;
+mod ctrl;
+mod error;
+mod handle;
+mod header;
+mod macros;
+mod message;
+
+pub use buffer::{GenericNetlinkMessageBuffer, GENL_ID_CTRL};
+pub use connection::new_connection;
+pub use ctrl::CtrlAttr;
+pub use error::GenericNetlinkError;
+pub use handle::GenericNetlinkHandle;
+pub use header::GenericNetlinkHeader;
+pub use message::{GenericNetlinkAttr, GenericNetlinkMessage};

--- a/src/netlink-generic/macros.rs
+++ b/src/netlink-generic/macros.rs
@@ -1,0 +1,20 @@
+#[macro_export]
+macro_rules! try_genl {
+    ($msg: expr) => {{
+        use netlink_packet_core::{NetlinkMessage, NetlinkPayload};
+        use $crate::GenericNetlinkError;
+
+        let (header, payload) = $msg.into_parts();
+        match payload {
+            NetlinkPayload::InnerMessage(msg) => msg,
+            NetlinkPayload::Error(err) => {
+                return Err(GenericNetlinkError::NetlinkError(err))
+            }
+            _ => {
+                return Err(GenericNetlinkError::UnexpectedMessage(
+                    NetlinkMessage::new(header, payload),
+                ))
+            }
+        }
+    }};
+}

--- a/src/netlink-generic/message.rs
+++ b/src/netlink-generic/message.rs
@@ -1,0 +1,118 @@
+use anyhow::Context;
+use netlink_packet_core::{
+    DecodeError, NetlinkDeserializable, NetlinkHeader, NetlinkPayload,
+    NetlinkSerializable,
+};
+use netlink_packet_utils::{
+    nla::{DefaultNla, NlasIterator},
+    Emitable, Parseable, ParseableParametrized,
+};
+
+use crate::{
+    buffer::GENL_ID_CTRL, CtrlAttr, GenericNetlinkHeader,
+    GenericNetlinkMessageBuffer,
+};
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum GenericNetlinkAttr {
+    Ctrl(Vec<CtrlAttr>),
+    Other(Vec<DefaultNla>),
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct GenericNetlinkMessage {
+    pub message_type: u16,
+    pub header: GenericNetlinkHeader,
+    pub nlas: GenericNetlinkAttr,
+}
+
+impl Emitable for GenericNetlinkMessage {
+    fn buffer_len(&self) -> usize {
+        self.header.buffer_len()
+            + match &self.nlas {
+                GenericNetlinkAttr::Ctrl(nlas) => nlas.as_slice().buffer_len(),
+                GenericNetlinkAttr::Other(nlas) => nlas.as_slice().buffer_len(),
+            }
+    }
+
+    fn emit(&self, buffer: &mut [u8]) {
+        self.header.emit(buffer);
+        match &self.nlas {
+            GenericNetlinkAttr::Ctrl(nlas) => nlas
+                .as_slice()
+                .emit(&mut buffer[self.header.buffer_len()..]),
+            GenericNetlinkAttr::Other(nlas) => nlas
+                .as_slice()
+                .emit(&mut buffer[self.header.buffer_len()..]),
+        }
+    }
+}
+
+impl NetlinkSerializable<GenericNetlinkMessage> for GenericNetlinkMessage {
+    fn message_type(&self) -> u16 {
+        self.message_type
+    }
+
+    fn buffer_len(&self) -> usize {
+        <Self as Emitable>::buffer_len(self)
+    }
+
+    fn serialize(&self, buffer: &mut [u8]) {
+        self.emit(buffer)
+    }
+}
+
+impl NetlinkDeserializable<GenericNetlinkMessage> for GenericNetlinkMessage {
+    type Error = DecodeError;
+    fn deserialize(
+        header: &NetlinkHeader,
+        payload: &[u8],
+    ) -> Result<Self, Self::Error> {
+        let buf = GenericNetlinkMessageBuffer::new(payload);
+        GenericNetlinkMessage::parse_with_param(&buf, header.message_type)
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized>
+    ParseableParametrized<GenericNetlinkMessageBuffer<&'a T>, u16>
+    for GenericNetlinkMessage
+{
+    fn parse_with_param(
+        buf: &GenericNetlinkMessageBuffer<&'a T>,
+        message_type: u16,
+    ) -> Result<Self, DecodeError> {
+        let header = GenericNetlinkHeader::parse(buf)
+            .context("failed to parse generic netlink message header")?;
+
+        match message_type {
+            GENL_ID_CTRL => {
+                match GenericNetlinkMessageBuffer::new_checked(&buf.inner()) {
+                    Ok(buf) => Ok(GenericNetlinkMessage {
+                        message_type,
+                        header,
+                        nlas: {
+                            let mut nlas = Vec::new();
+                            let error_msg =
+                                "failed to parse control message attributes";
+                            for nla in NlasIterator::new(buf.payload()) {
+                                let nla = &nla.context(error_msg)?;
+                                let parsed =
+                                    CtrlAttr::parse(nla).context(error_msg)?;
+                                nlas.push(parsed);
+                            }
+                            GenericNetlinkAttr::Ctrl(nlas)
+                        },
+                    }),
+                    Err(e) => Err(e),
+                }
+            }
+            _ => Err(format!("Unknown message type: {}", message_type).into()),
+        }
+    }
+}
+
+impl From<GenericNetlinkMessage> for NetlinkPayload<GenericNetlinkMessage> {
+    fn from(message: GenericNetlinkMessage) -> Self {
+        NetlinkPayload::InnerMessage(message)
+    }
+}

--- a/src/netlink-generic/tests/genl_ctrl_resolve_ethtool.rs
+++ b/src/netlink-generic/tests/genl_ctrl_resolve_ethtool.rs
@@ -1,0 +1,21 @@
+use netlink_generic::new_connection;
+use tokio;
+
+#[test]
+#[ignore] // Github Action does not have ethtool-netlink enabled
+fn test_genl_ctrl_resolve_ethtool() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()
+        .unwrap();
+    rt.block_on(genl_ctrl_resolve_ethtool());
+}
+
+async fn genl_ctrl_resolve_ethtool() {
+    let (connection, mut handle, _) = new_connection().unwrap();
+    tokio::spawn(connection);
+
+    let family_id = handle.resolve_family_name("ethtool").await.unwrap();
+    println!("Family ID of ethtool is {}", family_id);
+    assert!(family_id > 0);
+}

--- a/src/python/nispor/base_iface.py
+++ b/src/python/nispor/base_iface.py
@@ -15,6 +15,7 @@
 from .ip import NisporIPv4
 from .ip import NisporIPv6
 from .sr_iov import NisporSriov
+from .ethtool import NisporEthtool
 
 
 class NisporBaseIface:
@@ -22,8 +23,11 @@ class NisporBaseIface:
         self._info = info
         self._sub_state = None
         self._sr_iov = None
+        self._ethtool = None
         if "sriov" in self._info:
             self._sr_iov = NisporSriov(self._info["sriov"])
+        if "ethtool" in self._info:
+            self._ethtool = NisporEthtool(self._info["ethtool"])
 
     def __str__(self):
         return f"{self._info}"
@@ -85,6 +89,10 @@ class NisporBaseIface:
     @property
     def sr_iov(self):
         return self._sr_iov
+
+    @property
+    def ethtool(self):
+        return self._ethtool
 
 
 class NisporBaseSubordinateIface:

--- a/src/python/nispor/ethtool.py
+++ b/src/python/nispor/ethtool.py
@@ -1,0 +1,41 @@
+# Copyright 2020-2021 Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class NisporEthtool:
+    def __init__(self, info):
+        if "pause" in info:
+            self._pause = NisporEthtoolPause(info["pause"])
+        else:
+            self._pause = None
+
+    @property
+    def pause(self):
+        return self._pause
+
+class NisporEthtoolPause:
+    def __init__(self, info):
+        self._info = info
+
+    @property
+    def rx(self):
+        return self._info["rx"]
+
+    @property
+    def tx(self):
+        return self._info["tx"]
+
+    @property
+    def auto_negotiate(self):
+        return self._info["auto_negotiate"]

--- a/tools/test_env
+++ b/tools/test_env
@@ -7,12 +7,13 @@ TEST_MAC2="00:23:45:67:89:1b"
 TEST_MAC3="00:23:45:67:89:1c"
 TEST_MAC4="00:23:45:67:89:1d"
 TEST_MAC5="00:23:45:67:89:1f"
+TEST_MAC_SIM0="00:23:45:67:89:20"
 
 sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0 1>/dev/null
 
 if [ "CHK$1" == "CHK" ];then
     echo 'Need argument: bond, br, brv, vlan, dummy, vxlan, veth, vrf, sriov,'
-    echo 'rm, route, rule'
+    echo 'rm, route, rule, ethtool'
     exit 1
 fi
 
@@ -44,6 +45,14 @@ function create_nics {
     sudo ip link set eth2 address $TEST_MAC2
     sudo ip link set eth1.ep up
     sudo ip link set eth2.ep up
+}
+
+function create_netdevsim_nic {
+    sudo modprobe netdevsim
+    echo '1 1' | sudo tee /sys/bus/netdevsim/new_device
+    sleep 1
+    sudo ip link set eni1np1 name sim0
+    sudo ip link set sim0 address $TEST_MAC_SIM0
 }
 
 
@@ -117,14 +126,11 @@ elif [ "CHK$1" == "CHKvrf" ];then
     sudo ip link set eth1 up
     sleep $LINK_WAIT_TIME
 elif [ "CHK$1" == "CHKsriov" ];then
-    sudo modprobe netdevsim
-    echo '1 1' | sudo tee /sys/bus/netdevsim/new_device
-    sleep 5
-    sudo ip link set eni1np1 name eth1
-    echo 2 | sudo tee /sys/class/net/eth1/device/sriov_numvfs
-    sudo ip link set eth1 vf 0 vlan 100 mac 36:f7:09:ef:95:f0
-    sudo ip link set eth1 vf 1 mac 36:f7:09:ef:95:f1
-    sudo ip link set eth1 up
+    create_netdevsim_nic
+    echo 2 | sudo tee /sys/class/net/sim0/device/sriov_numvfs
+    sudo ip link set sim0 vf 0 vlan 100 mac 36:f7:09:ef:95:f0
+    sudo ip link set sim0 vf 1 mac 36:f7:09:ef:95:f1
+    sudo ip link set sim0 up
 elif [ "CHK$1" == "CHKtun" ];then
     sudo ip tuntap add name tun1 mode tun \
         user 1001 group 0 multi_queue vnet_hdr
@@ -171,6 +177,10 @@ elif [ "CHK$1" == "CHKrule" ];then
         tos 10 table 100 iif eth1 oif eth2 priority 999
     sudo ip -6 rule add from 2001:db8:f::254 to 2001:db8:f::253 \
         tos 10 table 100 iif eth1 oif eth2 priority 999
+elif [ "CHK$1" == "CHKethtool" ];then
+    create_netdevsim_nic
+    sudo ethtool -A sim0 tx on
+    sudo ethtool -A sim0 rx on
 elif [ "CHK$1" == "CHKrm" ];then
     clean_up 2>/dev/null
 fi


### PR DESCRIPTION
Example on `npc sim0` output against netdevsim nic:

```yaml
  ethtool:
    pause:
      rx: true
      tx: true
      auto_negotiate: false
```

Python binding also updated.

 Test case included but disabled for CI as CI system has no netdevsim kernel module