### PR TITLE
mac: Support changing MAC address

### DIFF
--- a/src/cli/examples/veth1_static_ip.yml
+++ b/src/cli/examples/veth1_static_ip.yml
@@ -2,6 +2,7 @@
 ifaces:
   - name: veth1
     type: veth
+    mac_address: "00:02:03:04:05:06"
     veth:
       peer: veth1.ep
     ipv4:

--- a/src/lib/mac.rs
+++ b/src/lib/mac.rs
@@ -32,3 +32,27 @@ pub(crate) fn parse_as_mac(
     }
     Ok(rt)
 }
+
+pub(crate) fn mac_str_to_raw(mac_addr: &str) -> Result<Vec<u8>, NisporError> {
+    let mac_addr = mac_addr.to_string().replace(":", "").replace("-", "");
+
+    let mut mac_raw: Vec<u8> = Vec::new();
+
+    let mac_addr = mac_addr.replace(":", "");
+    let mut chars = mac_addr.chars().peekable();
+
+    while chars.peek().is_some() {
+        let chunk: String = chars.by_ref().take(2).collect();
+        match u8::from_str_radix(&chunk, 16) {
+            Ok(i) => mac_raw.push(i),
+            Err(e) => {
+                return Err(NisporError::invalid_argument(format!(
+                    "Invalid hex string for MAC address {}: {}",
+                    mac_addr, e
+                )));
+            }
+        }
+    }
+
+    Ok(mac_raw)
+}

--- a/src/lib/tests/veth.rs
+++ b/src/lib/tests/veth.rs
@@ -83,6 +83,7 @@ fn test_create_down_delete_veth() {
     assert_eq!(&iface.iface_type, &nispor::IfaceType::Veth);
     assert_eq!(iface.veth.as_ref().unwrap().peer, "veth1.ep");
     assert_eq!(iface.state, IfaceState::Up);
+    assert_eq!(iface.mac_address, "00:23:45:67:89:1a".to_string());
 
     let net_conf: NetConf = serde_yaml::from_str(VETH_DOWN_YML).unwrap();
     net_conf.apply().unwrap();


### PR DESCRIPTION
Example on changing MAC address of interface:

```yml
---
ifaces:
  - name: veth1
    type: veth
    mac_address: "00:02:03:04:05:06"
    veth:
      peer: veth1.ep
```

Test case updated to assert desired MAC applied.