### PR TITLE
ethtool: Add ethtool features/offload support

### DIFF
--- a/src/lib/ifaces/ethtool.rs
+++ b/src/lib/ifaces/ethtool.rs
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use futures::stream::TryStreamExt;
-use netlink_ethtool::{self, EthoolAttr, EthtoolHeader, PauseAttr};
+use netlink_ethtool::{
+    self, EthoolAttr, EthtoolHandle, EthtoolHeader, FeatureAttr, FeatureBit,
+    PauseAttr,
+};
 use netlink_generic;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 
 use crate::NisporError;
 
@@ -28,54 +31,169 @@ pub struct EthtoolPauseInfo {
     auto_negotiate: bool,
 }
 
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct EthtoolFeatureInfo {
+    #[serde(serialize_with = "ordered_map")]
+    pub fixed: HashMap<String, bool>,
+    #[serde(serialize_with = "ordered_map")]
+    pub changeable: HashMap<String, bool>,
+}
+
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default)]
 pub struct EthtoolInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pause: Option<EthtoolPauseInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub features: Option<EthtoolFeatureInfo>,
+}
+
+fn ordered_map<S>(
+    value: &HashMap<String, bool>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let ordered: BTreeMap<_, _> = value.iter().collect();
+    ordered.serialize(serializer)
 }
 
 pub(crate) async fn get_ethtool_infos(
 ) -> Result<HashMap<String, EthtoolInfo>, NisporError> {
     let mut infos: HashMap<String, EthtoolInfo> = HashMap::new();
 
-    let family_id = get_family_id().await?;
+    let family_id = get_ethtool_family_id().await?;
 
     let (connection, mut handle, _) =
         netlink_ethtool::new_connection(family_id).unwrap();
+
     tokio::spawn(connection);
 
-    let mut ethtool_msg_handle = handle.pause().get(None).execute();
+    let mut pause_infos = dump_pause_infos(&mut handle).await?;
+    let mut feature_infos = dump_feature_infos(&mut handle).await?;
 
-    while let Some(ethtool_msg) = ethtool_msg_handle.try_next().await? {
-        let EthoolAttr::Pause(nlas) = ethtool_msg.nlas;
-        let mut iface_name = None;
-        let mut pause_info = EthtoolPauseInfo::default();
+    for (iface_name, pause_info) in pause_infos.drain() {
+        infos.insert(
+            iface_name,
+            EthtoolInfo {
+                pause: Some(pause_info),
+                ..Default::default()
+            },
+        );
+    }
 
-        for nla in &nlas {
-            if let PauseAttr::Header(hdrs) = nla {
-                iface_name = get_iface_name_from_header(&hdrs);
-            } else if let PauseAttr::AutoNeg(v) = nla {
-                pause_info.auto_negotiate = *v
-            } else if let PauseAttr::Rx(v) = nla {
-                pause_info.rx = *v
-            } else if let PauseAttr::Tx(v) = nla {
-                pause_info.tx = *v
+    for (iface_name, feature_info) in feature_infos.drain() {
+        match infos.get_mut(&iface_name) {
+            Some(ref mut info) => {
+                info.features = Some(feature_info);
+            }
+            None => {
+                infos.insert(
+                    iface_name,
+                    EthtoolInfo {
+                        features: Some(feature_info),
+                        ..Default::default()
+                    },
+                );
+            }
+        };
+    }
+
+    Ok(infos)
+}
+
+async fn dump_pause_infos(
+    handle: &mut EthtoolHandle,
+) -> Result<HashMap<String, EthtoolPauseInfo>, NisporError> {
+    let mut infos = HashMap::new();
+    let mut pause_handle = handle.pause().get(None).execute();
+    while let Some(ethtool_msg) = pause_handle.try_next().await? {
+        if let EthoolAttr::Pause(nlas) = ethtool_msg.nlas {
+            let mut iface_name = None;
+            let mut pause_info = EthtoolPauseInfo::default();
+
+            for nla in nlas {
+                if let PauseAttr::Header(hdrs) = nla {
+                    iface_name = get_iface_name_from_header(&hdrs);
+                } else if let PauseAttr::AutoNeg(v) = nla {
+                    pause_info.auto_negotiate = v
+                } else if let PauseAttr::Rx(v) = nla {
+                    pause_info.rx = v
+                } else if let PauseAttr::Tx(v) = nla {
+                    pause_info.tx = v
+                }
+            }
+            if let Some(i) = iface_name {
+                infos.insert(i, pause_info);
             }
         }
-        if let Some(i) = iface_name {
-            infos.insert(
-                i.to_string(),
-                EthtoolInfo {
-                    pause: Some(pause_info),
-                },
-            );
+    }
+    Ok(infos)
+}
+
+async fn dump_feature_infos(
+    handle: &mut EthtoolHandle,
+) -> Result<HashMap<String, EthtoolFeatureInfo>, NisporError> {
+    let mut infos = HashMap::new();
+    let mut feature_handle = handle.feature().get(None).execute();
+    while let Some(ethtool_msg) = feature_handle.try_next().await? {
+        if let EthoolAttr::Feature(nlas) = ethtool_msg.nlas {
+            let mut iface_name = None;
+            let mut fixed_features = HashMap::new();
+            let mut changeable_features = HashMap::new();
+
+            for nla in nlas {
+                if let FeatureAttr::Header(hdrs) = nla {
+                    iface_name = get_iface_name_from_header(&hdrs);
+                } else if let FeatureAttr::Hw(feature_bits) = nla {
+                    for feature_bit in feature_bits {
+                        match feature_bit {
+                            FeatureBit {
+                                index: _,
+                                name,
+                                value: true,
+                            } => {
+                                changeable_features.insert(name, false);
+                            }
+                            FeatureBit {
+                                index: _,
+                                name,
+                                value: false,
+                            } => {
+                                fixed_features.insert(name, false);
+                            }
+                        }
+                    }
+                } else if let FeatureAttr::Active(feature_bits) = nla {
+                    for feature_bit in feature_bits {
+                        if fixed_features.contains_key(&feature_bit.name) {
+                            fixed_features.insert(feature_bit.name, true);
+                        } else if changeable_features
+                            .contains_key(&feature_bit.name)
+                        {
+                            changeable_features.insert(feature_bit.name, true);
+                        }
+                    }
+                }
+            }
+
+            if let Some(i) = iface_name {
+                infos.insert(
+                    i.to_string(),
+                    EthtoolFeatureInfo {
+                        fixed: fixed_features,
+                        changeable: changeable_features,
+                    },
+                );
+            }
         }
     }
 
     Ok(infos)
 }
 
-async fn get_family_id() -> Result<u16, NisporError> {
+async fn get_ethtool_family_id() -> Result<u16, NisporError> {
     let (connection, mut handle, _) =
         netlink_generic::new_connection().unwrap();
     tokio::spawn(connection);
@@ -83,10 +201,10 @@ async fn get_family_id() -> Result<u16, NisporError> {
     Ok(handle.resolve_family_name("ethtool").await?)
 }
 
-fn get_iface_name_from_header(hdrs: &[EthtoolHeader]) -> Option<&str> {
+fn get_iface_name_from_header(hdrs: &[EthtoolHeader]) -> Option<String> {
     for hdr in hdrs {
         if let EthtoolHeader::DevName(iface_name) = hdr {
-            return Some(iface_name.as_str());
+            return Some(iface_name.to_string());
         }
     }
     None

--- a/src/lib/tests/ethtool.rs
+++ b/src/lib/tests/ethtool.rs
@@ -22,7 +22,7 @@ mod utils;
 const IFACE_NAME0: &str = "sim0";
 const IFACE_NAME1: &str = "sim1";
 
-const EXPECTED_IFACE_STATE0: &str = r#"---
+const EXPECTED_IFACE_STATE: &str = r#"---
 - name: sim0
   iface_type: ethernet
   state: down
@@ -36,29 +36,71 @@ const EXPECTED_IFACE_STATE0: &str = r#"---
       rx: true
       tx: true
       auto_negotiate: false
-  sriov:
-    vfs: []"#;
-
-const EXPECTED_IFACE_STATE1: &str = r#"---
-- name: sim1
-  iface_type: ethernet
-  state: down
-  mtu: 1500
-  flags:
-    - broadcast
-    - no_arp
-  mac_address: "00:23:45:67:89:21"
-  ethtool:
-    pause:
-      rx: true
-      tx: true
-      auto_negotiate: false
+    features:
+      fixed:
+        esp-hw-offload: true
+        esp-tx-csum-hw-offload: true
+        fcoe-mtu: false
+        highdma: true
+        l2-fwd-offload: false
+        loopback: false
+        macsec-hw-offload: false
+        netns-local: false
+        rx-all: false
+        rx-checksum: false
+        rx-fcs: false
+        rx-gro-hw: false
+        rx-hashing: false
+        rx-lro: false
+        rx-ntuple-filter: false
+        rx-vlan-filter: false
+        rx-vlan-hw-parse: false
+        rx-vlan-stag-filter: false
+        rx-vlan-stag-hw-parse: false
+        tls-hw-record: false
+        tls-hw-rx-offload: false
+        tls-hw-tx-offload: false
+        tx-checksum-fcoe-crc: false
+        tx-checksum-ip-generic: true
+        tx-checksum-ipv4: false
+        tx-checksum-ipv6: false
+        tx-checksum-sctp: false
+        tx-esp-segmentation: true
+        tx-fcoe-segmentation: false
+        tx-gre-csum-segmentation: false
+        tx-gre-segmentation: false
+        tx-gso-list: false
+        tx-gso-partial: false
+        tx-gso-robust: false
+        tx-ipxip4-segmentation: false
+        tx-ipxip6-segmentation: false
+        tx-lockless: false
+        tx-scatter-gather-fraglist: true
+        tx-sctp-segmentation: false
+        tx-tcp-ecn-segmentation: false
+        tx-tcp-mangleid-segmentation: false
+        tx-tcp-segmentation: true
+        tx-tcp6-segmentation: false
+        tx-tunnel-remcsum-segmentation: false
+        tx-udp-segmentation: false
+        tx-udp_tnl-csum-segmentation: false
+        tx-udp_tnl-segmentation: false
+        tx-vlan-hw-insert: false
+        tx-vlan-stag-hw-insert: false
+        vlan-challenged: false
+      changeable:
+        hw-tc-offload: false
+        rx-gro: true
+        rx-gro-list: false
+        rx-udp_tunnel-port-offload: true
+        tx-generic-segmentation: true
+        tx-nocache-copy: false
   sriov:
     vfs: []"#;
 
 #[test]
 #[ignore] // CI does not have netdevsim kernel module yet
-fn test_get_ethtool_pause_yaml() {
+fn test_get_ethtool_yaml() {
     with_ethtool_iface(|| {
         let state = NetState::retrieve().unwrap();
         let iface = &state.ifaces[IFACE_NAME0];
@@ -66,14 +108,19 @@ fn test_get_ethtool_pause_yaml() {
         assert_eq!(iface_type, &nispor::IfaceType::Ethernet);
         assert_eq!(
             serde_yaml::to_string(&vec![iface]).unwrap().trim(),
-            EXPECTED_IFACE_STATE0
+            EXPECTED_IFACE_STATE
         );
+
+        let state1 = EXPECTED_IFACE_STATE
+            .replace(IFACE_NAME0, IFACE_NAME1)
+            .replace("00:23:45:67:89:20", "00:23:45:67:89:21");
+
         let iface = &state.ifaces[IFACE_NAME1];
         let iface_type = &iface.iface_type;
         assert_eq!(iface_type, &nispor::IfaceType::Ethernet);
         assert_eq!(
             serde_yaml::to_string(&vec![iface]).unwrap().trim(),
-            EXPECTED_IFACE_STATE1
+            &state1
         );
     });
 }

--- a/src/netlink-ethtool/Cargo.toml
+++ b/src/netlink-ethtool/Cargo.toml
@@ -23,6 +23,7 @@ futures = "0.3.11"
 anyhow = "1.0.31"
 thiserror = "1"
 byteorder = "1.3.2"
+log = "0.4.14"
 
 [dev-dependencies]
 tokio = { version = "1.0.1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/src/netlink-ethtool/examples/dump_features.rs
+++ b/src/netlink-ethtool/examples/dump_features.rs
@@ -1,0 +1,42 @@
+use futures::stream::TryStreamExt;
+use netlink_ethtool;
+use netlink_generic;
+use tokio;
+
+// Once we find a way to load netsimdev kernel module in CI, we can convert this
+// to a test
+fn main() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()
+        .unwrap();
+    let family_id = rt.block_on(genl_ctrl_resolve_ethtool());
+    rt.block_on(get_feature(family_id, None));
+}
+
+async fn genl_ctrl_resolve_ethtool() -> u16 {
+    let (connection, mut handle, _) =
+        netlink_generic::new_connection().unwrap();
+    tokio::spawn(connection);
+
+    let family_id = handle.resolve_family_name("ethtool").await.unwrap();
+    println!("Family ID of ethtool is {}", family_id);
+    family_id
+}
+
+async fn get_feature(family_id: u16, iface_name: Option<&str>) {
+    let (connection, mut handle, _) =
+        netlink_ethtool::new_connection(family_id).unwrap();
+    tokio::spawn(connection);
+
+    let mut feature_handle = handle.feature().get(iface_name).execute();
+
+    let mut msgs = Vec::new();
+    while let Some(msg) = feature_handle.try_next().await.unwrap() {
+        msgs.push(msg);
+    }
+    assert!(msgs.len() > 0);
+    for msg in msgs {
+        println!("{:?}", msg);
+    }
+}

--- a/src/netlink-ethtool/feature/attr.rs
+++ b/src/netlink-ethtool/feature/attr.rs
@@ -1,0 +1,219 @@
+use anyhow::Context;
+use log::warn;
+use netlink_packet_utils::{
+    nla::{self, DefaultNla, NlaBuffer, NlasIterator, NLA_F_NESTED},
+    parsers::{parse_string, parse_u32},
+    DecodeError, Emitable, Parseable,
+};
+
+use crate::EthtoolHeader;
+
+const ETHTOOL_A_FEATURES_HEADER: u16 = 1;
+const ETHTOOL_A_FEATURES_HW: u16 = 2; // User changable features
+const ETHTOOL_A_FEATURES_WANTED: u16 = 3; // User requested fatures
+const ETHTOOL_A_FEATURES_ACTIVE: u16 = 4; // Active features
+const ETHTOOL_A_FEATURES_NOCHANGE: u16 = 5;
+
+const ETHTOOL_A_BITSET_BITS: u16 = 3;
+
+const ETHTOOL_A_BITSET_BITS_BIT: u16 = 1;
+
+const ETHTOOL_A_BITSET_BIT_INDEX: u16 = 1;
+const ETHTOOL_A_BITSET_BIT_NAME: u16 = 2;
+const ETHTOOL_A_BITSET_BIT_VALUE: u16 = 3;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct FeatureBit {
+    pub index: u32,
+    pub name: String,
+    pub value: bool,
+}
+
+impl FeatureBit {
+    fn new(has_mask: bool) -> Self {
+        Self {
+            index: 0,
+            name: "".into(),
+            value: if has_mask { false } else { true },
+        }
+    }
+}
+
+fn feature_bits_len(_feature_bits: &[FeatureBit]) -> usize {
+    todo!("Does not support changing ethtool feature yet")
+}
+
+fn feature_bits_emit(_feature_bits: &[FeatureBit], _buffer: &mut [u8]) {
+    todo!("Does not support changing ethtool feature yet")
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum FeatureAttr {
+    Header(Vec<EthtoolHeader>),
+    Hw(Vec<FeatureBit>),
+    Wanted(Vec<FeatureBit>),
+    Active(Vec<FeatureBit>),
+    NoChange(Vec<FeatureBit>),
+    Other(DefaultNla),
+}
+
+impl nla::Nla for FeatureAttr {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::Header(hdrs) => hdrs.as_slice().buffer_len(),
+            Self::Hw(feature_bits)
+            | Self::Wanted(feature_bits)
+            | Self::Active(feature_bits)
+            | Self::NoChange(feature_bits) => {
+                feature_bits_len(feature_bits.as_slice())
+            }
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::Header(_) => ETHTOOL_A_FEATURES_HEADER | NLA_F_NESTED,
+            Self::Hw(_) => ETHTOOL_A_FEATURES_HW | NLA_F_NESTED,
+            Self::Wanted(_) => ETHTOOL_A_FEATURES_WANTED | NLA_F_NESTED,
+            Self::Active(_) => ETHTOOL_A_FEATURES_ACTIVE | NLA_F_NESTED,
+            Self::NoChange(_) => ETHTOOL_A_FEATURES_NOCHANGE | NLA_F_NESTED,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::Header(ref nlas) => nlas.as_slice().emit(buffer),
+            Self::Hw(feature_bits)
+            | Self::Wanted(feature_bits)
+            | Self::Active(feature_bits)
+            | Self::NoChange(feature_bits) => {
+                feature_bits_emit(feature_bits.as_slice(), buffer)
+            }
+            Self::Other(ref attr) => attr.emit(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for FeatureAttr {
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            ETHTOOL_A_FEATURES_HEADER => {
+                let mut nlas = Vec::new();
+                let error_msg = "failed to parse feature header attributes";
+                for nla in NlasIterator::new(payload) {
+                    let nla = &nla.context(error_msg)?;
+                    let parsed =
+                        EthtoolHeader::parse(nla).context(error_msg)?;
+                    nlas.push(parsed);
+                }
+                Self::Header(nlas)
+            }
+            ETHTOOL_A_FEATURES_HW => {
+                Self::Hw(parse_bitset_bits_nlas(
+                    payload,
+                    true, /* ETHTOOL_A_FEATURES_HW is using mask */
+                )?)
+            }
+            ETHTOOL_A_FEATURES_WANTED => {
+                Self::Wanted(parse_bitset_bits_nlas(
+                    payload,
+                    false, /* ETHTOOL_A_FEATURES_WANTED does not use mask */
+                )?)
+            }
+            ETHTOOL_A_FEATURES_ACTIVE => {
+                Self::Active(parse_bitset_bits_nlas(
+                    payload,
+                    false, /* ETHTOOL_A_FEATURES_ACTIVE does not use mask */
+                )?)
+            }
+            ETHTOOL_A_FEATURES_NOCHANGE => {
+                Self::NoChange(parse_bitset_bits_nlas(
+                    payload,
+                    false, /* ETHTOOL_A_FEATURES_NOCHANGE does not use mask */
+                )?)
+            }
+            _ => Self::Other(
+                DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?,
+            ),
+        })
+    }
+}
+
+fn parse_bitset_bits_nlas(
+    raw: &[u8],
+    has_mask: bool,
+) -> Result<Vec<FeatureBit>, DecodeError> {
+    let error_msg = "failed to parse feature bit sets";
+    for nla in NlasIterator::new(raw) {
+        let nla = &nla.context(error_msg)?;
+        if nla.kind() == ETHTOOL_A_BITSET_BITS {
+            return parse_bitset_bits_nla(nla.value(), has_mask);
+        }
+    }
+    Err("No ETHTOOL_A_BITSET_BITS NLA found".into())
+}
+
+fn parse_bitset_bits_nla(
+    raw: &[u8],
+    has_mask: bool,
+) -> Result<Vec<FeatureBit>, DecodeError> {
+    let mut feature_bits = Vec::new();
+    let error_msg = "Failed to parse ETHTOOL_A_BITSET_BITS attributes";
+    for bit_nla in NlasIterator::new(raw) {
+        let bit_nla = &bit_nla.context(error_msg)?;
+        match bit_nla.kind() {
+            ETHTOOL_A_BITSET_BITS_BIT => {
+                let error_msg =
+                    "Failed to parse ETHTOOL_A_BITSET_BITS_BIT attributes";
+                let nlas = NlasIterator::new(bit_nla.value());
+                let mut cur_bit_info = FeatureBit::new(has_mask);
+                for nla in nlas {
+                    let nla = &nla.context(error_msg)?;
+                    let payload = nla.value();
+                    match nla.kind() {
+                        ETHTOOL_A_BITSET_BIT_INDEX => {
+                            if cur_bit_info.index != 0
+                                && &cur_bit_info.name != ""
+                            {
+                                feature_bits.push(cur_bit_info);
+                                cur_bit_info = FeatureBit::new(has_mask);
+                            }
+                            cur_bit_info.index = parse_u32(payload).context(
+                                "Invald ETHTOOL_A_BITSET_BIT_INDEX value",
+                            )?;
+                        }
+                        ETHTOOL_A_BITSET_BIT_NAME => {
+                            cur_bit_info.name = parse_string(payload).context(
+                                "Invald ETHTOOL_A_BITSET_BIT_NAME value",
+                            )?;
+                        }
+                        ETHTOOL_A_BITSET_BIT_VALUE => {
+                            cur_bit_info.value = true;
+                        }
+                        _ => {
+                            warn!(
+                                "Unknown ETHTOOL_A_BITSET_BITS_BIT {} {:?}",
+                                nla.kind(),
+                                nla.value(),
+                            );
+                        }
+                    }
+                }
+                if cur_bit_info.index != 0 && &cur_bit_info.name != "" {
+                    feature_bits.push(cur_bit_info);
+                }
+            }
+            _ => {
+                warn!(
+                    "Unknown ETHTOOL_A_BITSET_BITS kind {}, {:?}",
+                    bit_nla.kind(),
+                    bit_nla.value()
+                );
+            }
+        };
+    }
+    Ok(feature_bits)
+}

--- a/src/netlink-ethtool/feature/get.rs
+++ b/src/netlink-ethtool/feature/get.rs
@@ -1,0 +1,53 @@
+use futures::{self, future::Either, FutureExt, StreamExt, TryStream};
+use netlink_packet_core::{
+    NetlinkMessage, NLM_F_ACK, NLM_F_DUMP, NLM_F_REQUEST,
+};
+
+use crate::{try_ethtool, EthtoolError, EthtoolHandle, EthtoolMessage};
+
+pub struct FeatureGetRequest {
+    handle: EthtoolHandle,
+    iface_name: Option<String>,
+}
+
+impl FeatureGetRequest {
+    pub(crate) fn new(handle: EthtoolHandle, iface_name: Option<&str>) -> Self {
+        FeatureGetRequest {
+            handle,
+            iface_name: iface_name.map(|i| i.to_string()),
+        }
+    }
+
+    pub fn execute(
+        self,
+    ) -> impl TryStream<Ok = EthtoolMessage, Error = EthtoolError> {
+        let FeatureGetRequest {
+            mut handle,
+            iface_name,
+        } = self;
+
+        let nl_header_flags = match iface_name {
+            None => NLM_F_DUMP | NLM_F_REQUEST | NLM_F_ACK,
+            Some(_) => NLM_F_REQUEST,
+        };
+
+        let ethtool_msg = EthtoolMessage::new_feature_get(
+            handle.family_id,
+            iface_name.as_deref(),
+        );
+
+        let mut nl_msg = NetlinkMessage::from(ethtool_msg);
+
+        nl_msg.header.flags = nl_header_flags;
+
+        match handle.request(nl_msg) {
+            Ok(response) => {
+                Either::Left(response.map(move |msg| Ok(try_ethtool!(msg))))
+            }
+            Err(e) => Either::Right(
+                futures::future::err::<EthtoolMessage, EthtoolError>(e)
+                    .into_stream(),
+            ),
+        }
+    }
+}

--- a/src/netlink-ethtool/feature/handle.rs
+++ b/src/netlink-ethtool/feature/handle.rs
@@ -1,0 +1,14 @@
+use crate::{EthtoolHandle, FeatureGetRequest};
+
+pub struct FeatureHandle(EthtoolHandle);
+
+impl FeatureHandle {
+    pub fn new(handle: EthtoolHandle) -> Self {
+        FeatureHandle(handle)
+    }
+
+    /// Retrieve the ethtool features of a interface (equivalent to `ethtool -k eth1`)
+    pub fn get(&mut self, iface_name: Option<&str>) -> FeatureGetRequest {
+        FeatureGetRequest::new(self.0.clone(), iface_name)
+    }
+}

--- a/src/netlink-ethtool/feature/mod.rs
+++ b/src/netlink-ethtool/feature/mod.rs
@@ -1,0 +1,7 @@
+mod attr;
+mod get;
+mod handle;
+
+pub use attr::{FeatureAttr, FeatureBit};
+pub use get::FeatureGetRequest;
+pub use handle::FeatureHandle;

--- a/src/netlink-ethtool/handle.rs
+++ b/src/netlink-ethtool/handle.rs
@@ -16,7 +16,7 @@ use futures::Stream;
 use netlink_packet_core::NetlinkMessage;
 use netlink_proto::{sys::SocketAddr, ConnectionHandle};
 
-use crate::{EthtoolError, EthtoolMessage, PauseHandle};
+use crate::{EthtoolError, EthtoolMessage, FeatureHandle, PauseHandle};
 
 #[derive(Clone, Debug)]
 pub struct EthtoolHandle {
@@ -34,6 +34,10 @@ impl EthtoolHandle {
 
     pub fn pause(&mut self) -> PauseHandle {
         PauseHandle::new(self.clone())
+    }
+
+    pub fn feature(&mut self) -> FeatureHandle {
+        FeatureHandle::new(self.clone())
     }
 
     pub fn request(

--- a/src/netlink-ethtool/lib.rs
+++ b/src/netlink-ethtool/lib.rs
@@ -14,6 +14,7 @@
 
 mod connection;
 mod error;
+mod feature;
 mod handle;
 mod header;
 mod macros;
@@ -22,6 +23,7 @@ mod pause;
 
 pub use connection::new_connection;
 pub use error::EthtoolError;
+pub use feature::{FeatureAttr, FeatureBit, FeatureGetRequest, FeatureHandle};
 pub use handle::EthtoolHandle;
 pub use header::EthtoolHeader;
 pub use message::{EthoolAttr, EthtoolMessage};

--- a/src/python/nispor/ethtool.py
+++ b/src/python/nispor/ethtool.py
@@ -20,9 +20,18 @@ class NisporEthtool:
         else:
             self._pause = None
 
+        if "features" in info:
+            self._features = NisporEthtoolFeatures(info["features"])
+        else:
+            self._features = None
+
     @property
     def pause(self):
         return self._pause
+
+    @property
+    def features(self):
+        return self._features
 
 class NisporEthtoolPause:
     def __init__(self, info):
@@ -39,3 +48,15 @@ class NisporEthtoolPause:
     @property
     def auto_negotiate(self):
         return self._info["auto_negotiate"]
+
+class NisporEthtoolFeatures:
+    def __init__(self, info):
+        self._info = info
+
+    @property
+    def fixed(self):
+        return self._info["fixed"]
+
+    @property
+    def changeable(self):
+        return self._info["changeable"]


### PR DESCRIPTION
Example(paritally) on `npc lo` output:

```yaml
ethtool:
  features:
    fixed:
      esp-hw-offload: false
      esp-tx-csum-hw-offload: false
    changeable:
      rx-gro: true
      rx-gro-list: false
```

Python binding also updated.

Test case updated.