### PR TITLE
ethtool: Add support of ethtool ring

### DIFF
--- a/src/netlink-ethtool/examples/dump_rings.rs
+++ b/src/netlink-ethtool/examples/dump_rings.rs
@@ -1,0 +1,42 @@
+use futures::stream::TryStreamExt;
+use netlink_ethtool;
+use netlink_generic;
+use tokio;
+
+// Once we find a way to load netsimdev kernel module in CI, we can convert this
+// to a test
+fn main() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()
+        .unwrap();
+    let family_id = rt.block_on(genl_ctrl_resolve_ethtool());
+    rt.block_on(get_ring(family_id, None));
+}
+
+async fn genl_ctrl_resolve_ethtool() -> u16 {
+    let (connection, mut handle, _) =
+        netlink_generic::new_connection().unwrap();
+    tokio::spawn(connection);
+
+    let family_id = handle.resolve_family_name("ethtool").await.unwrap();
+    println!("Family ID of ethtool is {}", family_id);
+    family_id
+}
+
+async fn get_ring(family_id: u16, iface_name: Option<&str>) {
+    let (connection, mut handle, _) =
+        netlink_ethtool::new_connection(family_id).unwrap();
+    tokio::spawn(connection);
+
+    let mut ring_handle = handle.ring().get(iface_name).execute();
+
+    let mut msgs = Vec::new();
+    while let Some(msg) = ring_handle.try_next().await.unwrap() {
+        msgs.push(msg);
+    }
+    assert!(msgs.len() > 0);
+    for msg in msgs {
+        println!("{:?}", msg);
+    }
+}

--- a/src/netlink-ethtool/handle.rs
+++ b/src/netlink-ethtool/handle.rs
@@ -18,6 +18,7 @@ use netlink_proto::{sys::SocketAddr, ConnectionHandle};
 
 use crate::{
     CoalesceHandle, EthtoolError, EthtoolMessage, FeatureHandle, PauseHandle,
+    RingHandle,
 };
 
 #[derive(Clone, Debug)]
