### PR TITLE
API: Mark all public struct/enum as `non_exhaustive`

### DIFF
--- a/src/cli/npc.rs
+++ b/src/cli/npc.rs
@@ -531,15 +531,12 @@ fn filter_iface_state(
 }
 
 fn delete_iface(iface_name: &str) -> CliResult {
-    if let Err(e) = (NetConf {
-        ifaces: Some(vec![IfaceConf {
-            name: iface_name.to_string(),
-            state: IfaceState::Absent,
-            ..Default::default()
-        }]),
-    }
-    .apply())
-    {
+    let mut conf = NetConf::default();
+    let mut iface_conf = IfaceConf::default();
+    iface_conf.name = iface_name.to_string();
+    iface_conf.state = IfaceState::Absent;
+    conf.ifaces = Some(vec![iface_conf]);
+    if let Err(e) = conf.apply() {
         CliResult::NisporError(e)
     } else {
         CliResult::Pass

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -33,6 +33,7 @@ impl std::fmt::Display for ErrorKind {
 }
 
 #[derive(Debug, Clone, Serialize)]
+#[non_exhaustive]
 pub struct NisporError {
     pub kind: ErrorKind,
     pub msg: String,

--- a/src/lib/ifaces/bond.rs
+++ b/src/lib/ifaces/bond.rs
@@ -34,6 +34,7 @@ const BOND_MODE_ALB: u8 = 6;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum BondMode {
     #[serde(rename = "balance-rr")]
     BalanceRoundRobin,
@@ -76,6 +77,7 @@ impl From<u8> for BondMode {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum BondModeArpAllTargets {
     Any,
     All,
@@ -106,6 +108,7 @@ const BOND_ARP_FILTER_BACKUP: u32 = BOND_ARP_VALIDATE_BACKUP | BOND_ARP_FILTER;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum BondArpValidate {
     None,
     Active,
@@ -140,6 +143,7 @@ const BOND_PRI_RESELECT_FAILURE: u8 = 2;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum BondPrimaryReselect {
     Always,
     Better,
@@ -164,6 +168,7 @@ const BOND_FOM_FOLLOW: u8 = 2;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum BondFailOverMac {
     None,
     Active,
@@ -191,6 +196,7 @@ const BOND_XMIT_POLICY_VLAN_SRCMAC: u8 = 5;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum BondXmitHashPolicy {
     #[serde(rename = "layer2")]
     Layer2,
@@ -226,6 +232,7 @@ const BOND_ALL_SUBORDINATES_ACTIVE_DELIEVERD: u8 = 1;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum BondAllSubordinatesActive {
     Dropped,
     Delivered,
@@ -247,6 +254,7 @@ const AD_LACP_FAST: u8 = 1;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum BondLacpRate {
     Slow,
     Fast,
@@ -269,6 +277,7 @@ const BOND_AD_COUNT: u8 = 2;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum BondAdSelect {
     Stable,
     Bandwidth,
@@ -288,6 +297,7 @@ impl From<u8> for BondAdSelect {
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct BondAdInfo {
     pub aggregator: u16,
     pub num_ports: u16,
@@ -297,6 +307,7 @@ pub struct BondAdInfo {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct BondInfo {
     pub subordinates: Vec<String>,
     pub mode: BondMode,
@@ -358,6 +369,7 @@ pub struct BondInfo {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum BondSubordinateState {
     Active,
     Backup,
@@ -380,6 +392,7 @@ impl From<u8> for BondSubordinateState {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum BondMiiStatus {
     LinkUp,
     LinkFail,
@@ -407,6 +420,7 @@ impl From<u8> for BondMiiStatus {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[non_exhaustive]
 pub struct BondSubordinateInfo {
     pub subordinate_state: BondSubordinateState,
     pub mii_status: BondMiiStatus,
@@ -496,6 +510,7 @@ fn primary_index_to_iface_name(iface_states: &mut HashMap<String, Iface>) {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct BondConf {}
 
 impl BondConf {

--- a/src/lib/ifaces/bridge.rs
+++ b/src/lib/ifaces/bridge.rs
@@ -27,6 +27,7 @@ use crate::{
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum BridgeStpState {
     Disabled,
     KernelStp,
@@ -52,6 +53,7 @@ impl From<u32> for BridgeStpState {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum BridgeVlanProtocol {
     #[serde(rename = "802.1q")]
     Ieee8021Q,
@@ -75,6 +77,7 @@ impl From<u16> for BridgeVlanProtocol {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct BridgeInfo {
     pub ports: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -169,6 +172,7 @@ pub struct BridgeInfo {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum BridgePortStpState {
     Disabled,
     Listening,
@@ -206,6 +210,7 @@ impl From<u8> for BridgePortStpState {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum BridgePortMulticastRouterType {
     Disabled,
     TempQuery,
@@ -252,6 +257,7 @@ impl From<BridgePortMulticastRouterType> for u8 {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct BridgePortInfo {
     pub stp_state: BridgePortStpState,
     pub stp_priority: u16,
@@ -365,6 +371,7 @@ fn convert_back_port_index_to_name(iface_states: &mut HashMap<String, Iface>) {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct BridgeVlanEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub vid: Option<u16>,
@@ -390,6 +397,7 @@ pub(crate) fn parse_bridge_vlan_info(
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct BridgeConf {}
 
 impl BridgeConf {

--- a/src/lib/ifaces/ethtool.rs
+++ b/src/lib/ifaces/ethtool.rs
@@ -25,6 +25,7 @@ use serde::{Deserialize, Serialize, Serializer};
 use crate::NisporError;
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct EthtoolPauseInfo {
     pub rx: bool,
     pub tx: bool,
@@ -33,6 +34,7 @@ pub struct EthtoolPauseInfo {
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub struct EthtoolFeatureInfo {
     #[serde(serialize_with = "ordered_map")]
     pub fixed: HashMap<String, bool>,
@@ -41,6 +43,7 @@ pub struct EthtoolFeatureInfo {
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct EthtoolCoalesceInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pkt_rate_high: Option<u32>,
@@ -89,6 +92,7 @@ pub struct EthtoolCoalesceInfo {
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct EthtoolRingInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rx: Option<u32>,
@@ -110,6 +114,7 @@ pub struct EthtoolRingInfo {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum EthtoolLinkModeDuplex {
     Half,
     Full,
@@ -135,6 +140,7 @@ impl Default for EthtoolLinkModeDuplex {
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct EthtoolLinkModeInfo {
     pub auto_negotiate: bool,
     pub ours: Vec<String>,
@@ -151,6 +157,7 @@ pub struct EthtoolLinkModeInfo {
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct EthtoolInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pause: Option<EthtoolPauseInfo>,

--- a/src/lib/ifaces/iface.rs
+++ b/src/lib/ifaces/iface.rs
@@ -52,6 +52,7 @@ use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum IfaceType {
     Bond,
     Veth,
@@ -78,6 +79,7 @@ impl Default for IfaceType {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum IfaceState {
     Up,
     Dormant,
@@ -114,6 +116,7 @@ impl std::fmt::Display for IfaceState {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum IfaceFlags {
     AllMulti,
     AutoMedia,
@@ -143,6 +146,7 @@ impl Default for IfaceFlags {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum ControllerType {
     Bond,
     Bridge,
@@ -165,6 +169,7 @@ impl From<&str> for ControllerType {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct Iface {
     pub name: String,
     #[serde(skip_serializing)]
@@ -488,6 +493,7 @@ fn _parse_iface_flags(flags: u32) -> Vec<IfaceFlags> {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct IfaceConf {
     pub name: String,
     #[serde(default = "default_iface_state_in_conf")]

--- a/src/lib/ifaces/mac_vlan.rs
+++ b/src/lib/ifaces/mac_vlan.rs
@@ -32,6 +32,7 @@ const MACVLAN_MODE_SOURCE: u32 = 16;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum MacVlanMode {
     /* don't talk to other macvlans */
     Private,
@@ -68,6 +69,7 @@ impl From<u32> for MacVlanMode {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct MacVlanInfo {
     pub base_iface: String,
     pub mode: MacVlanMode,

--- a/src/lib/ifaces/mac_vtap.rs
+++ b/src/lib/ifaces/mac_vtap.rs
@@ -21,6 +21,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum MacVtapMode {
     /* don't talk to other macvlans */
     Private,
@@ -58,6 +59,7 @@ impl From<MacVlanMode> for MacVtapMode {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct MacVtapInfo {
     pub base_iface: String,
     pub mode: MacVtapMode,

--- a/src/lib/ifaces/sriov.rs
+++ b/src/lib/ifaces/sriov.rs
@@ -49,6 +49,7 @@ const IFLA_VF_STATS_TX_DROPPED: u16 = 8;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum VfLinkState {
     Auto,
     Enable,
@@ -74,6 +75,7 @@ impl From<u32> for VfLinkState {
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct VfState {
     pub rx_packets: u64,
     pub tx_packets: u64,
@@ -86,11 +88,13 @@ pub struct VfState {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct SriovInfo {
     pub vfs: Vec<VfInfo>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct VfInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub iface_name: Option<String>,

--- a/src/lib/ifaces/tun.rs
+++ b/src/lib/ifaces/tun.rs
@@ -33,6 +33,7 @@ const IFLA_TUN_NUM_QUEUES: u16 = 8;
 const IFLA_TUN_NUM_DISABLED_QUEUES: u16 = 9;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct TunInfo {
     pub mode: TunMode,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -51,6 +52,7 @@ pub struct TunInfo {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum TunMode {
     Tun,
     Tap,

--- a/src/lib/ifaces/veth.rs
+++ b/src/lib/ifaces/veth.rs
@@ -20,6 +20,7 @@ use serde::{Deserialize, Serialize};
 use crate::{Iface, IfaceType, NisporError};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[non_exhaustive]
 pub struct VethInfo {
     // Interface name of peer.
     // Use interface index number when peer interface is in other namespace.

--- a/src/lib/ifaces/vlan.rs
+++ b/src/lib/ifaces/vlan.rs
@@ -25,6 +25,7 @@ const ETH_P_8021AD: u16 = 0x88A8;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum VlanProtocol {
     #[serde(rename = "802.1q")]
     Ieee8021Q,
@@ -56,6 +57,7 @@ const VLAN_FLAG_MVRP: u32 = 0x8;
 const VLAN_FLAG_BRIDGE_BINDING: u32 = 0x10;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct VlanInfo {
     pub vlan_id: u16,
     pub protocol: VlanProtocol,
@@ -126,6 +128,7 @@ fn convert_base_iface_index_to_name(iface_states: &mut HashMap<String, Iface>) {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[non_exhaustive]
 pub struct VlanConf {
     pub vlan_id: u16,
     pub base_iface: String,

--- a/src/lib/ifaces/vrf.rs
+++ b/src/lib/ifaces/vrf.rs
@@ -25,12 +25,14 @@ use std::collections::HashMap;
 const IFLA_VRF_PORT_TABLE: u16 = 1;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct VrfInfo {
     pub table_id: u32,
     pub subordinates: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct VrfSubordinateInfo {
     pub table_id: u32,
 }

--- a/src/lib/ifaces/vxlan.rs
+++ b/src/lib/ifaces/vxlan.rs
@@ -23,6 +23,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct VxlanInfo {
     pub remote: String,
     pub vxlan_id: u32,

--- a/src/lib/ip.rs
+++ b/src/lib/ip.rs
@@ -31,11 +31,13 @@ use crate::{
 };
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct Ipv4Info {
     pub addresses: Vec<Ipv4AddrInfo>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct Ipv4AddrInfo {
     pub address: String,
     pub prefix_len: u8,
@@ -48,11 +50,13 @@ pub struct Ipv4AddrInfo {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct Ipv6Info {
     pub addresses: Vec<Ipv6AddrInfo>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct Ipv6AddrInfo {
     pub address: String,
     pub prefix_len: u8,
@@ -63,6 +67,7 @@ pub struct Ipv6AddrInfo {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct IpConf {
     pub addresses: Vec<IpAddrConf>,
 }
@@ -110,6 +115,7 @@ pub enum IpFamily {
 #[derive(
     Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone, Default,
 )]
+#[non_exhaustive]
 pub struct IpAddrConf {
     pub address: String,
     pub prefix_len: u8,

--- a/src/lib/net_conf.rs
+++ b/src/lib/net_conf.rs
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
 use tokio::runtime;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct NetConf {
     pub ifaces: Option<Vec<IfaceConf>>,
 }

--- a/src/lib/net_state.rs
+++ b/src/lib/net_state.rs
@@ -23,6 +23,7 @@ use std::collections::HashMap;
 use tokio::runtime;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[non_exhaustive]
 pub struct NetState {
     pub ifaces: HashMap<String, Iface>,
     pub routes: Vec<Route>,

--- a/src/lib/route.rs
+++ b/src/lib/route.rs
@@ -44,6 +44,7 @@ use std::collections::HashMap;
 const USER_HZ: u32 = 100;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct Route {
     pub address_family: AddressFamily,
     pub tos: u8,
@@ -346,6 +347,7 @@ const SIZE_OF_RTNEXTHOP: usize = 8;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub struct MultipathRoute {
     pub via: String,
     pub iface: String,

--- a/src/lib/route_rule.rs
+++ b/src/lib/route_rule.rs
@@ -74,6 +74,7 @@ impl Default for RuleAction {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[non_exhaustive]
 pub struct RouteRule {
     pub action: RuleAction,
     pub address_family: AddressFamily,


### PR DESCRIPTION
All the public struct/enum in nispor might add members/type, hence
marking them as `non_exhaustive` which will prevent API user from
in-compatibility usage.

Please refer to https://github.com/nispor/nispor/pull/173 for more detail