### PR TITLE
ethtool: Add ethtool coalesce support

### DIFF
--- a/src/lib/ifaces/ethtool.rs
+++ b/src/lib/ifaces/ethtool.rs
@@ -16,8 +16,8 @@ use std::collections::{BTreeMap, HashMap};
 
 use futures::stream::TryStreamExt;
 use netlink_ethtool::{
-    self, EthoolAttr, EthtoolHandle, EthtoolHeader, FeatureAttr, FeatureBit,
-    PauseAttr,
+    self, CoalesceAttr, EthoolAttr, EthtoolHandle, EthtoolHeader, FeatureAttr,
+    FeatureBit, PauseAttr,
 };
 use netlink_generic;
 use serde::{Deserialize, Serialize, Serializer};
@@ -41,11 +41,61 @@ pub struct EthtoolFeatureInfo {
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default)]
+pub struct EthtoolCoalesceInfo {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pkt_rate_high: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pkt_rate_low: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rate_sample_interval: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rx_max_frames: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rx_max_frames_high: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rx_max_frames_irq: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rx_max_frames_low: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rx_usecs: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rx_usecs_high: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rx_usecs_irq: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rx_usecs_low: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stats_block_usecs: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tx_max_frames: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tx_max_frames_high: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tx_max_frames_irq: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tx_max_frames_low: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tx_usecs: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tx_usecs_high: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tx_usecs_irq: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tx_usecs_low: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub use_adaptive_rx: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub use_adaptive_tx: Option<bool>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default)]
 pub struct EthtoolInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pause: Option<EthtoolPauseInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub features: Option<EthtoolFeatureInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub coalesce: Option<EthtoolCoalesceInfo>,
 }
 
 fn ordered_map<S>(
@@ -72,6 +122,7 @@ pub(crate) async fn get_ethtool_infos(
 
     let mut pause_infos = dump_pause_infos(&mut handle).await?;
     let mut feature_infos = dump_feature_infos(&mut handle).await?;
+    let mut coalesce_infos = dump_coalesce_infos(&mut handle).await?;
 
     for (iface_name, pause_info) in pause_infos.drain() {
         infos.insert(
@@ -93,6 +144,23 @@ pub(crate) async fn get_ethtool_infos(
                     iface_name,
                     EthtoolInfo {
                         features: Some(feature_info),
+                        ..Default::default()
+                    },
+                );
+            }
+        };
+    }
+
+    for (iface_name, coalesce_info) in coalesce_infos.drain() {
+        match infos.get_mut(&iface_name) {
+            Some(ref mut info) => {
+                info.coalesce = Some(coalesce_info);
+            }
+            None => {
+                infos.insert(
+                    iface_name,
+                    EthtoolInfo {
+                        coalesce: Some(coalesce_info),
                         ..Default::default()
                     },
                 );
@@ -190,6 +258,98 @@ async fn dump_feature_infos(
         }
     }
 
+    Ok(infos)
+}
+
+async fn dump_coalesce_infos(
+    handle: &mut EthtoolHandle,
+) -> Result<HashMap<String, EthtoolCoalesceInfo>, NisporError> {
+    let mut infos = HashMap::new();
+    let mut coalesce_handle = handle.coalesce().get(None).execute();
+    while let Some(ethtool_msg) = coalesce_handle.try_next().await? {
+        if let EthoolAttr::Coalesce(nlas) = ethtool_msg.nlas {
+            let mut iface_name = None;
+            let mut coalesce_info = EthtoolCoalesceInfo::default();
+
+            for nla in nlas {
+                match nla {
+                    CoalesceAttr::Header(hdrs) => {
+                        iface_name = get_iface_name_from_header(&hdrs)
+                    }
+                    CoalesceAttr::RxUsecs(d) => {
+                        coalesce_info.rx_usecs = Some(d)
+                    }
+                    CoalesceAttr::RxMaxFrames(d) => {
+                        coalesce_info.rx_max_frames = Some(d)
+                    }
+                    CoalesceAttr::RxUsecsIrq(d) => {
+                        coalesce_info.rx_usecs_irq = Some(d)
+                    }
+                    CoalesceAttr::RxMaxFramesIrq(d) => {
+                        coalesce_info.rx_max_frames_irq = Some(d)
+                    }
+                    CoalesceAttr::TxUsecs(d) => {
+                        coalesce_info.tx_usecs = Some(d)
+                    }
+                    CoalesceAttr::TxMaxFrames(d) => {
+                        coalesce_info.tx_max_frames = Some(d)
+                    }
+                    CoalesceAttr::TxUsecsIrq(d) => {
+                        coalesce_info.tx_usecs_irq = Some(d)
+                    }
+                    CoalesceAttr::TxMaxFramesIrq(d) => {
+                        coalesce_info.tx_max_frames_irq = Some(d)
+                    }
+                    CoalesceAttr::StatsBlockUsecs(d) => {
+                        coalesce_info.stats_block_usecs = Some(d)
+                    }
+                    CoalesceAttr::UseAdaptiveRx(d) => {
+                        coalesce_info.use_adaptive_rx = Some(d)
+                    }
+                    CoalesceAttr::UseAdaptiveTx(d) => {
+                        coalesce_info.use_adaptive_tx = Some(d)
+                    }
+                    CoalesceAttr::PktRateLow(d) => {
+                        coalesce_info.pkt_rate_low = Some(d)
+                    }
+                    CoalesceAttr::RxUsecsLow(d) => {
+                        coalesce_info.rx_usecs_low = Some(d)
+                    }
+                    CoalesceAttr::RxMaxFramesLow(d) => {
+                        coalesce_info.rx_max_frames_low = Some(d)
+                    }
+                    CoalesceAttr::TxUsecsLow(d) => {
+                        coalesce_info.tx_usecs_low = Some(d)
+                    }
+                    CoalesceAttr::TxMaxFramesLow(d) => {
+                        coalesce_info.tx_max_frames_low = Some(d)
+                    }
+                    CoalesceAttr::PktRateHigh(d) => {
+                        coalesce_info.pkt_rate_high = Some(d)
+                    }
+                    CoalesceAttr::RxUsecsHigh(d) => {
+                        coalesce_info.rx_usecs_high = Some(d)
+                    }
+                    CoalesceAttr::RxMaxFramesHigh(d) => {
+                        coalesce_info.rx_max_frames_high = Some(d)
+                    }
+                    CoalesceAttr::TxUsecsHigh(d) => {
+                        coalesce_info.tx_usecs_high = Some(d)
+                    }
+                    CoalesceAttr::TxMaxFramesHigh(d) => {
+                        coalesce_info.tx_max_frames_high = Some(d)
+                    }
+                    CoalesceAttr::RateSampleInterval(d) => {
+                        coalesce_info.rate_sample_interval = Some(d)
+                    }
+                    _ => eprintln!("WARN: Unsupported CoalesceAttr {:?}", nla),
+                }
+            }
+            if let Some(i) = iface_name {
+                infos.insert(i, coalesce_info);
+            }
+        }
+    }
     Ok(infos)
 }
 

--- a/src/netlink-ethtool/coalesce/attr.rs
+++ b/src/netlink-ethtool/coalesce/attr.rs
@@ -1,0 +1,300 @@
+use anyhow::Context;
+use byteorder::{ByteOrder, NativeEndian};
+use netlink_packet_utils::{
+    nla::{self, DefaultNla, NlaBuffer, NlasIterator, NLA_F_NESTED},
+    parsers::{parse_u32, parse_u8},
+    DecodeError, Emitable, Parseable,
+};
+
+use crate::EthtoolHeader;
+
+const ETHTOOL_A_COALESCE_HEADER: u16 = 1;
+const ETHTOOL_A_COALESCE_RX_USECS: u16 = 2;
+const ETHTOOL_A_COALESCE_RX_MAX_FRAMES: u16 = 3;
+const ETHTOOL_A_COALESCE_RX_USECS_IRQ: u16 = 4;
+const ETHTOOL_A_COALESCE_RX_MAX_FRAMES_IRQ: u16 = 5;
+const ETHTOOL_A_COALESCE_TX_USECS: u16 = 6;
+const ETHTOOL_A_COALESCE_TX_MAX_FRAMES: u16 = 7;
+const ETHTOOL_A_COALESCE_TX_USECS_IRQ: u16 = 8;
+const ETHTOOL_A_COALESCE_TX_MAX_FRAMES_IRQ: u16 = 9;
+const ETHTOOL_A_COALESCE_STATS_BLOCK_USECS: u16 = 10;
+const ETHTOOL_A_COALESCE_USE_ADAPTIVE_RX: u16 = 11;
+const ETHTOOL_A_COALESCE_USE_ADAPTIVE_TX: u16 = 12;
+const ETHTOOL_A_COALESCE_PKT_RATE_LOW: u16 = 13;
+const ETHTOOL_A_COALESCE_RX_USECS_LOW: u16 = 14;
+const ETHTOOL_A_COALESCE_RX_MAX_FRAMES_LOW: u16 = 15;
+const ETHTOOL_A_COALESCE_TX_USECS_LOW: u16 = 16;
+const ETHTOOL_A_COALESCE_TX_MAX_FRAMES_LOW: u16 = 17;
+const ETHTOOL_A_COALESCE_PKT_RATE_HIGH: u16 = 18;
+const ETHTOOL_A_COALESCE_RX_USECS_HIGH: u16 = 19;
+const ETHTOOL_A_COALESCE_RX_MAX_FRAMES_HIGH: u16 = 20;
+const ETHTOOL_A_COALESCE_TX_USECS_HIGH: u16 = 21;
+const ETHTOOL_A_COALESCE_TX_MAX_FRAMES_HIGH: u16 = 22;
+const ETHTOOL_A_COALESCE_RATE_SAMPLE_INTERVAL: u16 = 23;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum CoalesceAttr {
+    Header(Vec<EthtoolHeader>),
+    RxUsecs(u32),
+    RxMaxFrames(u32),
+    RxUsecsIrq(u32),
+    RxMaxFramesIrq(u32),
+    TxUsecs(u32),
+    TxMaxFrames(u32),
+    TxUsecsIrq(u32),
+    TxMaxFramesIrq(u32),
+    StatsBlockUsecs(u32),
+    UseAdaptiveRx(bool),
+    UseAdaptiveTx(bool),
+    PktRateLow(u32),
+    RxUsecsLow(u32),
+    RxMaxFramesLow(u32),
+    TxUsecsLow(u32),
+    TxMaxFramesLow(u32),
+    PktRateHigh(u32),
+    RxUsecsHigh(u32),
+    RxMaxFramesHigh(u32),
+    TxUsecsHigh(u32),
+    TxMaxFramesHigh(u32),
+    RateSampleInterval(u32),
+    Other(DefaultNla),
+}
+
+impl nla::Nla for CoalesceAttr {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::Header(hdrs) => hdrs.as_slice().buffer_len(),
+            Self::RxUsecs(_)
+            | Self::RxMaxFrames(_)
+            | Self::RxUsecsIrq(_)
+            | Self::RxMaxFramesIrq(_)
+            | Self::TxUsecs(_)
+            | Self::TxMaxFrames(_)
+            | Self::TxUsecsIrq(_)
+            | Self::TxMaxFramesIrq(_)
+            | Self::StatsBlockUsecs(_)
+            | Self::PktRateLow(_)
+            | Self::RxUsecsLow(_)
+            | Self::RxMaxFramesLow(_)
+            | Self::TxUsecsLow(_)
+            | Self::TxMaxFramesLow(_)
+            | Self::PktRateHigh(_)
+            | Self::RxUsecsHigh(_)
+            | Self::RxMaxFramesHigh(_)
+            | Self::TxUsecsHigh(_)
+            | Self::TxMaxFramesHigh(_)
+            | Self::RateSampleInterval(_) => 4,
+            Self::UseAdaptiveRx(_) | Self::UseAdaptiveTx(_) => 1,
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::Header(_) => ETHTOOL_A_COALESCE_HEADER | NLA_F_NESTED,
+            Self::RxUsecs(_) => ETHTOOL_A_COALESCE_RX_USECS,
+            Self::RxMaxFrames(_) => ETHTOOL_A_COALESCE_RX_MAX_FRAMES,
+            Self::RxUsecsIrq(_) => ETHTOOL_A_COALESCE_RX_USECS_IRQ,
+            Self::RxMaxFramesIrq(_) => ETHTOOL_A_COALESCE_RX_MAX_FRAMES_IRQ,
+            Self::TxUsecs(_) => ETHTOOL_A_COALESCE_TX_USECS,
+            Self::TxMaxFrames(_) => ETHTOOL_A_COALESCE_TX_MAX_FRAMES,
+            Self::TxUsecsIrq(_) => ETHTOOL_A_COALESCE_TX_USECS_IRQ,
+            Self::TxMaxFramesIrq(_) => ETHTOOL_A_COALESCE_TX_MAX_FRAMES_IRQ,
+            Self::StatsBlockUsecs(_) => ETHTOOL_A_COALESCE_STATS_BLOCK_USECS,
+            Self::UseAdaptiveRx(_) => ETHTOOL_A_COALESCE_USE_ADAPTIVE_RX,
+            Self::UseAdaptiveTx(_) => ETHTOOL_A_COALESCE_USE_ADAPTIVE_TX,
+            Self::PktRateLow(_) => ETHTOOL_A_COALESCE_PKT_RATE_LOW,
+            Self::RxUsecsLow(_) => ETHTOOL_A_COALESCE_RX_USECS_LOW,
+            Self::RxMaxFramesLow(_) => ETHTOOL_A_COALESCE_RX_MAX_FRAMES_LOW,
+            Self::TxUsecsLow(_) => ETHTOOL_A_COALESCE_TX_USECS_LOW,
+            Self::TxMaxFramesLow(_) => ETHTOOL_A_COALESCE_TX_MAX_FRAMES_LOW,
+            Self::PktRateHigh(_) => ETHTOOL_A_COALESCE_PKT_RATE_HIGH,
+            Self::RxUsecsHigh(_) => ETHTOOL_A_COALESCE_RX_USECS_HIGH,
+            Self::RxMaxFramesHigh(_) => ETHTOOL_A_COALESCE_RX_MAX_FRAMES_HIGH,
+            Self::TxUsecsHigh(_) => ETHTOOL_A_COALESCE_TX_USECS_HIGH,
+            Self::TxMaxFramesHigh(_) => ETHTOOL_A_COALESCE_TX_MAX_FRAMES_HIGH,
+            Self::RateSampleInterval(_) => {
+                ETHTOOL_A_COALESCE_RATE_SAMPLE_INTERVAL
+            }
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::Header(ref nlas) => nlas.as_slice().emit(buffer),
+            Self::Other(ref attr) => attr.emit(buffer),
+            Self::RxUsecs(d)
+            | Self::RxMaxFrames(d)
+            | Self::RxUsecsIrq(d)
+            | Self::RxMaxFramesIrq(d)
+            | Self::TxUsecs(d)
+            | Self::TxMaxFrames(d)
+            | Self::TxUsecsIrq(d)
+            | Self::TxMaxFramesIrq(d)
+            | Self::StatsBlockUsecs(d)
+            | Self::PktRateLow(d)
+            | Self::RxUsecsLow(d)
+            | Self::RxMaxFramesLow(d)
+            | Self::TxUsecsLow(d)
+            | Self::TxMaxFramesLow(d)
+            | Self::PktRateHigh(d)
+            | Self::RxUsecsHigh(d)
+            | Self::RxMaxFramesHigh(d)
+            | Self::TxUsecsHigh(d)
+            | Self::TxMaxFramesHigh(d)
+            | Self::RateSampleInterval(d) => {
+                NativeEndian::write_u32(buffer, *d)
+            }
+            Self::UseAdaptiveRx(d) | Self::UseAdaptiveTx(d) => {
+                buffer[0] = if *d { 1 } else { 0 }
+            }
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for CoalesceAttr {
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            ETHTOOL_A_COALESCE_HEADER => {
+                let mut nlas = Vec::new();
+                let error_msg = "failed to parse coalesce header attributes";
+                for nla in NlasIterator::new(payload) {
+                    let nla = &nla.context(error_msg)?;
+                    let parsed =
+                        EthtoolHeader::parse(nla).context(error_msg)?;
+                    nlas.push(parsed);
+                }
+                Self::Header(nlas)
+            }
+            ETHTOOL_A_COALESCE_RX_USECS => Self::RxUsecs(
+                parse_u32(payload)
+                    .context("Invalid ETHTOOL_A_COALESCE_RX_USECS value")?,
+            ),
+            ETHTOOL_A_COALESCE_RX_MAX_FRAMES => {
+                Self::RxMaxFrames(parse_u32(payload).context(
+                    "Invalid ETHTOOL_A_COALESCE_RX_MAX_FRAMES value",
+                )?)
+            }
+
+            ETHTOOL_A_COALESCE_RX_USECS_IRQ => Self::RxUsecsIrq(
+                parse_u32(payload)
+                    .context("Invalid ETHTOOL_A_COALESCE_RX_USECS_IRQ value")?,
+            ),
+
+            ETHTOOL_A_COALESCE_RX_MAX_FRAMES_IRQ => {
+                Self::RxMaxFramesIrq(parse_u32(payload).context(
+                    "Invalid ETHTOOL_A_COALESCE_RX_MAX_FRAMES_IRQ value",
+                )?)
+            }
+
+            ETHTOOL_A_COALESCE_TX_USECS => Self::TxUsecs(
+                parse_u32(payload)
+                    .context("Invalid ETHTOOL_A_COALESCE_TX_USECS value")?,
+            ),
+
+            ETHTOOL_A_COALESCE_TX_MAX_FRAMES => {
+                Self::TxMaxFrames(parse_u32(payload).context(
+                    "Invalid ETHTOOL_A_COALESCE_TX_MAX_FRAMES value",
+                )?)
+            }
+
+            ETHTOOL_A_COALESCE_TX_USECS_IRQ => Self::TxUsecsIrq(
+                parse_u32(payload)
+                    .context("Invalid ETHTOOL_A_COALESCE_TX_USECS_IRQ value")?,
+            ),
+
+            ETHTOOL_A_COALESCE_TX_MAX_FRAMES_IRQ => {
+                Self::TxMaxFramesIrq(parse_u32(payload).context(
+                    "Invalid ETHTOOL_A_COALESCE_TX_MAX_FRAMES_IRQ value",
+                )?)
+            }
+
+            ETHTOOL_A_COALESCE_STATS_BLOCK_USECS => {
+                Self::StatsBlockUsecs(parse_u32(payload).context(
+                    "Invalid ETHTOOL_A_COALESCE_STATS_BLOCK_USECS value",
+                )?)
+            }
+
+            ETHTOOL_A_COALESCE_USE_ADAPTIVE_RX => Self::UseAdaptiveRx(
+                parse_u8(payload).context(
+                    "Invalid ETHTOOL_A_COALESCE_USE_ADAPTIVE_RX value",
+                )? == 1,
+            ),
+
+            ETHTOOL_A_COALESCE_USE_ADAPTIVE_TX => Self::UseAdaptiveTx(
+                parse_u8(payload).context(
+                    "Invalid ETHTOOL_A_COALESCE_USE_ADAPTIVE_TX value",
+                )? == 1,
+            ),
+
+            ETHTOOL_A_COALESCE_PKT_RATE_LOW => Self::PktRateLow(
+                parse_u32(payload)
+                    .context("Invalid ETHTOOL_A_COALESCE_PKT_RATE_LOW value")?,
+            ),
+
+            ETHTOOL_A_COALESCE_RX_USECS_LOW => Self::RxUsecsLow(
+                parse_u32(payload)
+                    .context("Invalid ETHTOOL_A_COALESCE_RX_USECS_LOW value")?,
+            ),
+
+            ETHTOOL_A_COALESCE_RX_MAX_FRAMES_LOW => {
+                Self::RxMaxFramesLow(parse_u32(payload).context(
+                    "Invalid ETHTOOL_A_COALESCE_RX_MAX_FRAMES_LOW value",
+                )?)
+            }
+
+            ETHTOOL_A_COALESCE_TX_USECS_LOW => Self::TxUsecsLow(
+                parse_u32(payload)
+                    .context("Invalid ETHTOOL_A_COALESCE_TX_USECS_LOW value")?,
+            ),
+
+            ETHTOOL_A_COALESCE_TX_MAX_FRAMES_LOW => {
+                Self::TxMaxFramesLow(parse_u32(payload).context(
+                    "Invalid ETHTOOL_A_COALESCE_TX_MAX_FRAMES_LOW value",
+                )?)
+            }
+
+            ETHTOOL_A_COALESCE_PKT_RATE_HIGH => {
+                Self::PktRateHigh(parse_u32(payload).context(
+                    "Invalid ETHTOOL_A_COALESCE_PKT_RATE_HIGH value",
+                )?)
+            }
+
+            ETHTOOL_A_COALESCE_RX_USECS_HIGH => {
+                Self::RxUsecsHigh(parse_u32(payload).context(
+                    "Invalid ETHTOOL_A_COALESCE_RX_USECS_HIGH value",
+                )?)
+            }
+
+            ETHTOOL_A_COALESCE_RX_MAX_FRAMES_HIGH => {
+                Self::RxMaxFramesHigh(parse_u32(payload).context(
+                    "Invalid ETHTOOL_A_COALESCE_RX_MAX_FRAMES_HIGH value",
+                )?)
+            }
+
+            ETHTOOL_A_COALESCE_TX_USECS_HIGH => {
+                Self::TxUsecsHigh(parse_u32(payload).context(
+                    "Invalid ETHTOOL_A_COALESCE_TX_USECS_HIGH value",
+                )?)
+            }
+
+            ETHTOOL_A_COALESCE_TX_MAX_FRAMES_HIGH => {
+                Self::TxMaxFramesHigh(parse_u32(payload).context(
+                    "Invalid ETHTOOL_A_COALESCE_TX_MAX_FRAMES_HIGH value",
+                )?)
+            }
+
+            ETHTOOL_A_COALESCE_RATE_SAMPLE_INTERVAL => {
+                Self::RateSampleInterval(parse_u32(payload).context(
+                    "Invalid ETHTOOL_A_COALESCE_RATE_SAMPLE_INTERVAL value",
+                )?)
+            }
+
+            _ => Self::Other(
+                DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?,
+            ),
+        })
+    }
+}

