### PR TITLE
Cargo.toml: Use `derive` feature instead of `serde_derive`

### DIFF
--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -16,8 +16,7 @@ path = "lib.rs"
 crate-type = ["lib"]
 
 [dependencies]
-serde = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rtnetlink = "0.7"
 netlink-packet-route = "0.7"

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -16,7 +16,7 @@ use netlink_ethtool::EthtoolError;
 use netlink_generic::GenericNetlinkError;
 use netlink_packet_utils::DecodeError;
 use rtnetlink;
-use serde_derive::Serialize;
+use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "snake_case")]

--- a/src/lib/ifaces/bond.rs
+++ b/src/lib/ifaces/bond.rs
@@ -19,7 +19,7 @@ use crate::ControllerType;
 use crate::IfaceType;
 use crate::NisporError;
 use netlink_packet_route::rtnl::link::nlas;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 const BOND_MODE_ROUNDROBIN: u8 = 0;

--- a/src/lib/ifaces/bridge.rs
+++ b/src/lib/ifaces/bridge.rs
@@ -19,7 +19,7 @@ use crate::ControllerType;
 use crate::Iface;
 use crate::NisporError;
 use netlink_packet_route::rtnl::link::nlas;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]

--- a/src/lib/ifaces/ethtool.rs
+++ b/src/lib/ifaces/ethtool.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 use futures::stream::TryStreamExt;
 use netlink_ethtool::{self, EthoolAttr, EthtoolHeader, PauseAttr};
 use netlink_generic;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use crate::NisporError;
 

--- a/src/lib/ifaces/iface.rs
+++ b/src/lib/ifaces/iface.rs
@@ -56,7 +56,7 @@ use netlink_packet_route::rtnl::{
 use rtnetlink::new_connection;
 
 use rtnetlink::packet::rtnl::link::nlas::Nla;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]

--- a/src/lib/ifaces/mac_vlan.rs
+++ b/src/lib/ifaces/mac_vlan.rs
@@ -19,7 +19,7 @@ use crate::NisporError;
 use netlink_packet_route::rtnl::link::nlas;
 use netlink_packet_route::rtnl::link::nlas::InfoMacVlan;
 use netlink_packet_route::rtnl::link::nlas::InfoMacVtap;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 const ETH_ALEN: usize = 6;

--- a/src/lib/ifaces/mac_vtap.rs
+++ b/src/lib/ifaces/mac_vtap.rs
@@ -17,7 +17,7 @@ use crate::ifaces::mac_vlan::MacVlanInfo;
 use crate::ifaces::mac_vlan::MacVlanMode;
 use crate::NisporError;
 use netlink_packet_route::rtnl::link::nlas;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "lowercase")]

--- a/src/lib/ifaces/sriov.rs
+++ b/src/lib/ifaces/sriov.rs
@@ -17,7 +17,7 @@ use crate::netlink::parse_as_u64;
 use crate::parse_as_mac;
 use crate::NisporError;
 use netlink_packet_route::rtnl::nlas::NlasIterator;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 const IFLA_VF_MAC: u16 = 1;
 const IFLA_VF_VLAN: u16 = 2;

--- a/src/lib/ifaces/tun.rs
+++ b/src/lib/ifaces/tun.rs
@@ -17,7 +17,7 @@ use crate::netlink::parse_as_u8;
 use crate::NisporError;
 use netlink_packet_route::rtnl::link::nlas::InfoData;
 use netlink_packet_route::rtnl::nlas::NlasIterator;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 const IFF_TUN: u8 = 1;
 const IFF_TAP: u8 = 2;

--- a/src/lib/ifaces/veth.rs
+++ b/src/lib/ifaces/veth.rs
@@ -14,7 +14,7 @@
 
 use crate::Iface;
 use crate::IfaceType;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]

--- a/src/lib/ifaces/vlan.rs
+++ b/src/lib/ifaces/vlan.rs
@@ -16,7 +16,7 @@ use crate::Iface;
 use crate::IfaceType;
 use netlink_packet_route::rtnl::link::nlas::InfoData;
 use netlink_packet_route::rtnl::link::nlas::InfoVlan;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 const ETH_P_8021Q: u16 = 0x8100;

--- a/src/lib/ifaces/vrf.rs
+++ b/src/lib/ifaces/vrf.rs
@@ -19,7 +19,7 @@ use crate::NisporError;
 use netlink_packet_route::rtnl::link::nlas::InfoData;
 use netlink_packet_route::rtnl::link::nlas::InfoVrf;
 use netlink_packet_route::rtnl::nlas::NlaBuffer;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 const IFLA_VRF_PORT_TABLE: u16 = 1;

--- a/src/lib/ifaces/vxlan.rs
+++ b/src/lib/ifaces/vxlan.rs
@@ -19,7 +19,7 @@ use crate::IfaceType;
 use crate::NisporError;
 use netlink_packet_route::rtnl::link::nlas::InfoData;
 use netlink_packet_route::rtnl::link::nlas::InfoVxlan;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]

--- a/src/lib/ip.rs
+++ b/src/lib/ip.rs
@@ -20,7 +20,7 @@ use crate::NisporError;
 use futures::stream::TryStreamExt;
 use netlink_packet_route;
 use netlink_packet_route::rtnl::AddressMessage;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::net::IpAddr;

--- a/src/lib/net_conf.rs
+++ b/src/lib/net_conf.rs
@@ -15,7 +15,7 @@
 use crate::error::NisporError;
 use crate::ifaces::get_ifaces;
 use crate::ifaces::IfaceConf;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use tokio::runtime;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]

--- a/src/lib/net_state.rs
+++ b/src/lib/net_state.rs
@@ -19,7 +19,7 @@ use crate::route::get_routes;
 use crate::route::Route;
 use crate::route_rule::get_route_rules;
 use crate::route_rule::RouteRule;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tokio::runtime;
 

--- a/src/lib/route.rs
+++ b/src/lib/route.rs
@@ -38,7 +38,7 @@ use netlink_packet_route::RouteMessage;
 use netlink_packet_utils::traits::Parseable;
 use rtnetlink::new_connection;
 use rtnetlink::IpVersion;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 const USER_HZ: u32 = 100;

--- a/src/lib/route_rule.rs
+++ b/src/lib/route_rule.rs
@@ -23,7 +23,7 @@ use netlink_packet_route::rtnl::rule::nlas::Nla;
 use netlink_packet_route::RuleMessage;
 use rtnetlink::new_connection;
 use rtnetlink::IpVersion;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 const FR_ACT_TO_TBL: u8 = 1;
 const FR_ACT_GOTO: u8 = 2;


### PR DESCRIPTION
As suggested by https://serde.rs/derive.html , we should use

```
    serde = { version = "1.0", features = ["derive"] }
```