### PR TITLE
ethtool: Add support of ethtool link mode

### DIFF
--- a/src/lib/tests/ethtool.rs
+++ b/src/lib/tests/ethtool.rs
@@ -142,10 +142,15 @@ where
 const IFACE_TUN_NAME: &str = "tun1";
 const EXPECTED_ETHTOOL_COALESCE: &str = r#"---
 rx_max_frames: 60"#;
+const EXPECTED_ETHTOOL_LINK_MODE: &str = r#"---
+auto_negotiate: false
+ours: []
+speed: 10
+duplex: full"#;
 
 #[test]
 #[ignore] // CI does not have netdevsim and ethtool_netlink kernel module yet
-fn test_get_ethtool_coalesce_yaml() {
+fn test_get_ethtool_coalesce_and_link_mode_yaml() {
     with_tun_iface(|| {
         let state = NetState::retrieve().unwrap();
         let iface = &state.ifaces[IFACE_TUN_NAME];
@@ -153,6 +158,11 @@ fn test_get_ethtool_coalesce_yaml() {
             serde_yaml::to_string(&iface.ethtool.as_ref().unwrap().coalesce)
                 .unwrap(),
             EXPECTED_ETHTOOL_COALESCE
+        );
+        assert_eq!(
+            serde_yaml::to_string(&iface.ethtool.as_ref().unwrap().link_mode)
+                .unwrap(),
+            EXPECTED_ETHTOOL_LINK_MODE
         );
     });
 }

--- a/src/netlink-ethtool/examples/dump_link_mode.rs
+++ b/src/netlink-ethtool/examples/dump_link_mode.rs
@@ -1,0 +1,42 @@
+use futures::stream::TryStreamExt;
+use netlink_ethtool;
+use netlink_generic;
+use tokio;
+
+// Once we find a way to load netsimdev kernel module in CI, we can convert this
+// to a test
+fn main() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()
+        .unwrap();
+    let family_id = rt.block_on(genl_ctrl_resolve_ethtool());
+    rt.block_on(get_link_mode(family_id, None));
+}
+
+async fn genl_ctrl_resolve_ethtool() -> u16 {
+    let (connection, mut handle, _) =
+        netlink_generic::new_connection().unwrap();
+    tokio::spawn(connection);
+
+    let family_id = handle.resolve_family_name("ethtool").await.unwrap();
+    println!("Family ID of ethtool is {}", family_id);
+    family_id
+}
+
+async fn get_link_mode(family_id: u16, iface_name: Option<&str>) {
+    let (connection, mut handle, _) =
+        netlink_ethtool::new_connection(family_id).unwrap();
+    tokio::spawn(connection);
+
+    let mut link_mode_handle = handle.link_mode().get(iface_name).execute();
+
+    let mut msgs = Vec::new();
+    while let Some(msg) = link_mode_handle.try_next().await.unwrap() {
+        msgs.push(msg);
+    }
+    assert!(msgs.len() > 0);
+    for msg in msgs {
+        println!("{:?}", msg);
+    }
+}

--- a/src/netlink-ethtool/handle.rs
+++ b/src/netlink-ethtool/handle.rs
@@ -17,8 +17,8 @@ use netlink_packet_core::NetlinkMessage;
 use netlink_proto::{sys::SocketAddr, ConnectionHandle};
 
 use crate::{
-    CoalesceHandle, EthtoolError, EthtoolMessage, FeatureHandle, PauseHandle,
-    RingHandle,
+    CoalesceHandle, EthtoolError, EthtoolMessage, FeatureHandle,
+    LinkModeHandle, PauseHandle, RingHandle,
 };
 
 #[derive(Clone, Debug)]
