### PR TITLE
Enable logging

### DIFF
--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -15,3 +15,5 @@ serde_derive = "1.0"
 clap = "2.33.3"
 nispor = { path = "../lib" }
 serde_yaml = "0.8"
+env_logger = "0.9.0"
+log = "0.4.14"

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -27,6 +27,7 @@ netlink-generic = {path ="../netlink-generic"}
 tokio = { version = "1.9.0", features = ["macros", "rt"] }
 futures = "0.3"
 libc = "0.2.99"
+log = "0.4.14"
 
 [dev-dependencies]
 serde_yaml = "0.8"

--- a/src/lib/ifaces/ethtool.rs
+++ b/src/lib/ifaces/ethtool.rs
@@ -464,7 +464,7 @@ async fn dump_coalesce_infos(
                     CoalesceAttr::RateSampleInterval(d) => {
                         coalesce_info.rate_sample_interval = Some(d)
                     }
-                    _ => eprintln!("WARN: Unsupported CoalesceAttr {:?}", nla),
+                    _ => log::warn!("WARN: Unsupported CoalesceAttr {:?}", nla),
                 }
             }
             if let Some(i) = iface_name {
@@ -498,7 +498,7 @@ async fn dump_ring_infos(
                     RingAttr::RxMini(d) => ring_info.rx_mini = Some(d),
                     RingAttr::RxJumbo(d) => ring_info.rx_jumbo = Some(d),
                     RingAttr::Tx(d) => ring_info.tx = Some(d),
-                    _ => eprintln!("WARN: Unsupported RingAttr {:?}", nla),
+                    _ => log::warn!("WARN: Unsupported RingAttr {:?}", nla),
                 }
             }
             if let Some(i) = iface_name {
@@ -542,7 +542,7 @@ async fn dump_link_mode_infos(
                     }
                     LinkModeAttr::Lanes(d) => link_mode_info.lanes = Some(d),
 
-                    _ => eprintln!("WARN: Unsupported LinkModeAttr {:?}", nla),
+                    _ => log::warn!("WARN: Unsupported LinkModeAttr {:?}", nla),
                 }
             }
             if let Some(i) = iface_name {

--- a/src/lib/ifaces/iface.rs
+++ b/src/lib/ifaces/iface.rs
@@ -297,7 +297,7 @@ pub(crate) fn parse_nl_msg_to_iface(
                                 iface_state.tun = Some(info);
                             }
                             Err(e) => {
-                                eprintln!("Error parsing TUN info: {}", e);
+                                log::warn!("Error parsing TUN info: {}", e);
                             }
                         },
                         IfaceType::Vlan => iface_state.vlan = get_vlan_info(d),
