### PR TITLE
New release: 1.2.4

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [build]
-rustflags = "-Clink-arg=-Wl,-soname=libnispor.so.1.2.3"
+rustflags = "-Clink-arg=-Wl,-soname=libnispor.so.1.2.4"
 
 [target.x86_64-unknown-linux-gnu]
 runner = 'sudo -E'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,19 @@
 # Changelog
+## [1.2.4] - 2022-03-15
+## Break changes
+ * Mark all public struct/enum as `non_exhaustive`. (58fa534)
+
+## New features
+ * Support max and min MTU. (892dcc5, cebe8ea)
+ * Support changing dynamic IP. (43e9496)
+ * Support changing route. (b8ffe1a, 06cc9c8)
+ * Support mulitpath route in python binding. (e70991e)
+ * Support IP over InfiniBand. (f374d62)
+
+## Bug fixes
+
+ * Remove all usages of `expect`. (25f1868)
+
 ## [1.2.3] - 2022-01-12
 ## Break changes
  * N/A

--- a/DEVEL.md
+++ b/DEVEL.md
@@ -59,12 +59,12 @@ autocmd FileType rust nnoremap <silent> <leader>f :RustFmt<cr>
 ## Release workflow
 
 ```bash
-sed -i -e 's/1.2.3/1.2.4/' \
+sed -i -e 's/1.2.4/1.2.5/' \
     Makefile.inc src/*/Cargo.toml src/python/setup.py .cargo/config.toml
 ```
 
 ```bash
-git log --oneline v1.2.3..HEAD
+git log --oneline v1.2.4..HEAD
 ```
 
 [rust-vim]: https://github.com/rust-lang/rust.vim

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,4 +1,4 @@
-CLIB_VERSION=1.2.3
+CLIB_VERSION=1.2.4
 CLIB_VERSION_MAJOR=$(shell echo $(CLIB_VERSION) | cut -f1 -d.)
 CLIB_VERSION_MINOR=$(shell echo $(CLIB_VERSION) | cut -f2 -d.)
 CLIB_VERSION_MICRO=$(shell echo $(CLIB_VERSION) | cut -f3 -d.)

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nispor-cli"
-version = "1.2.3"
+version = "1.2.4"
 authors = ["Gris Ge <fge@redhat.com>"]
 edition = "2018"
 

--- a/src/clib/Cargo.toml
+++ b/src/clib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nispor-clib"
 description = "Nispor C binding"
-version = "1.2.3"
+version = "1.2.4"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nispor"
-version = "1.2.3"
+version = "1.2.4"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="nispor",
-    version="1.2.3",
+    version="1.2.4",
     author="Gris Ge",
     author_email="fge@redhat.com",
     description="Python binding of Nispor",


### PR DESCRIPTION
## Break changes
 * Mark all public struct/enum as `non_exhaustive`. (58fa534)

## New features
 * Support max and min MTU. (892dcc5, cebe8ea)
 * Support changing dynamic IP. (43e9496)
 * Support changing route. (b8ffe1a, 06cc9c8)
 * Support mulitpath route in python binding. (e70991e)
 * Support IP over InfiniBand. (f374d62)

## Bug fixes
 * Remove all usages of `expect`. (25f1868)