### PR TITLE
npc: Use specific version for `cargo publish`

### DIFF
--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -13,7 +13,7 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 clap = { version = "3.1.2", features = ["cargo"] }
-nispor = { path = "../lib", version="1.0" }
+nispor = { path = "../lib", version="1.2.4" }
 serde_yaml = "0.8"
 env_logger = "0.9.0"
 log = "0.4.14"

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -2,7 +2,14 @@
 name = "nispor-cli"
 version = "1.2.4"
 authors = ["Gris Ge <fge@redhat.com>"]
+license = "Apache-2.0"
 edition = "2018"
+description = "Command line tool for nispor project"
+homepage = "https://github.com/nispor/nispor"
+repository = "https://github.com/nispor/nispor"
+keywords = ["network"]
+categories = ["network-programming", "os"]
+
 
 [[bin]]
 name = "npc"

--- a/src/clib/Cargo.toml
+++ b/src/clib/Cargo.toml
@@ -1,10 +1,14 @@
 [package]
 name = "nispor-clib"
-description = "Nispor C binding"
 version = "1.2.4"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2018"
+description = "C binding for nispor project"
+homepage = "https://github.com/nispor/nispor"
+repository = "https://github.com/nispor/nispor"
+keywords = ["network"]
+categories = ["network-programming", "os"]
 
 [lib]
 name = "nispor"


### PR DESCRIPTION
Local dependency is not allowed for `cargo publish`