@@ -44,6 +45,10 @@ impl EthtoolHandle {
 
     pub fn coalesce(&mut self) -> CoalesceHandle {
         CoalesceHandle::new(self.clone())
+    }
+
+    pub fn ring(&mut self) -> RingHandle {
+        RingHandle::new(self.clone())
     }
 
     pub fn request(

--- a/src/netlink-ethtool/lib.rs
+++ b/src/netlink-ethtool/lib.rs
@@ -21,6 +21,7 @@ mod header;
 mod macros;
 mod message;
 mod pause;
+mod ring;
 
 pub use coalesce::{CoalesceAttr, CoalesceGetRequest, CoalesceHandle};
 pub use connection::new_connection;
@@ -30,3 +31,4 @@ pub use handle::EthtoolHandle;
 pub use header::EthtoolHeader;
 pub use message::{EthoolAttr, EthtoolMessage};
 pub use pause::{PauseAttr, PauseGetRequest, PauseHandle};
+pub use ring::{RingAttr, RingGetRequest, RingHandle};

--- a/src/netlink-ethtool/ring/attr.rs
+++ b/src/netlink-ethtool/ring/attr.rs
@@ -1,0 +1,135 @@
+use anyhow::Context;
+use byteorder::{ByteOrder, NativeEndian};
+use netlink_packet_utils::{
+    nla::{self, DefaultNla, NlaBuffer, NlasIterator, NLA_F_NESTED},
+    parsers::parse_u32,
+    DecodeError, Emitable, Parseable,
+};
+
+use crate::EthtoolHeader;
+
+const ETHTOOL_A_RINGS_HEADER: u16 = 1;
+const ETHTOOL_A_RINGS_RX_MAX: u16 = 2;
+const ETHTOOL_A_RINGS_RX_MINI_MAX: u16 = 3;
+const ETHTOOL_A_RINGS_RX_JUMBO_MAX: u16 = 4;
+const ETHTOOL_A_RINGS_TX_MAX: u16 = 5;
+const ETHTOOL_A_RINGS_RX: u16 = 6;
+const ETHTOOL_A_RINGS_RX_MINI: u16 = 7;
+const ETHTOOL_A_RINGS_RX_JUMBO: u16 = 8;
+const ETHTOOL_A_RINGS_TX: u16 = 9;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum RingAttr {
+    Header(Vec<EthtoolHeader>),
+    RxMax(u32),
+    RxMiniMax(u32),
+    RxJumboMax(u32),
+    TxMax(u32),
+    Rx(u32),
+    RxMini(u32),
+    RxJumbo(u32),
+    Tx(u32),
+    Other(DefaultNla),
+}
+
+impl nla::Nla for RingAttr {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::Header(hdrs) => hdrs.as_slice().buffer_len(),
+            Self::RxMax(_)
+            | Self::RxMiniMax(_)
+            | Self::RxJumboMax(_)
+            | Self::TxMax(_)
+            | Self::Rx(_)
+            | Self::RxMini(_)
+            | Self::RxJumbo(_)
+            | Self::Tx(_) => 4,
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::Header(_) => ETHTOOL_A_RINGS_HEADER | NLA_F_NESTED,
+            Self::RxMax(_) => ETHTOOL_A_RINGS_RX_MAX,
+            Self::RxMiniMax(_) => ETHTOOL_A_RINGS_RX_MINI_MAX,
+            Self::RxJumboMax(_) => ETHTOOL_A_RINGS_RX_JUMBO_MAX,
+            Self::TxMax(_) => ETHTOOL_A_RINGS_TX_MAX,
+            Self::Rx(_) => ETHTOOL_A_RINGS_RX,
+            Self::RxMini(_) => ETHTOOL_A_RINGS_RX_MINI,
+            Self::RxJumbo(_) => ETHTOOL_A_RINGS_RX_JUMBO,
+            Self::Tx(_) => ETHTOOL_A_RINGS_TX,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::Header(ref nlas) => nlas.as_slice().emit(buffer),
+            Self::RxMax(d)
+            | Self::RxMiniMax(d)
+            | Self::RxJumboMax(d)
+            | Self::TxMax(d)
+            | Self::Rx(d)
+            | Self::RxMini(d)
+            | Self::RxJumbo(d)
+            | Self::Tx(d) => NativeEndian::write_u32(buffer, *d),
+            Self::Other(ref attr) => attr.emit(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for RingAttr {
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            ETHTOOL_A_RINGS_HEADER => {
+                let mut nlas = Vec::new();
+                let error_msg = "failed to parse ring header attributes";
+                for nla in NlasIterator::new(payload) {
+                    let nla = &nla.context(error_msg)?;
+                    let parsed =
+                        EthtoolHeader::parse(nla).context(error_msg)?;
+                    nlas.push(parsed);
+                }
+                Self::Header(nlas)
+            }
+            ETHTOOL_A_RINGS_RX_MAX => Self::RxMax(
+                parse_u32(payload)
+                    .context("Invalid ETHTOOL_A_RINGS_RX_MAX value")?,
+            ),
+
+            ETHTOOL_A_RINGS_RX_MINI_MAX => Self::RxMiniMax(
+                parse_u32(payload)
+                    .context("Invalid ETHTOOL_A_RINGS_RX_MINI_MAX value")?,
+            ),
+            ETHTOOL_A_RINGS_RX_JUMBO_MAX => Self::RxJumboMax(
+                parse_u32(payload)
+                    .context("Invalid ETHTOOL_A_RINGS_RX_JUMBO_MAX value")?,
+            ),
+            ETHTOOL_A_RINGS_TX_MAX => Self::TxMax(
+                parse_u32(payload)
+                    .context("Invalid ETHTOOL_A_RINGS_TX_MAX value")?,
+            ),
+            ETHTOOL_A_RINGS_RX => Self::Rx(
+                parse_u32(payload)
+                    .context("Invalid ETHTOOL_A_RINGS_RX value")?,
+            ),
+            ETHTOOL_A_RINGS_RX_MINI => Self::RxMini(
+                parse_u32(payload)
+                    .context("Invalid ETHTOOL_A_RINGS_RX_MINI value")?,
+            ),
+            ETHTOOL_A_RINGS_RX_JUMBO => Self::RxJumbo(
+                parse_u32(payload)
+                    .context("Invalid ETHTOOL_A_RINGS_RX_JUMBO value")?,
+            ),
+            ETHTOOL_A_RINGS_TX => Self::Tx(
+                parse_u32(payload)
+                    .context("Invalid ETHTOOL_A_RINGS_TX value")?,
+            ),
+            _ => Self::Other(
+                DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?,
+            ),
+        })
+    }
+}

--- a/src/netlink-ethtool/ring/get.rs
+++ b/src/netlink-ethtool/ring/get.rs
@@ -1,0 +1,53 @@
+use futures::{self, future::Either, FutureExt, StreamExt, TryStream};
+use netlink_packet_core::{
+    NetlinkMessage, NLM_F_ACK, NLM_F_DUMP, NLM_F_REQUEST,
+};
+
+use crate::{try_ethtool, EthtoolError, EthtoolHandle, EthtoolMessage};
+
+pub struct RingGetRequest {
+    handle: EthtoolHandle,
+    iface_name: Option<String>,
+}
+
+impl RingGetRequest {
+    pub(crate) fn new(handle: EthtoolHandle, iface_name: Option<&str>) -> Self {
+        RingGetRequest {
+            handle,
+            iface_name: iface_name.map(|i| i.to_string()),
+        }
+    }
+
+    pub fn execute(
+        self,
+    ) -> impl TryStream<Ok = EthtoolMessage, Error = EthtoolError> {
+        let RingGetRequest {
+            mut handle,
+            iface_name,
+        } = self;
+
+        let nl_header_flags = match iface_name {
+            None => NLM_F_DUMP | NLM_F_REQUEST | NLM_F_ACK,
+            Some(_) => NLM_F_REQUEST,
+        };
+
+        let ethtool_msg = EthtoolMessage::new_ring_get(
+            handle.family_id,
+            iface_name.as_deref(),
+        );
+
+        let mut nl_msg = NetlinkMessage::from(ethtool_msg);
+
+        nl_msg.header.flags = nl_header_flags;
+
+        match handle.request(nl_msg) {
+            Ok(response) => {
+                Either::Left(response.map(move |msg| Ok(try_ethtool!(msg))))
+            }
+            Err(e) => Either::Right(
+                futures::future::err::<EthtoolMessage, EthtoolError>(e)
+                    .into_stream(),
+            ),
+        }
+    }
+}

--- a/src/netlink-ethtool/ring/handle.rs
+++ b/src/netlink-ethtool/ring/handle.rs
@@ -1,0 +1,14 @@
+use crate::{EthtoolHandle, RingGetRequest};
+
+pub struct RingHandle(EthtoolHandle);
+
+impl RingHandle {
+    pub fn new(handle: EthtoolHandle) -> Self {
+        RingHandle(handle)
+    }
+
+    /// Retrieve the ethtool rings of a interface (equivalent to `ethtool -k eth1`)
+    pub fn get(&mut self, iface_name: Option<&str>) -> RingGetRequest {
+        RingGetRequest::new(self.0.clone(), iface_name)
+    }
+}

--- a/src/netlink-ethtool/ring/mod.rs
+++ b/src/netlink-ethtool/ring/mod.rs
@@ -1,0 +1,7 @@
+mod attr;
+mod get;
+mod handle;
+
+pub use attr::RingAttr;
+pub use get::RingGetRequest;
+pub use handle::RingHandle;

--- a/src/python/nispor/ethtool.py
+++ b/src/python/nispor/ethtool.py
@@ -30,6 +30,11 @@ class NisporEthtool:
         else:
             self._coalesce = None
 
+        if "ring" in info:
+            self._ring = NisporEthtoolRing(info["ring"])
+        else:
+            self._ring = None
+
     @property
     def pause(self):
         return self._pause
@@ -41,6 +46,10 @@ class NisporEthtool:
     @property
     def coalesce(self):
         return self._coalesce
+
+    @property
+    def ring(self):
+        return self._ring
 
 
 class NisporEthtoolPause:
@@ -164,3 +173,40 @@ class NisporEthtoolCoalesce:
     @property
     def use_adaptive_tx(self):
         return self._info.get("use_adaptive_tx")
+
+
+class NisporEthtoolRing:
+    def __init__(self, info):
+        self._info = info
+
+    @property
+    def rx(self):
+        return self._info.get("rx")
+
+    @property
+    def rx_max(self):
+        return self._info.get("rx_max")
+
+    @property
+    def rx_jumbo(self):
+        return self._info.get("rx_jumbo")
+
+    @property
+    def rx_jumbo_max(self):
+        return self._info.get("rx_jumbo_max")
+
+    @property
+    def rx_mini(self):
+        return self._info.get("rx_mini")
+
+    @property
+    def rx_mini_max(self):
+        return self._info.get("rx_mini_max")
+
+    @property
+    def tx(self):
+        return self._info.get("tx")
+
+    @property
+    def tx_max(self):
+        return self._info.get("tx_max")


### PR DESCRIPTION
Example on `npc eno3` output on one igb NIC:

```yaml
ethtool:
  ring:
    rx: 256
    rx_max: 4096
    tx: 256
    tx_max: 4096

```

Python binding also updated.

No test case yet as there is no software based NIC for this.