--- a/src/netlink-ethtool/coalesce/get.rs
+++ b/src/netlink-ethtool/coalesce/get.rs
@@ -1,0 +1,53 @@
+use futures::{self, future::Either, FutureExt, StreamExt, TryStream};
+use netlink_packet_core::{
+    NetlinkMessage, NLM_F_ACK, NLM_F_DUMP, NLM_F_REQUEST,
+};
+
+use crate::{try_ethtool, EthtoolError, EthtoolHandle, EthtoolMessage};
+
+pub struct CoalesceGetRequest {
+    handle: EthtoolHandle,
+    iface_name: Option<String>,
+}
+
+impl CoalesceGetRequest {
+    pub(crate) fn new(handle: EthtoolHandle, iface_name: Option<&str>) -> Self {
+        CoalesceGetRequest {
+            handle,
+            iface_name: iface_name.map(|i| i.to_string()),
+        }
+    }
+
+    pub fn execute(
+        self,
+    ) -> impl TryStream<Ok = EthtoolMessage, Error = EthtoolError> {
+        let CoalesceGetRequest {
+            mut handle,
+            iface_name,
+        } = self;
+
+        let nl_header_flags = match iface_name {
+            None => NLM_F_DUMP | NLM_F_REQUEST | NLM_F_ACK,
+            Some(_) => NLM_F_REQUEST,
+        };
+
+        let ethtool_msg = EthtoolMessage::new_coalesce_get(
+            handle.family_id,
+            iface_name.as_deref(),
+        );
+
+        let mut nl_msg = NetlinkMessage::from(ethtool_msg);
+
+        nl_msg.header.flags = nl_header_flags;
+
+        match handle.request(nl_msg) {
+            Ok(response) => {
+                Either::Left(response.map(move |msg| Ok(try_ethtool!(msg))))
+            }
+            Err(e) => Either::Right(
+                futures::future::err::<EthtoolMessage, EthtoolError>(e)
+                    .into_stream(),
+            ),
+        }
+    }
+}