@@ -311,7 +311,7 @@ pub(crate) fn parse_nl_msg_to_iface(
                         IfaceType::MacVtap => {
                             iface_state.mac_vtap = get_mac_vtap_info(d)?
                         }
-                        _ => eprintln!(
+                        _ => log::warn!(
                             "Unhandled IFLA_INFO_DATA for iface type {:?}",
                             iface_state.iface_type
                         ),
@@ -344,7 +344,7 @@ pub(crate) fn parse_nl_msg_to_iface(
                                 iface_state.vrf_subordinate =
                                     get_vrf_subordinate_info(d)?;
                             }
-                            _ => eprintln!(
+                            _ => log::warn!(
                                 "Unknown controller type {:?}",
                                 controller_type
                             ),
@@ -498,7 +498,7 @@ pub struct IfaceConf {
 
 impl IfaceConf {
     pub async fn apply(&self, cur_iface: &Iface) -> Result<(), NisporError> {
-        eprintln!(
+        log::warn!(
             "WARN: IfaceConf::apply() is deprecated, \
             please use NetConf::apply() instead"
         );

--- a/src/lib/ifaces/mac_vlan.rs
+++ b/src/lib/ifaces/mac_vlan.rs
@@ -95,7 +95,7 @@ pub(crate) fn get_mac_vlan_info(
                 }
                 macv_info.allowed_mac_addresses = Some(addrs);
             } else {
-                eprintln!("Unknown MAC VLAN info {:?}", info)
+                log::warn!("Unknown MAC VLAN info {:?}", info)
             }
         }
         Ok(Some(macv_info))
@@ -114,7 +114,7 @@ pub(crate) fn get_mac_vlan_info(
                 }
                 macv_info.allowed_mac_addresses = Some(addrs);
             } else {
-                eprintln!("Unknown MAC VTAP info {:?}", info)
+                log::warn!("Unknown MAC VTAP info {:?}", info)
             }
         }
         Ok(Some(macv_info))

--- a/src/lib/ifaces/mod.rs
+++ b/src/lib/ifaces/mod.rs
@@ -97,7 +97,7 @@ pub(crate) async fn get_ifaces() -> Result<HashMap<String, Iface>, NisporError>
         }
         Err(e) => {
             // Ethtool is considered as optional
-            eprintln!("Failed to query ethtool info: {}", e);
+            log::warn!("Failed to query ethtool info: {}", e);
         }
     };
 

--- a/src/lib/ifaces/sriov.rs
+++ b/src/lib/ifaces/sriov.rs
@@ -215,7 +215,7 @@ pub(crate) fn get_sriov_info(
                     vf_info.broadcast = parse_vf_mac(nla.value(), mac_len)?;
                 }
                 _ => {
-                    eprintln!(
+                    log::warn!(
                         "Unhandled SRIOV NLA {} {:?}",
                         nla.kind(),
                         nla.value()
@@ -268,7 +268,7 @@ fn parse_vf_stats(raw: &[u8]) -> Result<VfState, NisporError> {
             IFLA_VF_STATS_TX_DROPPED => {
                 state.tx_dropped = parse_as_u64(nla.value())?;
             }
-            _ => eprintln!(
+            _ => log::warn!(
                 "Unhandled IFLA_VF_STATS {}, {:?}",
                 nla.kind(),
                 nla.value()

--- a/src/lib/ifaces/tun.rs
+++ b/src/lib/ifaces/tun.rs
@@ -69,7 +69,7 @@ impl From<u8> for TunMode {
             IFF_TUN => TunMode::Tun,
             IFF_TAP => TunMode::Tap,
             _ => {
-                eprintln!("Unhandled TUN mode {}", d);
+                log::warn!("Unhandled TUN mode {}", d);
                 TunMode::Unknown
             }
         }
@@ -112,7 +112,7 @@ pub(crate) fn get_tun_info(data: &InfoData) -> Result<TunInfo, NisporError> {
                         Some(parse_as_u32(nla.value())?);
                 }
                 _ => {
-                    eprintln!(
+                    log::warn!(
                         "Unhandled TUN NLA {} {:?}",
                         nla.kind(),
                         nla.value()

--- a/src/lib/ifaces/vlan.rs
+++ b/src/lib/ifaces/vlan.rs
@@ -92,7 +92,7 @@ pub(crate) fn get_vlan_info(data: &InfoData) -> Option<VlanInfo> {
                     vlan_info.is_bridge_binding = true
                 }
             } else {
-                eprintln!("Unknown VLAN info: {:?}", info);
+                log::warn!("Unknown VLAN info: {:?}", info);
             }
         }
         Some(vlan_info)

--- a/src/lib/ifaces/vrf.rs
+++ b/src/lib/ifaces/vrf.rs
@@ -42,7 +42,7 @@ pub(crate) fn get_vrf_info(data: &InfoData) -> Option<VrfInfo> {
             if let InfoVrf::TableId(d) = *info {
                 vrf_info.table_id = d;
             } else {
-                eprintln!("Unknown VRF info {:?}", info)
+                log::warn!("Unknown VRF info {:?}", info)
             }
         }
         Some(vrf_info)

--- a/src/lib/ifaces/vxlan.rs
+++ b/src/lib/ifaces/vxlan.rs
@@ -118,7 +118,7 @@ pub(crate) fn get_vxlan_info(
             } else if let InfoVxlan::Df(d) = *info {
                 vxlan_info.df = d;
             } else {
-                eprintln!("Unknown VXLAN info {:?}", info)
+                log::warn!("Unknown VXLAN info {:?}", info)
             }
         }
         Ok(Some(vxlan_info))

--- a/src/lib/ip.rs
+++ b/src/lib/ip.rs
@@ -113,7 +113,7 @@ impl IpConf {
         cur_iface: &Iface,
         family: IpFamily,
     ) -> Result<(), NisporError> {
-        eprintln!("WARN: Deprecated, please use NetConf::apply() instead");
+        log::warn!("WARN: Deprecated, please use NetConf::apply() instead");
         let iface = match family {
             IpFamily::Ipv4 => IfaceConf {
                 ipv4: Some(self.clone()),

--- a/src/lib/netlink/bond.rs
+++ b/src/lib/netlink/bond.rs
@@ -37,7 +37,7 @@ fn parse_as_nested_ipv4_addr(raw: &[u8]) -> Vec<Ipv4Addr> {
         match nla {
             Ok(nla) => addresses.push(parse_as_ipv4(nla.value())),
             Err(e) => {
-                eprintln!("{}", e);
+                log::warn!("{}", e);
             }
         }
     }
@@ -92,7 +92,7 @@ fn parse_ad_info(raw: &[u8]) -> Result<BondAdInfo, NisporError> {
                     ad_info.partner_mac = parse_as_48_bits_mac(nla.value())?;
                 }
                 _ => {
-                    eprintln!(
+                    log::warn!(
                         "unknown nla kind {} value: {:?}",
                         nla.kind(),
                         nla.value()
@@ -100,7 +100,7 @@ fn parse_ad_info(raw: &[u8]) -> Result<BondAdInfo, NisporError> {
                 }
             },
             Err(e) => {
-                eprintln!("{}", e);
+                log::warn!("{}", e);
             }
         }
     }
@@ -117,11 +117,11 @@ fn get_bond_mode(raw: &[u8]) -> Result<BondMode, NisporError> {
                 }
             }
             Err(e) => {
-                eprintln!("{}", e);
+                log::warn!("{}", e);
             }
         }
     }
-    eprintln!("Failed to parse bond mode from NLAS: {:?}", nlas);
+    log::warn!("Failed to parse bond mode from NLAS: {:?}", nlas);
     Ok(BondMode::Unknown)
 }
 
@@ -439,7 +439,7 @@ pub(crate) fn parse_bond_info(raw: &[u8]) -> Result<BondInfo, NisporError> {
                 } else if nla.kind() == IFLA_BOND_AD_INFO {
                     bond_info.ad_info = Some(parse_ad_info(nla.value())?);
                 } else {
-                    eprintln!(
+                    log::warn!(
                         "Failed to parse IFLA_LINKINFO for bond: {:?} {:?}",
                         nla.kind(),
                         nla.value()
@@ -447,7 +447,7 @@ pub(crate) fn parse_bond_info(raw: &[u8]) -> Result<BondInfo, NisporError> {
                 }
             }
             Err(e) => {
-                eprintln!("Failed to parse IFLA_LINKINFO {:?}", e);
+                log::warn!("Failed to parse IFLA_LINKINFO {:?}", e);
             }
         }
     }
@@ -505,7 +505,7 @@ pub(crate) fn parse_bond_subordinate_info(
                         Some(parse_as_u16(nla.value())?);
                 }
                 _ => {
-                    eprintln!(
+                    log::warn!(
                         "unknown nla kind {} value: {:?}",
                         nla.kind(),
                         nla.value()
@@ -513,7 +513,7 @@ pub(crate) fn parse_bond_subordinate_info(
                 }
             },
             Err(e) => {
-                eprintln!("{}", e);
+                log::warn!("{}", e);
             }
         }
     }

--- a/src/lib/netlink/bridge.rs
+++ b/src/lib/netlink/bridge.rs
@@ -115,7 +115,7 @@ pub(crate) fn parse_bridge_info(
         } else if let InfoBridge::MultiBoolOpt(d) = info {
             bridge_info.multi_bool_opt = Some(*d);
         } else {
-            eprintln!("Unknown NLA {:?}", &info);
+            log::warn!("Unknown NLA {:?}", &info);
         }
     }
     Ok(bridge_info)

--- a/src/lib/netlink/bridge_port.rs
+++ b/src/lib/netlink/bridge_port.rs
@@ -373,7 +373,7 @@ pub(crate) fn parse_bridge_port_info(
                 {
                     func(nla.value(), &mut port_info)?;
                 } else {
-                    eprintln!(
+                    log::warn!(
                         "Unhandled BRIDGE_PORT_INFO {} {:?}",
                         nla.kind(),
                         nla.value()
@@ -381,7 +381,7 @@ pub(crate) fn parse_bridge_port_info(
                 }
             }
             Err(e) => {
-                eprintln!("{}", e);
+                log::warn!("{}", e);
             }
         }
     }

--- a/src/lib/netlink/bridge_vlan.rs
+++ b/src/lib/netlink/bridge_vlan.rs
@@ -44,14 +44,14 @@ pub(crate) fn parse_af_spec_bridge_info(
                     }
                 }
                 _ => {
-                    eprintln!(
+                    log::warn!(
                         "Unhandled AF_SPEC_BRIDGE_INFO: {} {:?}",
                         nla.kind(),
                         nla.value()
                     );
                 }
             },
-            Err(e) => eprintln!("{}", e),
+            Err(e) => log::warn!("{}", e),
         }
     }
     if !vlans.is_empty() {
@@ -100,7 +100,7 @@ fn parse_vlan_info(
         entry.is_range_end = (flags & BRIDGE_VLAN_INFO_RANGE_END) > 0;
         Ok(Some(entry))
     } else {
-        eprintln!(
+        log::warn!(
             "Invalid kernel bridge vlan info: {:?}, should be [u8;4]",
             data
         );
@@ -128,7 +128,7 @@ fn merge_vlan_range(
                         is_egress_untagged: k_vlan.is_egress_untagged,
                     })
                 } else {
-                    eprintln!(
+                    log::warn!(
                         "Invalid kernel bridge vlan information: \
                         missing start VLAN for {}",
                         k_vlan.vid

--- a/src/lib/netlink/ip.rs
+++ b/src/lib/netlink/ip.rs
@@ -73,9 +73,10 @@ pub(crate) fn fill_ip_addr(
             }
         }
         _ => {
-            eprintln!(
+            log::warn!(
                 "unknown address family {} {:?}",
-                nl_msg.header.family, nl_msg
+                nl_msg.header.family,
+                nl_msg
             );
         }
     };
@@ -209,9 +210,10 @@ pub(crate) fn get_ip_addr(nl_addr_msg: &AddressMessage) -> String {
             }
         }
         _ => {
-            eprintln!(
+            log::warn!(
                 "unknown address family {} {:?}",
-                nl_addr_msg.header.family, nl_addr_msg
+                nl_addr_msg.header.family,
+                nl_addr_msg
             );
         }
     }

--- a/src/lib/route.rs
+++ b/src/lib/route.rs
@@ -510,7 +510,7 @@ fn get_route(
                             rt.fastopen_no_cookie = Some(d);
                         }
                         _ => {
-                            eprintln!(
+                            log::warn!(
                                 "Unknown RTA_METRICS message {:?}",
                                 metric
                             );
@@ -573,14 +573,14 @@ fn get_route(
                         RTA_VIA => {
                             // Kernel will use RTA_VIA when gateway family does
                             // not match nexthop family
-                            eprintln!(
+                            log::warn!(
                                 "dual stack(RTA_VIA) multipath route next hop
                                  is not supported by nispor yet"
                             );
                             continue;
                         }
                         _ => {
-                            eprintln!(
+                            log::warn!(
                                 "Got unexpected RTA_MULTIPATH NLA {} {:?}",
                                 nla.kind(),
                                 nla.value()
@@ -638,7 +638,7 @@ fn get_route(
             Nla::Pref(d) => {
                 rt.perf = Some(d[0]);
             }
-            _ => eprintln!("Unknown NLA message for route {:?}", nla),
+            _ => log::warn!("Unknown NLA message for route {:?}", nla),
         }
     }
 

--- a/src/lib/route_rule.rs
+++ b/src/lib/route_rule.rs
@@ -211,7 +211,7 @@ fn get_rule(rule_msg: RuleMessage) -> Result<RouteRule, NisporError> {
             Nla::L3MDev(ref d) => {
                 rl.l3mdev = Some(*d > 0);
             }
-            _ => eprintln!("Unknown NLA message for route rule {:?}", nla),
+            _ => log::warn!("Unknown NLA message for route rule {:?}", nla),
         }
     }
 


### PR DESCRIPTION
The library only use `log` crate to define the logging abstracts.
User should chose their actual logging implementation if they would like
to enable the logging.

The command tool `npc` use `env_logger` as logging implementation. By
default `npc` will only show warning+ message from nmstate.

    * `npc -v` show info+ message from nmstate.
    * `npc -vv` show debug+ message from nmstate.
    * `npc -vvv` show debug+ message from all sources.