### PR TITLE
ethtool: Fix pause info dumping

### DIFF
--- a/src/lib/ifaces/ethtool.rs
+++ b/src/lib/ifaces/ethtool.rs
@@ -44,7 +44,9 @@ pub(crate) async fn get_ethtool_infos(
         netlink_ethtool::new_connection(family_id).unwrap();
     tokio::spawn(connection);
 
-    for ethtool_msg in handle.pause().get(None).execute().try_next().await? {
+    let mut ethtool_msg_handle = handle.pause().get(None).execute();
+
+    while let Some(ethtool_msg) = ethtool_msg_handle.try_next().await? {
         let EthoolAttr::Pause(nlas) = ethtool_msg.nlas;
         let mut iface_name = None;
         let mut pause_info = EthtoolPauseInfo::default();

--- a/src/lib/tests/ethtool.rs
+++ b/src/lib/tests/ethtool.rs
@@ -19,9 +19,10 @@ use std::panic;
 
 mod utils;
 
-const IFACE_NAME: &str = "sim0";
+const IFACE_NAME0: &str = "sim0";
+const IFACE_NAME1: &str = "sim1";
 
-const EXPECTED_IFACE_STATE: &str = r#"---
+const EXPECTED_IFACE_STATE0: &str = r#"---
 - name: sim0
   iface_type: ethernet
   state: down
@@ -38,17 +39,41 @@ const EXPECTED_IFACE_STATE: &str = r#"---
   sriov:
     vfs: []"#;
 
+const EXPECTED_IFACE_STATE1: &str = r#"---
+- name: sim1
+  iface_type: ethernet
+  state: down
+  mtu: 1500
+  flags:
+    - broadcast
+    - no_arp
+  mac_address: "00:23:45:67:89:21"
+  ethtool:
+    pause:
+      rx: true
+      tx: true
+      auto_negotiate: false
+  sriov:
+    vfs: []"#;
+
 #[test]
 #[ignore] // CI does not have netdevsim kernel module yet
 fn test_get_ethtool_pause_yaml() {
     with_ethtool_iface(|| {
         let state = NetState::retrieve().unwrap();
-        let iface = &state.ifaces[IFACE_NAME];
+        let iface = &state.ifaces[IFACE_NAME0];
         let iface_type = &iface.iface_type;
         assert_eq!(iface_type, &nispor::IfaceType::Ethernet);
         assert_eq!(
             serde_yaml::to_string(&vec![iface]).unwrap().trim(),
-            EXPECTED_IFACE_STATE
+            EXPECTED_IFACE_STATE0
+        );
+        let iface = &state.ifaces[IFACE_NAME1];
+        let iface_type = &iface.iface_type;
+        assert_eq!(iface_type, &nispor::IfaceType::Ethernet);
+        assert_eq!(
+            serde_yaml::to_string(&vec![iface]).unwrap().trim(),
+            EXPECTED_IFACE_STATE1
         );
     });
 }

--- a/src/netlink-ethtool/Cargo.toml
+++ b/src/netlink-ethtool/Cargo.toml
@@ -26,3 +26,4 @@ byteorder = "1.3.2"
 
 [dev-dependencies]
 tokio = { version = "1.0.1", features = ["macros", "rt", "rt-multi-thread"] }
+env_logger = "0.8.3"

--- a/tools/test_env
+++ b/tools/test_env
@@ -8,6 +8,7 @@ TEST_MAC3="00:23:45:67:89:1c"
 TEST_MAC4="00:23:45:67:89:1d"
 TEST_MAC5="00:23:45:67:89:1f"
 TEST_MAC_SIM0="00:23:45:67:89:20"
+TEST_MAC_SIM1="00:23:45:67:89:21"
 
 sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0 1>/dev/null
 
@@ -49,10 +50,12 @@ function create_nics {
 
 function create_netdevsim_nic {
     sudo modprobe netdevsim
-    echo '1 1' | sudo tee /sys/bus/netdevsim/new_device
-    sleep 1
+    echo '1 2' | sudo tee /sys/bus/netdevsim/new_device
+    sleep 5
     sudo ip link set eni1np1 name sim0
+    sudo ip link set eni1np2 name sim1
     sudo ip link set sim0 address $TEST_MAC_SIM0
+    sudo ip link set sim1 address $TEST_MAC_SIM1
 }
 
 
@@ -181,6 +184,8 @@ elif [ "CHK$1" == "CHKethtool" ];then
     create_netdevsim_nic
     sudo ethtool -A sim0 tx on
     sudo ethtool -A sim0 rx on
+    sudo ethtool -A sim1 tx on
+    sudo ethtool -A sim1 rx on
 elif [ "CHK$1" == "CHKrm" ];then
     clean_up 2>/dev/null
 fi


### PR DESCRIPTION
Due to bug https://bugzilla.redhat.com/show_bug.cgi?id=1953847 , the
kernel will not set `NLM_F_MULTI` flags to instruct rust-netlink to
parse multiple netlink message in single socket reply.

To workaround this problem, use `NLM_F_ACK` flag where kernel
acknowledgment on data finish is required, so rust-netlink will keep
parsing till got the ACK netlink message.

And previous `for msg in handle.execute().try_next()` is wrong, should
use `while` against saved handle execution instead.

Test case updated to test against two netdevsim interfaces.