### PR TITLE
mac: Restore the interface state after MAC changed

### DIFF
--- a/src/lib/ifaces/mod.rs
+++ b/src/lib/ifaces/mod.rs
@@ -305,7 +305,17 @@ async fn change_ifaces_mac(
     for iface in ifaces {
         if let Some(mac_addr) = &iface.mac_address {
             if let Some(cur_iface) = cur_ifaces.get(&iface.name) {
+                if cur_iface.state != IfaceState::Down {
+                    // We can only change MAC address when link down
+                    change_iface_state(handle, cur_iface.index, false).await?;
+                }
                 change_iface_mac(handle, cur_iface.index, mac_addr).await?;
+                if cur_iface.state == IfaceState::Up
+                    && iface.state == IfaceState::Up
+                {
+                    // Restore the interface state
+                    change_iface_state(handle, cur_iface.index, true).await?;
+                }
             }
         }
     }

--- a/src/lib/tests/veth.rs
+++ b/src/lib/tests/veth.rs
@@ -62,6 +62,12 @@ ifaces:
   - name: veth1.ep
     type: veth"#;
 
+const VETH_CHANGE_MAC_YML: &str = r#"---
+ifaces:
+  - name: veth1
+    type: veth
+    mac_address: 00:23:45:67:89:2a"#;
+
 const VETH_DOWN_YML: &str = r#"---
 ifaces:
   - name: veth1
@@ -84,6 +90,14 @@ fn test_create_down_delete_veth() {
     assert_eq!(iface.veth.as_ref().unwrap().peer, "veth1.ep");
     assert_eq!(iface.state, IfaceState::Up);
     assert_eq!(iface.mac_address, "00:23:45:67:89:1a".to_string());
+
+    // Change the MAC should have the interface as UP state
+    let net_conf: NetConf = serde_yaml::from_str(VETH_CHANGE_MAC_YML).unwrap();
+    net_conf.apply().unwrap();
+    let state = NetState::retrieve().unwrap();
+    let iface = &state.ifaces[IFACE_NAME];
+    assert_eq!(iface.state, IfaceState::Up);
+    assert_eq!(iface.mac_address, "00:23:45:67:89:2a".to_string());
 
     let net_conf: NetConf = serde_yaml::from_str(VETH_DOWN_YML).unwrap();
     net_conf.apply().unwrap();


### PR DESCRIPTION
It is required to bring down the interface before changing MAC address,
we should restore the previous UP state after MAC changed.

Test case updated for this use case.