### PR TITLE
ip: Fix failure of repeat dynamic IP set call

### DIFF
--- a/src/cli/npc.rs
+++ b/src/cli/npc.rs
@@ -157,8 +157,11 @@ impl CliIfaceBrief {
                         let mut addr_strs = Vec::new();
                         for addr in &ip_info.addresses {
                             addr_strs.push(format!(
-                                "{}/{}",
-                                addr.address, addr.prefix_len
+                                "{}/{} {} {}",
+                                addr.address,
+                                addr.prefix_len,
+                                addr.preferred_lft,
+                                addr.valid_lft
                             ));
                         }
                         addr_strs
@@ -170,8 +173,11 @@ impl CliIfaceBrief {
                         let mut addr_strs = Vec::new();
                         for addr in &ip_info.addresses {
                             addr_strs.push(format!(
-                                "{}/{}",
-                                addr.address, addr.prefix_len
+                                "{}/{} {} {}",
+                                addr.address,
+                                addr.prefix_len,
+                                addr.preferred_lft,
+                                addr.valid_lft
                             ));
                         }
                         addr_strs

--- a/src/lib/net_conf.rs
+++ b/src/lib/net_conf.rs
@@ -21,7 +21,7 @@ use crate::ifaces::{
 use serde::{Deserialize, Serialize};
 use tokio::runtime;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
 pub struct NetConf {
     pub ifaces: Option<Vec<IfaceConf>>,
 }

--- a/src/lib/tests/ip.rs
+++ b/src/lib/tests/ip.rs
@@ -164,3 +164,26 @@ fn test_add_and_remove_dynamic_ip() {
         );
     });
 }
+
+#[test]
+fn test_add_dynamic_ip_repeat() {
+    with_veth_iface(|| {
+        let conf: NetConf = serde_yaml::from_str(ADD_IP_CONF_DYNAMIC).unwrap();
+        conf.apply().unwrap();
+        conf.apply().unwrap();
+        std::thread::sleep(std::time::Duration::from_secs(2));
+        conf.apply().unwrap();
+        let state = NetState::retrieve().unwrap();
+        let iface = &state.ifaces[IFACE_NAME];
+        let iface_type = &iface.iface_type;
+        assert_eq!(iface_type, &nispor::IfaceType::Veth);
+        assert_eq!(
+            serde_yaml::to_string(&iface.ipv4).unwrap().trim(),
+            EXPECTED_IPV4_DYNAMIC_INFO
+        );
+        assert_eq!(
+            serde_yaml::to_string(&iface.ipv6).unwrap().trim(),
+            EXPECTED_IPV6_DYNAMIC_INFO
+        );
+    });
+}


### PR DESCRIPTION
On the repeat call of setting dynamic IP, nispor will failure on EEXIST OS
error. To fix that, we remove existing matching dynamic IP before setting
them.

Integration case included.