### PR TITLE
dns: Add DNS resolver query support

### DIFF
--- a/src/cli/npc.rs
+++ b/src/cli/npc.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use clap::{clap_app, crate_authors, crate_version};
-use nispor::{Iface, NetConf, NetState, NisporError, Route, RouteRule};
+use nispor::{
+    DnsResolver, Iface, NetConf, NetState, NisporError, Route, RouteRule,
+};
 use serde_derive::Serialize;
 use serde_json;
 use serde_yaml;
@@ -38,6 +40,7 @@ enum CliResult {
     Ifaces(Vec<Iface>),
     Routes(Vec<Route>),
     RouteRules(Vec<RouteRule>),
+    DnsResolver(DnsResolver),
     CliError(CliError),
     NisporError(NisporError),
 }
@@ -68,6 +71,10 @@ macro_rules! npc_print {
             }
             CliResult::RouteRules(rules) => {
                 writeln!(stdout(), "{}", $display_func(&rules).unwrap()).ok();
+                process::exit(0);
+            }
+            CliResult::DnsResolver(dns) => {
+                writeln!(stdout(), "{}", $display_func(&dns).unwrap()).ok();
                 process::exit(0);
             }
             CliResult::NisporError(e) => {
@@ -142,6 +149,10 @@ fn main() {
             (@arg json: -j --json "Show in json format")
             (about: "Show routes rules")
         )
+        (@subcommand dns =>
+            (@arg json: -j --json "Show in json format")
+            (about: "Show routes rules")
+        )
         (@subcommand set =>
             (@arg file_path: [FILE_PATH] +required "config file to apply")
             (about: "Apply network config")
@@ -176,6 +187,9 @@ fn main() {
                 } else if let Some(m) = matches.subcommand_matches("rule") {
                     output_format = parse_arg_output_format(m);
                     CliResult::RouteRules(state.rules)
+                } else if let Some(m) = matches.subcommand_matches("dns") {
+                    output_format = parse_arg_output_format(m);
+                    CliResult::DnsResolver(state.dns_resolver)
                 } else {
                     /* Show everything if no cmdline arg has been supplied */
                     CliResult::Full(state)

--- a/src/lib/dns.rs
+++ b/src/lib/dns.rs
@@ -1,0 +1,140 @@
+// Copyright 2021 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ffi::CStr;
+use std::net::IpAddr;
+
+use libc;
+use serde_derive::{Deserialize, Serialize};
+
+use crate::error::NisporError;
+
+const MAXNS: usize = 3;
+const MAXDNSRCH: usize = 6;
+const MAXRESOLVSORT: usize = 10;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct ResStateSortList {
+    pub addr: libc::in_addr,
+    pub mask: u32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+union ResStateU {
+    pad: [libc::c_char; 52],
+    _ext: ResStateExt,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+struct ResStateExt {
+    nscount: u16,
+    nsmap: [u16; MAXNS],
+    nssocks: [libc::c_int; MAXNS],
+    nscount6: u16,
+    nsaddrs: [*mut libc::sockaddr_in6; MAXNS],
+    __glibc_reserved: [libc::c_uint; 2],
+}
+
+#[repr(C)]
+#[derive(Clone)]
+struct ResState {
+    retrans: libc::c_int,
+    retry: libc::c_int,
+    options: libc::c_ulong,
+    nscount: libc::c_int,
+    nsaddr_list: [libc::sockaddr_in; MAXNS],
+    id: libc::c_ushort,
+    dnsrch: [*mut libc::c_char; MAXDNSRCH + 1],
+    defdname: [libc::c_char; 256], // deprecated
+    pfcode: libc::c_ulong,
+    ndots_nsort_ipv6_unavail_unused: u32,
+    sort_list: [ResStateSortList; MAXRESOLVSORT],
+    __glibc_unused_qhook: *mut libc::c_void,
+    __glibc_unused_rhook: *mut libc::c_void,
+    res_h_errno: libc::c_int,
+    _vcsock: libc::c_int,
+    _flags: libc::c_uint,
+    _u: ResStateU,
+}
+
+#[link(name = "c")]
+extern "C" {
+    fn __res_ninit(state: *mut ResState) -> libc::c_int;
+    fn __res_nclose(state: *mut ResState);
+}
+
+impl Drop for ResState {
+    fn drop(&mut self) {
+        unsafe { __res_nclose(self) }
+    }
+}
+
+impl ResState {
+    fn new() -> Self {
+        let mut state: ResState = unsafe { std::mem::zeroed() };
+        unsafe {
+            __res_ninit(&mut state);
+        }
+        state
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct DnsResolver {
+    name_servers: Vec<IpAddr>,
+    searches: Vec<String>,
+}
+
+pub fn get_dns_resolver() -> Result<DnsResolver, NisporError> {
+    let state = ResState::new();
+    let mut name_servers = Vec::new();
+    for index in 0..(state.nscount as usize) {
+        if state.nsaddr_list[index].sin_family == libc::AF_INET as u16 {
+            name_servers.push(IpAddr::V4(std::net::Ipv4Addr::from(
+                u32::from_be(state.nsaddr_list[index].sin_addr.s_addr),
+            )));
+        } else {
+            let sock_addr6 = unsafe { *state._u._ext.nsaddrs[index] };
+            if sock_addr6.sin6_family == libc::AF_INET6 as u16 {
+                name_servers.push(IpAddr::V6(std::net::Ipv6Addr::from(
+                    sock_addr6.sin6_addr.s6_addr,
+                )));
+            }
+        }
+    }
+    let mut searches = Vec::new();
+    for index in 0..MAXDNSRCH + 1 {
+        if !state.dnsrch[index].is_null() {
+            let search_cstr = unsafe { CStr::from_ptr(state.dnsrch[index]) };
+            match search_cstr.to_str() {
+                Ok(s) => searches.push(s.into()),
+                Err(e) => {
+                    eprintln!(
+                        "WARN: Got error when concerting DNS search \
+                        to String: {}",
+                        e
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(DnsResolver {
+        name_servers,
+        searches,
+    })
+}

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod dns;
 mod error;
 mod ifaces;
 mod ip;
@@ -22,6 +23,7 @@ mod netlink;
 mod route;
 mod route_rule;
 
+pub use crate::dns::DnsResolver;
 pub use crate::error::NisporError;
 pub use crate::ifaces::BondAdInfo;
 pub use crate::ifaces::BondAdSelect;

--- a/src/lib/net_state.rs
+++ b/src/lib/net_state.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::dns::{get_dns_resolver, DnsResolver};
 use crate::error::NisporError;
 use crate::ifaces::get_ifaces;
 use crate::ifaces::Iface;
@@ -28,6 +29,7 @@ pub struct NetState {
     pub ifaces: HashMap<String, Iface>,
     pub routes: Vec<Route>,
     pub rules: Vec<RouteRule>,
+    pub dns_resolver: DnsResolver,
 }
 
 impl NetState {
@@ -36,10 +38,12 @@ impl NetState {
         let ifaces = rt.block_on(get_ifaces())?;
         let routes = rt.block_on(get_routes(&ifaces))?;
         let rules = rt.block_on(get_route_rules())?;
+        let dns_resolver = get_dns_resolver()?;
         Ok(NetState {
             ifaces,
             routes,
             rules,
+            dns_resolver,
         })
     }
 

--- a/src/python/nispor/dns.py
+++ b/src/python/nispor/dns.py
@@ -1,0 +1,29 @@
+# Copyright 2020 Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class NisporDnsState:
+    def __init__(self, info):
+        self._info = info
+
+    def __str__(self):
+        return f"{self._info}"
+
+    @property
+    def name_servers(self):
+        return self._info["name_servers"]
+
+    @property
+    def searches(self):
+        return self._info["searches"]

--- a/src/python/nispor/state.py
+++ b/src/python/nispor/state.py
@@ -15,6 +15,7 @@
 import json
 
 from .clib_wrapper import retrieve_net_state_json
+from .dns import NisporDnsState
 from .iface import NisporIfaceState
 from .route import NisporRouteState
 from .route_rule import NisporRouteRuleState
@@ -29,6 +30,7 @@ class NisporNetState:
         self._ifaces = NisporIfaceState(info.get("ifaces"))
         self._routes = NisporRouteState(info.get("routes"))
         self._route_rules = NisporRouteRuleState(info.get("rules"))
+        self._dns = NisporDnsState(info.get("dns_resolver"))
 
     @property
     def ifaces(self):
@@ -41,6 +43,10 @@ class NisporNetState:
     @property
     def route_rules(self):
         return self._route_rules
+
+    @property
+    def dns_resolver(self):
+        return self._dns
 
     @staticmethod
     def retrieve():


### PR DESCRIPTION
Support querying DNS resolver name server and search through the libc
`res_ninit()` and `res_nclose()`.

Rust API `NetState.dns_resolver`:
```rust
    struct DnsResolver {
        name_servers: Vec<IpAddr>,
        searches: Vec<String>,
    }
```

Python binding included as:
 * `nispor.NisporNetState.retrieve().dns_resolver.name_servers`
 * `nispor.NisporNetState.retrieve().dns_resolver.searches`

The CLI tool `npc` now support `dns` subcommand, example:

```
$ npc dns
---
name_servers:
  - 127.0.0.1
  - "::1"
searches:
  - nispor.info
```