### PR TITLE
CHANGELOG: New release 1.2.0

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [build]
-rustflags = "-Clink-arg=-Wl,-soname=libnispor.so.1.1.1"
+rustflags = "-Clink-arg=-Wl,-soname=libnispor.so.1.2.0"
 
 [target.x86_64-unknown-linux-gnu]
 runner = 'sudo -E'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,21 @@
 # Changelog
+## [1.2.0] - 2021-09-30
+## Break changes
+ * N/A
+
+## New features
+ * Support creating linux bridge. (b1f1e0f)
+ * Support creating veth. (af09cab)
+ * Support changing MAC address. (f582227)
+ * Support creating VLAN. (5b172da)
+ * Support changing link state(up/down). (d5de240)
+ * Support creating bond. (466c785)
+ * support changing controller. (b1815e7)
+
+## Bug fixes
+ * Use upstream ethtool crate instead vendoring. (4202aa7)
+ * Fix CLI interface name filter on querying. (1e0f092)
+
 ## [1.1.1] - 2021-06-19
 ## Break changes
  * Running `npc` command without argument will only show bridge network

--- a/DEVEL.md
+++ b/DEVEL.md
@@ -59,12 +59,12 @@ autocmd FileType rust nnoremap <silent> <leader>f :RustFmt<cr>
 ## Release workflow
 
 ```bash
-sed -i -e 's/1.1.1/1.1.2/' \
+sed -i -e 's/1.2.0/1.2.1/' \
     Makefile.inc src/*/Cargo.toml src/python/setup.py .cargo/config.toml
 ```
 
 ```bash
-git log --oneline v1.1.0..HEAD
+git log --oneline v1.2.0..HEAD
 ```
 
 [rust-vim]: https://github.com/rust-lang/rust.vim

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,4 +1,4 @@
-CLIB_VERSION=1.1.1
+CLIB_VERSION=1.2.0
 CLIB_VERSION_MAJOR=$(shell echo $(CLIB_VERSION) | cut -f1 -d.)
 CLIB_VERSION_MINOR=$(shell echo $(CLIB_VERSION) | cut -f2 -d.)
 CLIB_VERSION_MICRO=$(shell echo $(CLIB_VERSION) | cut -f3 -d.)

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nispor-cli"
-version = "1.1.1"
+version = "1.2.0"
 authors = ["Gris Ge <fge@redhat.com>"]
 edition = "2018"
 

--- a/src/clib/Cargo.toml
+++ b/src/clib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nispor-clib"
 description = "Nispor C binding"
-version = "1.1.1"
+version = "1.2.0"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nispor"
-version = "1.1.1"
+version = "1.2.0"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="nispor",
-    version="1.1.1",
+    version="1.2.0",
     author="Gris Ge",
     author_email="fge@redhat.com",
     description="Python binding of Nispor",


### PR DESCRIPTION
Break changes
 * N/A

New features
 * Support creating linux bridge. (b1f1e0f)
 * Support creating VETH. (af09cab)
 * Support changing MAC address. (f582227)
 * Support creating VLAN. (5b172da)
 * Support changing link state(up/down). (d5de240)
 * Support creating bond. (466c785)
 * support changing controller. (b1815e7)

Bug fixes
 * Use upstream ethtool crate instead vendoring. (4202aa7)
 * Fix CLI interface name filter on querying. (1e0f092)