--- a/src/netlink-ethtool/coalesce/handle.rs
+++ b/src/netlink-ethtool/coalesce/handle.rs
@@ -1,0 +1,14 @@
+use crate::{CoalesceGetRequest, EthtoolHandle};
+
+pub struct CoalesceHandle(EthtoolHandle);
+
+impl CoalesceHandle {
+    pub fn new(handle: EthtoolHandle) -> Self {
+        CoalesceHandle(handle)
+    }
+
+    /// Retrieve the ethtool coalesces of a interface (equivalent to `ethtool -k eth1`)
+    pub fn get(&mut self, iface_name: Option<&str>) -> CoalesceGetRequest {
+        CoalesceGetRequest::new(self.0.clone(), iface_name)
+    }
+}

--- a/src/netlink-ethtool/coalesce/mod.rs
+++ b/src/netlink-ethtool/coalesce/mod.rs
@@ -1,0 +1,7 @@
+mod attr;
+mod get;
+mod handle;
+
+pub use attr::CoalesceAttr;
+pub use get::CoalesceGetRequest;
+pub use handle::CoalesceHandle;

--- a/src/netlink-ethtool/examples/dump_coalesce.rs
+++ b/src/netlink-ethtool/examples/dump_coalesce.rs
@@ -1,0 +1,42 @@
+use futures::stream::TryStreamExt;
+use netlink_ethtool;
+use netlink_generic;
+use tokio;
+
+// Once we find a way to load netsimdev kernel module in CI, we can convert this
+// to a test
+fn main() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()
+        .unwrap();
+    let family_id = rt.block_on(genl_ctrl_resolve_ethtool());
+    rt.block_on(get_coalesce(family_id, None));
+}
+
+async fn genl_ctrl_resolve_ethtool() -> u16 {
+    let (connection, mut handle, _) =
+        netlink_generic::new_connection().unwrap();
+    tokio::spawn(connection);
+
+    let family_id = handle.resolve_family_name("ethtool").await.unwrap();
+    println!("Family ID of ethtool is {}", family_id);
+    family_id
+}
+
+async fn get_coalesce(family_id: u16, iface_name: Option<&str>) {
+    let (connection, mut handle, _) =
+        netlink_ethtool::new_connection(family_id).unwrap();
+    tokio::spawn(connection);
+
+    let mut coalesce_handle = handle.coalesce().get(iface_name).execute();
+
+    let mut msgs = Vec::new();
+    while let Some(msg) = coalesce_handle.try_next().await.unwrap() {
+        msgs.push(msg);
+    }
+    assert!(msgs.len() > 0);
+    for msg in msgs {
+        println!("{:?}", msg);
+    }
+}

