### PR TITLE
New release: 1.2.3

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [build]
-rustflags = "-Clink-arg=-Wl,-soname=libnispor.so.1.2.2"
+rustflags = "-Clink-arg=-Wl,-soname=libnispor.so.1.2.3"
 
 [target.x86_64-unknown-linux-gnu]
 runner = 'sudo -E'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,16 @@
 # Changelog
+## [1.2.3] - 2022-01-12
+## Break changes
+ * N/A
+
+## New features
+ * N/A
+
+## Bug fixes
+
+ * Fix bridge vlan filtering on i40e. (5bc1603)
+ * Expose struct member of ethtool. (60483d9)
+
 ## [1.2.2] - 2021-11-29
 ## Break changes
  * N/A

--- a/DEVEL.md
+++ b/DEVEL.md
@@ -59,12 +59,12 @@ autocmd FileType rust nnoremap <silent> <leader>f :RustFmt<cr>
 ## Release workflow
 
 ```bash
-sed -i -e 's/1.2.2/1.2.3/' \
+sed -i -e 's/1.2.3/1.2.4/' \
     Makefile.inc src/*/Cargo.toml src/python/setup.py .cargo/config.toml
 ```
 
 ```bash
-git log --oneline v1.2.2..HEAD
+git log --oneline v1.2.3..HEAD
 ```
 
 [rust-vim]: https://github.com/rust-lang/rust.vim

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,4 +1,4 @@
-CLIB_VERSION=1.2.2
+CLIB_VERSION=1.2.3
 CLIB_VERSION_MAJOR=$(shell echo $(CLIB_VERSION) | cut -f1 -d.)
 CLIB_VERSION_MINOR=$(shell echo $(CLIB_VERSION) | cut -f2 -d.)
 CLIB_VERSION_MICRO=$(shell echo $(CLIB_VERSION) | cut -f3 -d.)

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nispor-cli"
-version = "1.2.2"
+version = "1.2.3"
 authors = ["Gris Ge <fge@redhat.com>"]
 edition = "2018"
 

--- a/src/clib/Cargo.toml
+++ b/src/clib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nispor-clib"
 description = "Nispor C binding"
-version = "1.2.2"
+version = "1.2.3"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nispor"
-version = "1.2.2"
+version = "1.2.3"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="nispor",
-    version="1.2.2",
+    version="1.2.3",
     author="Gris Ge",
     author_email="fge@redhat.com",
     description="Python binding of Nispor",


### PR DESCRIPTION
Bug fixes:
 * Fix bridge vlan filtering on i40e. (5bc1603)
 * Expose struct member of ethtool. (60483d9)