### PR TITLE
New release 1.1.1

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [build]
-rustflags = "-Clink-arg=-Wl,-soname=libnispor.so.1.1.0"
+rustflags = "-Clink-arg=-Wl,-soname=libnispor.so.1.1.1"
 
 [target.x86_64-unknown-linux-gnu]
 runner = 'sudo -E'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,14 @@
 # Changelog
+## [1.1.1] - 2021-06-19
+## Break changes
+ * Running `npc` command without argument will only show bridge network
+   information. (69cc9aa)
+
+### Bug fixes
+ * Fix ethool feature on tx-lockless which is always unchangable. (235458b)
+ * Fix detection of loopback interface type. (11eb434)
+ * Remove the use of `unwrap()` in ethtool code. (6ea512e)
+
 ## [1.1.0] - 2021-05-14
 ### New features
  * Support ethtool link mode. (c23e7b5)

--- a/DEVEL.md
+++ b/DEVEL.md
@@ -59,12 +59,12 @@ autocmd FileType rust nnoremap <silent> <leader>f :RustFmt<cr>
 ## Release workflow
 
 ```bash
-sed -i -e 's/1.1.0/1.1.1/' \
+sed -i -e 's/1.1.1/1.1.2/' \
     Makefile.inc src/*/Cargo.toml src/python/setup.py .cargo/config.toml
 ```
 
 ```bash
-git log --oneline v1.0.1..HEAD
+git log --oneline v1.1.0..HEAD
 ```
 
 [rust-vim]: https://github.com/rust-lang/rust.vim

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,4 +1,4 @@
-CLIB_VERSION=1.1.0
+CLIB_VERSION=1.1.1
 CLIB_VERSION_MAJOR=$(shell echo $(CLIB_VERSION) | cut -f1 -d.)
 CLIB_VERSION_MINOR=$(shell echo $(CLIB_VERSION) | cut -f2 -d.)
 CLIB_VERSION_MICRO=$(shell echo $(CLIB_VERSION) | cut -f3 -d.)

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nispor-cli"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Gris Ge <fge@redhat.com>"]
 edition = "2018"
 

--- a/src/clib/Cargo.toml
+++ b/src/clib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nispor-clib"
 description = "Nispor C binding"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nispor"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2018"
@@ -24,7 +24,7 @@ netlink-sys = "0.6"
 netlink-packet-utils = "0.4"
 netlink-ethtool = {path ="../netlink-ethtool"}
 netlink-generic = {path ="../netlink-generic"}
-tokio = { version = "1.1.0", features = ["macros", "rt"] }
+tokio = { version = "1.1.1", features = ["macros", "rt"] }
 futures = "0.3"
 libc = "0.2.74"
 

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="nispor",
-    version="1.1.0",
+    version="1.1.1",
     author="Gris Ge",
     author_email="fge@redhat.com",
     description="Python binding of Nispor",


### PR DESCRIPTION
* Break changes
    * Running `npc` command without argument will only show bridge network
   information. (69cc9aa)

* Bug fixes
    * Fix ethool feature on tx-lockless which is always unchangable. (235458b)
    * Fix detection of loopback interface type. (11eb434)
    * Remove the use of `unwrap()` in ethtool code. (6ea512e)