### PR TITLE
sriov: Include VF interface name in VfInfo

### DIFF
--- a/src/lib/ifaces/iface.rs
+++ b/src/lib/ifaces/iface.rs
@@ -406,10 +406,10 @@ pub(crate) fn fill_bridge_vlan_info(
     if name.is_empty() {
         return Ok(());
     }
-    if let Some(mut iface_state) = iface_states.get_mut(&name) {
+    if let Some(iface_state) = iface_states.get_mut(&name) {
         for nla in &nl_msg.nlas {
             if let Nla::AfSpecBridge(data) = nla {
-                parse_bridge_vlan_info(&mut iface_state, data)?;
+                parse_bridge_vlan_info(iface_state, data)?;
                 break;
             }
         }

--- a/src/lib/ifaces/iface.rs
+++ b/src/lib/ifaces/iface.rs
@@ -353,7 +353,7 @@ pub(crate) fn parse_nl_msg_to_iface(
                 }
             }
         } else if let Nla::VfInfoList(data) = nla {
-            if let Ok(info) = get_sriov_info(data, mac_len) {
+            if let Ok(info) = get_sriov_info(&iface_state.name, data, mac_len) {
                 iface_state.sriov = Some(info);
             }
         } else {

--- a/src/lib/tests/ethtool.rs
+++ b/src/lib/tests/ethtool.rs
@@ -62,7 +62,6 @@ fixed:
   tx-fcoe-segmentation: false
   tx-gre-csum-segmentation: false
   tx-gre-segmentation: false
-  tx-gso-list: false
   tx-gso-partial: false
   tx-gso-robust: false
   tx-ipxip4-segmentation: false
@@ -71,7 +70,6 @@ fixed:
   tx-nocache-copy: false
   tx-scatter-gather-fraglist: true
   tx-tunnel-remcsum-segmentation: false
-  tx-udp-segmentation: false
   tx-udp_tnl-csum-segmentation: false
   tx-udp_tnl-segmentation: false
   tx-vlan-hw-insert: false
@@ -113,8 +111,37 @@ fn test_get_ethtool_pause_yaml() {
 
 #[test]
 fn test_get_ethtool_feature_yaml_of_loopback() {
-    let state = NetState::retrieve().unwrap();
-    let iface = &state.ifaces["lo"];
+    let mut state = NetState::retrieve().unwrap();
+    let iface = state.ifaces.get_mut("lo").unwrap();
+    // These property value is different between Github CI and my Archlinux
+    iface
+        .ethtool
+        .as_mut()
+        .unwrap()
+        .features
+        .as_mut()
+        .map(|features| features.fixed.remove("tx-gso-list"));
+    iface
+        .ethtool
+        .as_mut()
+        .unwrap()
+        .features
+        .as_mut()
+        .map(|features| features.changeable.remove("tx-gso-list"));
+    iface
+        .ethtool
+        .as_mut()
+        .unwrap()
+        .features
+        .as_mut()
+        .map(|features| features.fixed.remove("tx-udp-segmentation"));
+    iface
+        .ethtool
+        .as_mut()
+        .unwrap()
+        .features
+        .as_mut()
+        .map(|features| features.changeable.remove("tx-udp-segmentation"));
     assert_eq!(&iface.iface_type, &nispor::IfaceType::Loopback);
     assert_eq!(
         serde_yaml::to_string(&iface.ethtool.as_ref().unwrap().features)

--- a/src/python/nispor/sr_iov.py
+++ b/src/python/nispor/sr_iov.py
@@ -27,6 +27,10 @@ class NisporSriovVf:
         self._info = info
 
     @property
+    def iface_name(self):
+        return self._info.get("iface_name")
+
+    @property
     def vf_id(self):
         return self._info["id"]
 


### PR DESCRIPTION
Currently there is no valid netlink way to get information as the kernel
code is in at PCI level: `drivers/pci/iov.c`.

We use the first nic name in sysfs folder
`/sys/class/net/<pf_name>/devices/virtfn<sriov_id>/net/` as VF interface
name.

Python binding is also updated by including new property:
`NisporSriovVf.iface_name`.

This has been tested on:
 * Intel X520: ixgbe
 * BCM BCM57414: bnxt_en
 * Mellanox MT27710: mlx5_core