### PR TITLE
New release 1.2.1

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [build]
-rustflags = "-Clink-arg=-Wl,-soname=libnispor.so.1.2.0"
+rustflags = "-Clink-arg=-Wl,-soname=libnispor.so.1.2.1"
 
 [target.x86_64-unknown-linux-gnu]
 runner = 'sudo -E'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,18 @@
 # Changelog
+## [1.2.1] - 2021-10-25
+## Break changes
+ * N/A
+
+## New features
+ * Include SR-IOV VF interface name in `VfInfo`. (1e74459)
+ * Implement From BridgePortMulticastRouterType to u8. (b15f82a)
+ * Added `--delete` option to npc for deleting a interface. (0b273d5, e8b0a49)
+ * Expose VlanConf. (bd64243)
+
+## Bug fixes
+
+ * N/A
+
 ## [1.2.0] - 2021-09-30
 ## Break changes
  * N/A

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,4 +1,4 @@
-CLIB_VERSION=1.2.0
+CLIB_VERSION=1.2.1
 CLIB_VERSION_MAJOR=$(shell echo $(CLIB_VERSION) | cut -f1 -d.)
 CLIB_VERSION_MINOR=$(shell echo $(CLIB_VERSION) | cut -f2 -d.)
 CLIB_VERSION_MICRO=$(shell echo $(CLIB_VERSION) | cut -f3 -d.)

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nispor-cli"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Gris Ge <fge@redhat.com>"]
 edition = "2018"
 

--- a/src/cli/npc.rs
+++ b/src/cli/npc.rs
@@ -338,7 +338,6 @@ fn main() {
                 .about("Show interface")
                 .arg(
                     clap::Arg::with_name("delete")
-                        .short("d")
                         .takes_value(false)
                         .help("Delete the specified interface"),
                 )

--- a/src/clib/Cargo.toml
+++ b/src/clib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nispor-clib"
 description = "Nispor C binding"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nispor"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="nispor",
-    version="1.2.0",
+    version="1.2.1",
     author="Gris Ge",
     author_email="fge@redhat.com",
     description="Python binding of Nispor",


### PR DESCRIPTION
## Break changes
 * N/A
 * 
## New features
 * Include SR-IOV VF interface name in `VfInfo`. (1e74459)
 * Implement From BridgePortMulticastRouterType to u8. (b15f82a)
 * Added `--delete` option to npc for deleting a interface. (0b273d5, e8b0a49)
 * Expose VlanConf. (bd64243)

## Bug fixes
 * N/A