--- a/src/netlink-ethtool/handle.rs
+++ b/src/netlink-ethtool/handle.rs
@@ -16,7 +16,9 @@ use futures::Stream;
 use netlink_packet_core::NetlinkMessage;
 use netlink_proto::{sys::SocketAddr, ConnectionHandle};
 
-use crate::{EthtoolError, EthtoolMessage, FeatureHandle, PauseHandle};
+use crate::{
+    CoalesceHandle, EthtoolError, EthtoolMessage, FeatureHandle, PauseHandle,
+};
 
 #[derive(Clone, Debug)]
 pub struct EthtoolHandle {
@@ -38,6 +40,10 @@ impl EthtoolHandle {
 
     pub fn feature(&mut self) -> FeatureHandle {
         FeatureHandle::new(self.clone())
+    }
+
+    pub fn coalesce(&mut self) -> CoalesceHandle {
+        CoalesceHandle::new(self.clone())
     }
 
     pub fn request(

--- a/src/netlink-ethtool/lib.rs
+++ b/src/netlink-ethtool/lib.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod coalesce;
 mod connection;
 mod error;
 mod feature;
@@ -21,6 +22,7 @@ mod macros;
 mod message;
 mod pause;
 
+pub use coalesce::{CoalesceAttr, CoalesceGetRequest, CoalesceHandle};
 pub use connection::new_connection;
 pub use error::EthtoolError;
 pub use feature::{FeatureAttr, FeatureBit, FeatureGetRequest, FeatureHandle};

--- a/src/python/nispor/ethtool.py
+++ b/src/python/nispor/ethtool.py
@@ -25,6 +25,11 @@ class NisporEthtool:
         else:
             self._features = None
 
+        if "coalesce" in info:
+            self._coalesce = NisporEthtoolCoalesce(info["coalesce"])
+        else:
+            self._coalesce = None
+
     @property
     def pause(self):
         return self._pause
@@ -32,6 +37,11 @@ class NisporEthtool:
     @property
     def features(self):
         return self._features
+
+    @property
+    def coalesce(self):
+        return self._coalesce
+
 
 class NisporEthtoolPause:
     def __init__(self, info):
@@ -49,6 +59,7 @@ class NisporEthtoolPause:
     def auto_negotiate(self):
         return self._info["auto_negotiate"]
 
+
 class NisporEthtoolFeatures:
     def __init__(self, info):
         self._info = info
@@ -60,3 +71,96 @@ class NisporEthtoolFeatures:
     @property
     def changeable(self):
         return self._info["changeable"]
+
+
+class NisporEthtoolCoalesce:
+    def __init__(self, info):
+        self._info = info
+
+    @property
+    def pkt_rate_high(self):
+        return self._info.get("pkt_rate_high")
+
+    @property
+    def pkt_rate_low(self):
+        return self._info.get("pkt_rate_low")
+
+    @property
+    def rate_sample_interval(self):
+        return self._info.get("rate_sample_interval")
+
+    @property
+    def rx_max_frames(self):
+        return self._info.get("rx_max_frames")
+
+    @property
+    def rx_max_frames_high(self):
+        return self._info.get("rx_max_frames_high")
+
+    @property
+    def rx_max_frames_irq(self):
+        return self._info.get("rx_max_frames_irq")
+
+    @property
+    def rx_max_frames_low(self):
+        return self._info.get("rx_max_frames_low")
+
+    @property
+    def rx_usecs(self):
+        return self._info.get("rx_usecs")
+
+    @property
+    def rx_usecs_high(self):
+        return self._info.get("rx_usecs_high")
+
+    @property
+    def rx_usecs_irq(self):
+        return self._info.get("rx_usecs_irq")
+
+    @property
+    def rx_usecs_low(self):
+        return self._info.get("rx_usecs_low")
+
+    @property
+    def stats_block_usecs(self):
+        return self._info.get("stats_block_usecs")
+
+    @property
+    def tx_max_frames(self):
+        return self._info.get("tx_max_frames")
+
+    @property
+    def tx_max_frames_high(self):
+        return self._info.get("tx_max_frames_high")
+
+    @property
+    def tx_max_frames_irq(self):
+        return self._info.get("tx_max_frames_irq")
+
+    @property
+    def tx_max_frames_low(self):
+        return self._info.get("tx_max_frames_low")
+
+    @property
+    def tx_usecs(self):
+        return self._info.get("tx_usecs")
+
+    @property
+    def tx_usecs_high(self):
+        return self._info.get("tx_usecs_high")
+
+    @property
+    def tx_usecs_irq(self):
+        return self._info.get("tx_usecs_irq")
+
+    @property
+    def tx_usecs_low(self):
+        return self._info.get("tx_usecs_low")
+
+    @property
+    def use_adaptive_rx(self):
+        return self._info.get("use_adaptive_rx")
+
+    @property
+    def use_adaptive_tx(self):
+        return self._info.get("use_adaptive_tx")

--- a/tools/test_env
+++ b/tools/test_env
@@ -138,6 +138,7 @@ elif [ "CHK$1" == "CHKtun" ];then
     sudo ip tuntap add name tun1 mode tun \
         user 1001 group 0 multi_queue vnet_hdr
     sudo ip link set tun1 up
+    sudo ethtool -C tun1 rx-frames 60
     sleep $LINK_WAIT_TIME
 elif [ "CHK$1" == "CHKtap" ];then
     sudo ip tuntap add name tap1 mode tap \


### PR DESCRIPTION
Example on `npc tun1` output:

```yaml
ethtool:
  coalesce:
    rx_max_frames: 60
```

Python binding also updated.

Test case included but disabled as CI has ethtool netlink disabled.