### PR TITLE
ipoib: Add base_iface property

### DIFF
--- a/src/lib/ifaces/iface.rs
+++ b/src/lib/ifaces/iface.rs
@@ -415,6 +415,11 @@ pub(crate) fn parse_nl_msg_to_iface(
             vlan_info.base_iface = format!("{}", base_iface_index);
         }
     }
+    if let Some(ref mut ib_info) = iface_state.ipoib {
+        if let Some(base_iface_index) = link {
+            ib_info.base_iface = Some(format!("{}", base_iface_index));
+        }
+    }
     if let Some(iface_index) = link {
         match iface_state.iface_type {
             IfaceType::Veth => {

--- a/src/lib/ifaces/mod.rs
+++ b/src/lib/ifaces/mod.rs
@@ -47,6 +47,7 @@ use crate::ifaces::iface::{
     fill_bridge_vlan_info, parse_nl_msg_to_iface,
     parse_nl_msg_to_name_and_index,
 };
+use crate::ifaces::ipoib::ipoib_iface_tidy_up;
 use crate::ifaces::mac_vlan::mac_vlan_iface_tidy_up;
 use crate::ifaces::veth::veth_iface_tidy_up;
 use crate::ifaces::vlan::vlan_iface_tidy_up;
@@ -116,6 +117,7 @@ fn tidy_up(iface_states: &mut HashMap<String, Iface>) {
     veth_iface_tidy_up(iface_states);
     vrf_iface_tidy_up(iface_states);
     mac_vlan_iface_tidy_up(iface_states);
+    ipoib_iface_tidy_up(iface_states);
 }
 
 fn controller_iface_index_to_name(iface_states: &mut HashMap<String, Iface>) {

--- a/src/python/nispor/ipoib.py
+++ b/src/python/nispor/ipoib.py
@@ -30,3 +30,7 @@ class NisporIpoib(NisporBaseIface):
     @property
     def umcast(self):
         return self._ipoib_info["umcast"]
+
+    @property
+    def base_iface(self):
+        return self._ipoib_info.get("base_iface")


### PR DESCRIPTION
When certain IPoIB interface is p-key based interface, show the
`base_iface` for its parent.