### PR TITLE
npc: Show brief network state when no argument

### DIFF
--- a/src/lib/ifaces/iface.rs
+++ b/src/lib/ifaces/iface.rs
@@ -102,6 +102,23 @@ impl Default for IfaceState {
     }
 }
 
+impl std::fmt::Display for IfaceState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Up => "up",
+                Self::Dormant => "dormant",
+                Self::Down => "down",
+                Self::LowerLayerDown => "lower_layer_down",
+                Self::Other(s) => s.as_str(),
+                Self::Unknown => "unknown",
+            }
+        )
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum IfaceFlags {


### PR DESCRIPTION
When running `npc` without any argument, instead of dumping all
information, this patch changed to show brief network status.

Added new sub command `iface` to `npc` for old behaviour:

    * `npc eth1` -- show eth1 interface info.
    * `npc iface eth1` -- the same as `npc eth1`.
    * `npc iface` -- show full information in yaml format.
    * `npc` -- show brief network state.
    * `npc --json` -- show brief network state in json format.

Example on running `npc` without argument:

```
1: lo: <LOOPBACK,LOWERUP,RUNNING,UP> state unknown mtu 65536
    mac 00:00:00:00:00:00
    ipv4 127.0.0.1/8
    ipv6 ::1/128
2: eth1: <BROADCAST,LOWERUP,MULTICAST,RUNNING,UP> state up mtu 1500
    mac 00:01:02:03:04:05
    ipv4 192.0.2.6/24 gw4 192.0.2.1
    ipv6 2001:db8::6/64 fe80::6/64 gw6 fe80::1
```

This patch contains many memory copy done by `to_string()`, `clone()`,
`to_vec()`. We can improve it in future if that cause any problem.