### PR TITLE
controller: Support changing controller

### DIFF
--- a/src/cli/examples/bond0_up.yml
+++ b/src/cli/examples/bond0_up.yml
@@ -2,3 +2,11 @@
 ifaces:
   - name: bond0
     type: bond
+  - name: veth1
+    type: veth
+    controller: bond0
+    veth:
+      peer: veth1.ep
+  - name: veth1.ep
+    type: veth
+    state: up

--- a/src/lib/ifaces/iface.rs
+++ b/src/lib/ifaces/iface.rs
@@ -489,6 +489,7 @@ pub struct IfaceConf {
     pub state: IfaceState,
     #[serde(rename = "type")]
     pub iface_type: Option<IfaceType>,
+    pub controller: Option<String>,
     pub ipv4: Option<IpConf>,
     pub ipv6: Option<IpConf>,
     pub veth: Option<VethConf>,


### PR DESCRIPTION
Example of npc yaml:

```yml
---
ifaces:
 - name: bond0
   type: bond
 - name: veth1
   type: veth
   controller: bond0
   veth:
     peer: veth1.ep
```

Not mentioned controller means detach from controller.

Integration test case updated to test bond port attach and detach.