### PR TITLE
New release 1.2.5

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [build]
-rustflags = "-Clink-arg=-Wl,-soname=libnispor.so.1.2.4"
+rustflags = "-Clink-arg=-Wl,-soname=libnispor.so.1.2.5"
 
 [target.x86_64-unknown-linux-gnu]
 runner = 'sudo -E'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,21 @@
 # Changelog
+## [1.2.5] - 2022-03-30
+
+## Break changes
+ * N/A
+
+## New features
+
+ * N/A
+
+## Bug fixes
+
+ * apply: Enable Default traits for VethConf and VlanConf. (3b3f446)
+ * ipoib: Add base_iface property. (9349ed7)
+ * clib: Update Cargo.toml with description and etc. (4494f54)
+ * npc: Update Cargo.toml for `cargo publish`. (26d8bb6)
+ * npc: Use specific version for `cargo publish`.  (4f0faa3)
+
 ## [1.2.4] - 2022-03-15
 ## Break changes
  * Mark all public struct/enum as `non_exhaustive`. (58fa534)

--- a/DEVEL.md
+++ b/DEVEL.md
@@ -59,12 +59,12 @@ autocmd FileType rust nnoremap <silent> <leader>f :RustFmt<cr>
 ## Release workflow
 
 ```bash
-sed -i -e 's/1.2.4/1.2.5/' \
+sed -i -e 's/1.2.5/1.2.6/' \
     Makefile.inc src/*/Cargo.toml src/python/setup.py .cargo/config.toml
 ```
 
 ```bash
-git log --oneline v1.2.4..HEAD
+git log --oneline v1.2.5..HEAD
 ```
 
 [rust-vim]: https://github.com/rust-lang/rust.vim

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,4 +1,4 @@
-CLIB_VERSION=1.2.4
+CLIB_VERSION=1.2.5
 CLIB_VERSION_MAJOR=$(shell echo $(CLIB_VERSION) | cut -f1 -d.)
 CLIB_VERSION_MINOR=$(shell echo $(CLIB_VERSION) | cut -f2 -d.)
 CLIB_VERSION_MICRO=$(shell echo $(CLIB_VERSION) | cut -f3 -d.)

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nispor-cli"
-version = "1.2.4"
+version = "1.2.5"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2018"
@@ -20,7 +20,7 @@ serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 clap = { version = "3.1.2", features = ["cargo"] }
-nispor = { path = "../lib", version="1.2.4" }
+nispor = { path = "../lib", version="1.2.5" }
 serde_yaml = "0.8"
 env_logger = "0.9.0"
 log = "0.4.14"

--- a/src/clib/Cargo.toml
+++ b/src/clib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nispor-clib"
-version = "1.2.4"
+version = "1.2.5"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nispor"
-version = "1.2.4"
+version = "1.2.5"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="nispor",
-    version="1.2.4",
+    version="1.2.5",
     author="Gris Ge",
     author_email="fge@redhat.com",
     description="Python binding of Nispor",


### PR DESCRIPTION
Bug fixes:
 * apply: Enable Default traits for VethConf and VlanConf. (3b3f446)
 * ipoib: Add base_iface property. (9349ed7)
 * clib: Update Cargo.toml with description and etc. (4494f54)
 * npc: Update Cargo.toml for `cargo publish`. (26d8bb6)
 * npc: Use specific version for `cargo publish`.  (4f0faa3)