### PR TITLE
bridge vlan: Fix querying on i40e

### DIFF
--- a/src/lib/ifaces/bridge.rs
+++ b/src/lib/ifaces/bridge.rs
@@ -379,7 +379,12 @@ pub(crate) fn parse_bridge_vlan_info(
     data: &[u8],
 ) -> Result<(), NisporError> {
     if let Some(ref mut port_info) = iface_state.bridge_port {
-        port_info.vlans = parse_af_spec_bridge_info(data)?;
+        if let Some(cur_vlans) = parse_af_spec_bridge_info(data)? {
+            match port_info.vlans.as_mut() {
+                Some(vlans) => vlans.extend(cur_vlans),
+                None => port_info.vlans = Some(cur_vlans),
+            };
+        }
     }
     Ok(())
 }

--- a/src/lib/ifaces/iface.rs
+++ b/src/lib/ifaces/iface.rs
@@ -410,7 +410,6 @@ pub(crate) fn fill_bridge_vlan_info(
         for nla in &nl_msg.nlas {
             if let Nla::AfSpecBridge(data) = nla {
                 parse_bridge_vlan_info(iface_state, data)?;
-                break;
             }
         }
     }


### PR DESCRIPTION
Problem:

    Cannot show the VLAN filtering on i40e card.

Root cause:

    The i40e driver is using two netlink messages for AfSpecBridge.
    The first one contains IFLA_BRIDGE_VLAN_INFO, the second one contains
    IFLA_BRIDGE_MODE and IFLA_BRIDGE_FLAGS.
    The second parse done by nispor is overriding the first one.
    Hence nispor is showing vlan filter as None.

Fix:

    Extend the VLAN filtering information instead of overriding.