### PR TITLE
link: Support link up/down

### DIFF
--- a/src/cli/examples/veth1_static_ip.yml
+++ b/src/cli/examples/veth1_static_ip.yml
@@ -12,3 +12,5 @@ ifaces:
       addresses:
         - address: "2001:db8:a::9"
           prefix_len: 64
+  - name: veth1.ep
+    type: veth

--- a/src/lib/net_conf.rs
+++ b/src/lib/net_conf.rs
@@ -36,13 +36,14 @@ impl NetConf {
             let mut chg_ifaces = Vec::new();
             for iface in ifaces {
                 let cur_iface_index = cur_iface_name_2_index.get(&iface.name);
-                if iface.state == Some(IfaceState::Absent) {
+                if iface.state == IfaceState::Absent {
                     if let Some(cur_iface_index) = cur_iface_index {
                         del_ifaces
                             .push((iface.name.as_str(), *cur_iface_index));
                     }
                 } else if cur_iface_index == None {
                     new_ifaces.push(iface);
+                    chg_ifaces.push(iface);
                 } else {
                     chg_ifaces.push(iface);
                 }

--- a/src/lib/tests/veth.rs
+++ b/src/lib/tests/veth.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use nispor::{NetConf, NetState};
+use nispor::{IfaceState, NetConf, NetState};
 use pretty_assertions::assert_eq;
 use serde_yaml;
 use std::panic;
@@ -58,7 +58,15 @@ ifaces:
     type: veth
     mac_address: 00:23:45:67:89:1a
     veth:
-      peer: veth1.ep"#;
+      peer: veth1.ep
+  - name: veth1.ep
+    type: veth"#;
+
+const VETH_DOWN_YML: &str = r#"---
+ifaces:
+  - name: veth1
+    type: veth
+    state: down"#;
 
 const VETH_DELETE_YML: &str = r#"---
 ifaces:
@@ -67,13 +75,20 @@ ifaces:
     state: absent"#;
 
 #[test]
-fn test_create_delete_veth() {
+fn test_create_down_delete_veth() {
     let net_conf: NetConf = serde_yaml::from_str(VETH_CREATE_YML).unwrap();
     net_conf.apply().unwrap();
     let state = NetState::retrieve().unwrap();
     let iface = &state.ifaces[IFACE_NAME];
     assert_eq!(&iface.iface_type, &nispor::IfaceType::Veth);
     assert_eq!(iface.veth.as_ref().unwrap().peer, "veth1.ep");
+    assert_eq!(iface.state, IfaceState::Up);
+
+    let net_conf: NetConf = serde_yaml::from_str(VETH_DOWN_YML).unwrap();
+    net_conf.apply().unwrap();
+    let state = NetState::retrieve().unwrap();
+    let iface = &state.ifaces[IFACE_NAME];
+    assert_eq!(iface.state, IfaceState::Down);
 
     let net_conf: NetConf = serde_yaml::from_str(VETH_DELETE_YML).unwrap();
     net_conf.apply().unwrap();


### PR DESCRIPTION
By default, NetConf assume `IfaceState::Up`. You may bring a interface down
using `IfaceState::Down`. This is example for `npc set`:

```yml
---
ifaces:
  - name: veth1
    state: down
```

Integration test case included.