### PR TITLE
MAC VLAP/VTAP: Fix the order of derives

### DIFF
--- a/src/lib/ifaces/mac_vlan.rs
+++ b/src/lib/ifaces/mac_vlan.rs
@@ -16,8 +16,8 @@ const MACVLAN_MODE_BRIDGE: u32 = 4;
 const MACVLAN_MODE_PASSTHRU: u32 = 8;
 const MACVLAN_MODE_SOURCE: u32 = 16;
 
-#[serde(rename_all = "lowercase")]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "lowercase")]
 pub enum MacVlanMode {
     /* don't talk to other macvlans */
     Private,

--- a/src/lib/ifaces/mac_vtap.rs
+++ b/src/lib/ifaces/mac_vtap.rs
@@ -5,8 +5,8 @@ use crate::NisporError;
 use netlink_packet_route::rtnl::link::nlas;
 use serde_derive::{Deserialize, Serialize};
 
-#[serde(rename_all = "lowercase")]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "lowercase")]
 pub enum MacVtapMode {
     /* don't talk to other macvlans */
     Private,


### PR DESCRIPTION
The `serde(rename_all)` should be used after `derive(Serialize,
Deserialize)` as suggested by rust 1.53.0-nightly