### PR TITLE
lib: update libc, netlink and tokio dependencies

### DIFF
--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -18,15 +18,15 @@ crate-type = ["lib"]
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-rtnetlink = "0.7"
-netlink-packet-route = "0.7"
-netlink-sys = "0.6"
-netlink-packet-utils = "0.4"
+rtnetlink = "0.8"
+netlink-packet-route = "0.7.1"
+netlink-sys = "0.7"
+netlink-packet-utils = "0.4.1"
 netlink-ethtool = {path ="../netlink-ethtool"}
 netlink-generic = {path ="../netlink-generic"}
-tokio = { version = "1.1.1", features = ["macros", "rt"] }
+tokio = { version = "1.9.0", features = ["macros", "rt"] }
 futures = "0.3"
-libc = "0.2.74"
+libc = "0.2.99"
 
 [dev-dependencies]
 serde_yaml = "0.8"


### PR DESCRIPTION
The dependencies are being updated in order to do the packaging in
Fedora.

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>