@@ -49,6 +49,10 @@ impl EthtoolHandle {
 
     pub fn ring(&mut self) -> RingHandle {
         RingHandle::new(self.clone())
+    }
+
+    pub fn link_mode(&mut self) -> LinkModeHandle {
+        LinkModeHandle::new(self.clone())
     }
 
     pub fn request(

--- a/src/netlink-ethtool/lib.rs
+++ b/src/netlink-ethtool/lib.rs
@@ -18,6 +18,7 @@ mod error;
 mod feature;
 mod handle;
 mod header;
+mod link_mode;
 mod macros;
 mod message;
 mod pause;
@@ -29,6 +30,9 @@ pub use error::EthtoolError;
 pub use feature::{FeatureAttr, FeatureBit, FeatureGetRequest, FeatureHandle};
 pub use handle::EthtoolHandle;
 pub use header::EthtoolHeader;
+pub use link_mode::{
+    LinkModeAttr, LinkModeDuplex, LinkModeGetRequest, LinkModeHandle,
+};
 pub use message::{EthoolAttr, EthtoolMessage};
 pub use pause::{PauseAttr, PauseGetRequest, PauseHandle};
 pub use ring::{RingAttr, RingGetRequest, RingHandle};

--- a/src/netlink-ethtool/link_mode/attr.rs
+++ b/src/netlink-ethtool/link_mode/attr.rs
@@ -1,0 +1,225 @@
+use anyhow::Context;
+use log::warn;
+use netlink_packet_utils::{
+    nla::{self, DefaultNla, NlaBuffer, NlasIterator, NLA_F_NESTED},
+    parsers::{parse_string, parse_u32, parse_u8},
+    DecodeError, Emitable, Parseable,
+};
+
+use crate::EthtoolHeader;
+
+const ETHTOOL_A_LINKMODES_HEADER: u16 = 1;
+const ETHTOOL_A_LINKMODES_AUTONEG: u16 = 2;
+const ETHTOOL_A_LINKMODES_OURS: u16 = 3;
+const ETHTOOL_A_LINKMODES_PEER: u16 = 4;
+const ETHTOOL_A_LINKMODES_SPEED: u16 = 5;
+const ETHTOOL_A_LINKMODES_DUPLEX: u16 = 6;
+const ETHTOOL_A_LINKMODES_SUBORDINATE_CFG: u16 = 7;
+const ETHTOOL_A_LINKMODES_SUBORDINATE_STATE: u16 = 8;
+const ETHTOOL_A_LINKMODES_LANES: u16 = 9;
+
+const ETHTOOL_A_BITSET_BITS: u16 = 3;
+
+const ETHTOOL_A_BITSET_BITS_BIT: u16 = 1;
+
+const ETHTOOL_A_BITSET_BIT_INDEX: u16 = 1;
+const ETHTOOL_A_BITSET_BIT_NAME: u16 = 2;
+const ETHTOOL_A_BITSET_BIT_VALUE: u16 = 3;
+
+const DUPLEX_HALF: u8 = 0x00;
+const DUPLEX_FULL: u8 = 0x01;
+const DUPLEX_UNKNOWN: u8 = 0xff;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum LinkModeDuplex {
+    Half,
+    Full,
+    Unknown,
+    Other(u8),
+}
+
+impl From<u8> for LinkModeDuplex {
+    fn from(d: u8) -> Self {
+        match d {
+            DUPLEX_HALF => Self::Half,
+            DUPLEX_FULL => Self::Full,
+            DUPLEX_UNKNOWN => Self::Unknown,
+            _ => Self::Other(d),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum LinkModeAttr {
+    Header(Vec<EthtoolHeader>),
+    Autoneg(bool),
+    Ours(Vec<String>),
+    Peer(Vec<String>),
+    Speed(u32),
+    Duplex(LinkModeDuplex),
+    ControllerSubordinateCfg(u8),
+    ControllerSubordinateState(u8),
+    Lanes(u32),
+    Other(DefaultNla),
+}
+
+impl nla::Nla for LinkModeAttr {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::Header(hdrs) => hdrs.as_slice().buffer_len(),
+            Self::Autoneg(_)
+            | Self::Duplex(_)
+            | Self::ControllerSubordinateCfg(_)
+            | Self::ControllerSubordinateState(_) => 1,
+            Self::Ours(_) => {
+                todo!("Does not support changing ethtool link mode yet")
+            }
+            Self::Peer(_) => {
+                todo!("Does not support changing ethtool link mode yet")
+            }
+            Self::Speed(_) | Self::Lanes(_) => 4,
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::Header(_) => ETHTOOL_A_LINKMODES_HEADER | NLA_F_NESTED,
+            Self::Autoneg(_) => ETHTOOL_A_LINKMODES_AUTONEG,
+            Self::Ours(_) => ETHTOOL_A_LINKMODES_OURS,
+            Self::Peer(_) => ETHTOOL_A_LINKMODES_PEER,
+            Self::Speed(_) => ETHTOOL_A_LINKMODES_SPEED,
+            Self::Duplex(_) => ETHTOOL_A_LINKMODES_DUPLEX,
+            Self::ControllerSubordinateCfg(_) => {
+                ETHTOOL_A_LINKMODES_SUBORDINATE_CFG
+            }
+            Self::ControllerSubordinateState(_) => {
+                ETHTOOL_A_LINKMODES_SUBORDINATE_STATE
+            }
+            Self::Lanes(_) => ETHTOOL_A_LINKMODES_LANES,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::Header(ref nlas) => nlas.as_slice().emit(buffer),
+            Self::Other(ref attr) => attr.emit(buffer),
+            _ => todo!("Does not support changing ethtool link mode yet"),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for LinkModeAttr {
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            ETHTOOL_A_LINKMODES_HEADER => {
+                let mut nlas = Vec::new();
+                let error_msg = "failed to parse link_mode header attributes";
+                for nla in NlasIterator::new(payload) {
+                    let nla = &nla.context(error_msg)?;
+                    let parsed =
+                        EthtoolHeader::parse(nla).context(error_msg)?;
+                    nlas.push(parsed);
+                }
+                Self::Header(nlas)
+            }
+            ETHTOOL_A_LINKMODES_AUTONEG => Self::Autoneg(
+                parse_u8(payload)
+                    .context("Invalid ETHTOOL_A_LINKMODES_AUTONEG value")?
+                    == 1,
+            ),
+
+            ETHTOOL_A_LINKMODES_OURS => {
+                Self::Ours(parse_bitset_bits_nlas(payload)?)
+            }
+            ETHTOOL_A_LINKMODES_PEER => {
+                Self::Peer(parse_bitset_bits_nlas(payload)?)
+            }
+            ETHTOOL_A_LINKMODES_SPEED => Self::Speed(
+                parse_u32(payload)
+                    .context("Invalid ETHTOOL_A_LINKMODES_SPEED value")?,
+            ),
+            ETHTOOL_A_LINKMODES_DUPLEX => Self::Duplex(
+                parse_u8(payload)
+                    .context("Invalid ETHTOOL_A_LINKMODES_DUPLEX value")?
+                    .into(),
+            ),
+            ETHTOOL_A_LINKMODES_SUBORDINATE_CFG => {
+                Self::ControllerSubordinateCfg(parse_u8(payload).context(
+                    "Invalid ETHTOOL_A_LINKMODES_SUBORDINATE_CFG value",
+                )?)
+            }
+            ETHTOOL_A_LINKMODES_SUBORDINATE_STATE => {
+                Self::ControllerSubordinateState(parse_u8(payload).context(
+                    "Invalid ETHTOOL_A_LINKMODES_SUBORDINATE_STATE value",
+                )?)
+            }
+            ETHTOOL_A_LINKMODES_LANES => Self::Lanes(
+                parse_u32(payload)
+                    .context("Invalid ETHTOOL_A_LINKMODES_LANES value")?,
+            ),
+            _ => Self::Other(
+                DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?,
+            ),
+        })
+    }
+}
+
+fn parse_bitset_bits_nlas(raw: &[u8]) -> Result<Vec<String>, DecodeError> {
+    let error_msg = "failed to parse mode bit sets";
+    for nla in NlasIterator::new(raw) {
+        let nla = &nla.context(error_msg)?;
+        if nla.kind() == ETHTOOL_A_BITSET_BITS {
+            return parse_bitset_bits_nla(nla.value());
+        }
+    }
+    Err("No ETHTOOL_A_BITSET_BITS NLA found".into())
+}
+
+fn parse_bitset_bits_nla(raw: &[u8]) -> Result<Vec<String>, DecodeError> {
+    let mut modes = Vec::new();
+    let error_msg = "Failed to parse ETHTOOL_A_BITSET_BITS attributes";
+    for bit_nla in NlasIterator::new(raw) {
+        let bit_nla = &bit_nla.context(error_msg)?;
+        match bit_nla.kind() {
+            ETHTOOL_A_BITSET_BITS_BIT => {
+                let error_msg =
+                    "Failed to parse ETHTOOL_A_BITSET_BITS_BIT attributes";
+                let nlas = NlasIterator::new(bit_nla.value());
+                for nla in nlas {
+                    let nla = &nla.context(error_msg)?;
+                    let payload = nla.value();
+                    match nla.kind() {
+                        ETHTOOL_A_BITSET_BIT_INDEX
+                        | ETHTOOL_A_BITSET_BIT_VALUE => {
+                            // ignored
+                            ()
+                        }
+                        ETHTOOL_A_BITSET_BIT_NAME => {
+                            modes.push(parse_string(payload).context(
+                                "Invald ETHTOOL_A_BITSET_BIT_NAME value",
+                            )?);
+                        }
+                        _ => {
+                            warn!(
+                                "Unknown ETHTOOL_A_BITSET_BITS_BIT {} {:?}",
+                                nla.kind(),
+                                nla.value(),
+                            );
+                        }
+                    }
+                }
+            }
+            _ => {
+                warn!(
+                    "Unknown ETHTOOL_A_BITSET_BITS kind {}, {:?}",
+                    bit_nla.kind(),
+                    bit_nla.value()
+                );
+            }
+        };
+    }
+    Ok(modes)
+}

--- a/src/netlink-ethtool/link_mode/get.rs
+++ b/src/netlink-ethtool/link_mode/get.rs
@@ -1,0 +1,53 @@
+use futures::{self, future::Either, FutureExt, StreamExt, TryStream};
+use netlink_packet_core::{
+    NetlinkMessage, NLM_F_ACK, NLM_F_DUMP, NLM_F_REQUEST,
+};
+
+use crate::{try_ethtool, EthtoolError, EthtoolHandle, EthtoolMessage};
+
+pub struct LinkModeGetRequest {
+    handle: EthtoolHandle,
+    iface_name: Option<String>,
+}
+
+impl LinkModeGetRequest {
+    pub(crate) fn new(handle: EthtoolHandle, iface_name: Option<&str>) -> Self {
+        LinkModeGetRequest {
+            handle,
+            iface_name: iface_name.map(|i| i.to_string()),
+        }
+    }
+
+    pub fn execute(
+        self,
+    ) -> impl TryStream<Ok = EthtoolMessage, Error = EthtoolError> {
+        let LinkModeGetRequest {
+            mut handle,
+            iface_name,
+        } = self;
+
+        let nl_header_flags = match iface_name {
+            None => NLM_F_DUMP | NLM_F_REQUEST | NLM_F_ACK,
+            Some(_) => NLM_F_REQUEST,
+        };
+
+        let ethtool_msg = EthtoolMessage::new_link_mode_get(
+            handle.family_id,
+            iface_name.as_deref(),
+        );
+
+        let mut nl_msg = NetlinkMessage::from(ethtool_msg);
+
+        nl_msg.header.flags = nl_header_flags;
+
+        match handle.request(nl_msg) {
+            Ok(response) => {
+                Either::Left(response.map(move |msg| Ok(try_ethtool!(msg))))
+            }
+            Err(e) => Either::Right(
+                futures::future::err::<EthtoolMessage, EthtoolError>(e)
+                    .into_stream(),
+            ),
+        }
+    }
+}

--- a/src/netlink-ethtool/link_mode/handle.rs
+++ b/src/netlink-ethtool/link_mode/handle.rs
@@ -1,0 +1,14 @@
+use crate::{EthtoolHandle, LinkModeGetRequest};
+
+pub struct LinkModeHandle(EthtoolHandle);
+
+impl LinkModeHandle {
+    pub fn new(handle: EthtoolHandle) -> Self {
+        LinkModeHandle(handle)
+    }
+
+    /// Retrieve the ethtool link_modes of a interface (equivalent to `ethtool -k eth1`)
+    pub fn get(&mut self, iface_name: Option<&str>) -> LinkModeGetRequest {
+        LinkModeGetRequest::new(self.0.clone(), iface_name)
+    }
+}

--- a/src/netlink-ethtool/link_mode/mod.rs
+++ b/src/netlink-ethtool/link_mode/mod.rs
@@ -1,0 +1,7 @@
+mod attr;
+mod get;
+mod handle;
+
+pub use attr::{LinkModeAttr, LinkModeDuplex};
+pub use get::LinkModeGetRequest;
+pub use handle::LinkModeHandle;

--- a/src/python/nispor/ethtool.py
+++ b/src/python/nispor/ethtool.py
@@ -35,6 +35,11 @@ class NisporEthtool:
         else:
             self._ring = None
 
+        if "link_mode" in info:
+            self._link_mode = NisporEthtoolLinkMode(info["link_mode"])
+        else:
+            self._link_mode = None
+
     @property
     def pause(self):
         return self._pause
@@ -51,6 +56,9 @@ class NisporEthtool:
     def ring(self):
         return self._ring
 
+    @property
+    def link_mode(self):
+        return self._link_mode
 
 class NisporEthtoolPause:
     def __init__(self, info):
@@ -210,3 +218,40 @@ class NisporEthtoolRing:
     @property
     def tx_max(self):
         return self._info.get("tx_max")
+
+
+class NisporEthtoolLinkMode:
+    def __init__(self, info):
+        self._info = info
+
+    @property
+    def auto_negotiate(self):
+        return self._info["auto_negotiate"]
+
+    @property
+    def ours(self):
+        return self._info["ours"]
+
+    @property
+    def peer(self):
+        return self._info.get("peer")
+
+    @property
+    def speed(self):
+        return self._info["speed"]
+
+    @property
+    def duplex(self):
+        return self._info["duplex"]
+
+    @property
+    def controller_subordinate_cfg(self):
+        return self._info.get("controller_subordinate_cfg")
+
+    @property
+    def controller_subordinate_state(self):
+        return self._info.get("controller_subordinate_state")
+
+    @property
+    def lanes(self):
+        return self._info.get("lanes")

--- a/tools/test_env
+++ b/tools/test_env
@@ -52,7 +52,9 @@ function create_netdevsim_nic {
     sudo modprobe netdevsim
     echo '1 2' | sudo tee /sys/bus/netdevsim/new_device
     sleep 5
+    sudo ip link set eni1np1 down
     sudo ip link set eni1np1 name sim0
+    sudo ip link set eni1np2 down
     sudo ip link set eni1np2 name sim1
     sudo ip link set sim0 address $TEST_MAC_SIM0
     sudo ip link set sim1 address $TEST_MAC_SIM1


### PR DESCRIPTION
```yaml
  link_mode:
    auto_negotiate: false
    ours:
      - FIBRE
      - 10000baseT/Full
      - Pause
    speed: 10000
    duplex: full
```

Python binding also updated. Test case updated to use TUN for link mode,
disabled as CI does not support it.