### PR TITLE
vlan: Support creating VLAN

### DIFF
--- a/src/cli/examples/vlan0_up.yml
+++ b/src/cli/examples/vlan0_up.yml
@@ -1,0 +1,7 @@
+---
+ifaces:
+  - name: vlan0
+    type: vlan
+    vlan:
+      base_iface: eth1
+      vlan_id: 99

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -18,8 +18,8 @@ crate-type = ["lib"]
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-rtnetlink = "0.8"
-netlink-packet-route = "0.7.1"
+rtnetlink = "0.8.1"
+netlink-packet-route = "0.8.0"
 netlink-sys = "0.7"
 netlink-packet-utils = "0.4.1"
 ethtool = "0.1"

--- a/src/lib/ifaces/iface.rs
+++ b/src/lib/ifaces/iface.rs
@@ -29,7 +29,7 @@ use crate::{
         sriov::{get_sriov_info, SriovInfo},
         tun::{get_tun_info, TunInfo},
         veth::{VethConf, VethInfo},
-        vlan::{get_vlan_info, VlanInfo},
+        vlan::{get_vlan_info, VlanConf, VlanInfo},
         vrf::{
             get_vrf_info, get_vrf_subordinate_info, VrfInfo, VrfSubordinateInfo,
         },
@@ -495,6 +495,7 @@ pub struct IfaceConf {
     pub mac_address: Option<String>,
     pub veth: Option<VethConf>,
     pub bridge: Option<BridgeConf>,
+    pub vlan: Option<VlanConf>,
 }
 
 impl IfaceConf {

--- a/src/lib/ifaces/vlan.rs
+++ b/src/lib/ifaces/vlan.rs
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::Iface;
-use crate::IfaceType;
-use netlink_packet_route::rtnl::link::nlas::InfoData;
-use netlink_packet_route::rtnl::link::nlas::InfoVlan;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+
+use netlink_packet_route::rtnl::link::nlas::{InfoData, InfoVlan};
+use rtnetlink::Handle;
+use serde::{Deserialize, Serialize};
+
+use crate::{Iface, IfaceType, NisporError};
 
 const ETH_P_8021Q: u16 = 0x8100;
 const ETH_P_8021AD: u16 = 0x88A8;
@@ -120,6 +121,35 @@ fn convert_base_iface_index_to_name(iface_states: &mut HashMap<String, Iface>) {
             {
                 vlan_info.base_iface = base_iface_name.clone();
             }
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+pub struct VlanConf {
+    pub vlan_id: u16,
+    pub base_iface: String,
+}
+
+impl VlanConf {
+    pub(crate) async fn create(
+        handle: &Handle,
+        name: &str,
+        vlan_id: u16,
+        base_iface_index: u32,
+    ) -> Result<(), NisporError> {
+        match handle
+            .link()
+            .add()
+            .vlan(name.to_string(), base_iface_index, vlan_id)
+            .execute()
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(e) => Err(NisporError::bug(format!(
+                "Failed to create new vlan '{}': {}",
+                &name, e
+            ))),
         }
     }
 }

--- a/src/lib/net_conf.rs
+++ b/src/lib/net_conf.rs
@@ -29,8 +29,8 @@ pub struct NetConf {
 impl NetConf {
     pub fn apply(&self) -> Result<(), NisporError> {
         let rt = runtime::Builder::new_current_thread().enable_io().build()?;
-        let cur_iface_name_2_index = rt.block_on(get_iface_name2index())?;
         if let Some(ref ifaces) = &self.ifaces {
+            let cur_iface_name_2_index = rt.block_on(get_iface_name2index())?;
             let mut new_ifaces = Vec::new();
             let mut del_ifaces = Vec::new();
             let mut chg_ifaces = Vec::new();
@@ -49,7 +49,7 @@ impl NetConf {
                 }
             }
             rt.block_on(delete_ifaces(&del_ifaces))?;
-            rt.block_on(create_ifaces(&new_ifaces))?;
+            rt.block_on(create_ifaces(&new_ifaces, &cur_iface_name_2_index))?;
 
             let cur_ifaces = rt.block_on(get_ifaces())?;
             rt.block_on(change_ifaces(&chg_ifaces, &cur_ifaces))?;


### PR DESCRIPTION
Example of npc yaml:

```yml
---
ifaces:
  - name: vlan0
    type: vlan
    vlan:
      base_iface: eth1
      vlan_id: 99
```

For performance and complexity concern, the base interface should be
created beforehand, nispor will fail if otherwise.

Integration test case included.