### PR TITLE
iface: get min_mtu and max_mtu attributes as Option

### DIFF
--- a/src/python/nispor/base_iface.py
+++ b/src/python/nispor/base_iface.py
@@ -100,11 +100,11 @@ class NisporBaseIface:
 
     @property
     def max_mtu(self):
-        return self._info["max_mtu"]
+        return self._info.get("max_mtu")
 
     @property
     def min_mtu(self):
-        return self._info["min_mtu"]
+        return self._info.get("min_mtu")
 
 
 class NisporBaseSubordinateIface:


### PR DESCRIPTION
Issue #168 was open and I started to work on it, but it was already solved by commit 892dcc5b5. However, I had forgot to fetch last changes and started working on top of a some weeks old version of nispor, and I didn't see it.

Anyway, in my implementation I had choose to use Option instead of an integer because it gives better semantics to know when the value doesn't make sense and should be used. Since I had it already done, I submit the changes just in case you find it better.

If you don't think it is worth it, I'm fine with you just rejecting this PR.