### PR TITLE
clib: Change SONAME to libnispor.so.1

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [build]
-rustflags = "-Clink-arg=-Wl,-soname=libnispor.so.1.2.5"
+rustflags = "-Clink-arg=-Wl,-soname=libnispor.so.1"
 
 [target.x86_64-unknown-linux-gnu]
 runner = 'sudo -E'

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,8 @@ install: $(CLI_EXEC_RELEASE)
 		$(DESTDIR)$(PREFIX)/bin/$(CLI_EXEC)
 	install -p -D -m755 $(CLIB_SO_DEV_RELEASE) \
 		$(DESTDIR)$(LIBDIR)/$(CLIB_SO_FULL)
+	patchelf --set-soname libnispor.so.$(CLIB_VERSION_MAJOR) \
+		$(DESTDIR)$(LIBDIR)/$(CLIB_SO_MAN)
 	ln -sfv $(CLIB_SO_FULL) $(DESTDIR)$(LIBDIR)/$(CLIB_SO_MAN)
 	ln -sfv $(CLIB_SO_FULL) $(DESTDIR)$(LIBDIR)/$(CLIB_SO_DEV)
 	if [ $(SKIP_PYTHON_INSTALL) != 1 ];then \

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -16,9 +16,8 @@ name = "npc"
 path = "npc.rs"
 
 [dependencies]
-serde = "1.0"
 serde_json = "1.0"
-serde_derive = "1.0"
+serde = { version = "1.0.136", features = ["derive"] }
 clap = { version = "3.1.2", features = ["cargo"] }
 nispor = { path = "../lib", version="1.2.5" }
 serde_yaml = "0.8"

--- a/src/cli/npc.rs
+++ b/src/cli/npc.rs
@@ -17,7 +17,7 @@ use nispor::{
     Iface, IfaceConf, IfaceState, IfaceType, NetConf, NetState, NisporError,
     Route, RouteRule,
 };
-use serde_derive::Serialize;
+use serde::Serialize;
 use std::collections::HashMap;
 use std::fmt;
 use std::io::{stderr, stdout, Write};

--- a/src/lib/tests/bridge.rs
+++ b/src/lib/tests/bridge.rs
@@ -101,6 +101,8 @@ group_fwd_mask: 0
 neigh_suppress: false
 isolated: false
 mrp_ring_open: false
+mcast_eht_hosts_limit: 512
+mcast_eht_hosts_cnt: 0
 vlans:
   - vid: 1
     is_pvid: true
@@ -138,6 +140,8 @@ group_fwd_mask: 0
 neigh_suppress: false
 isolated: false
 mrp_ring_open: false
+mcast_eht_hosts_limit: 512
+mcast_eht_hosts_cnt: 0
 vlans:
   - vid: 1
     is_pvid: true

--- a/src/lib/tests/bridge_vlan_filter.rs
+++ b/src/lib/tests/bridge_vlan_filter.rs
@@ -55,6 +55,8 @@ group_fwd_mask: 0
 neigh_suppress: false
 isolated: false
 mrp_ring_open: false
+mcast_eht_hosts_limit: 512
+mcast_eht_hosts_cnt: 0
 vlans:
   - vid: 1
     is_pvid: false
@@ -95,6 +97,8 @@ group_fwd_mask: 0
 neigh_suppress: false
 isolated: false
 mrp_ring_open: false
+mcast_eht_hosts_limit: 512
+mcast_eht_hosts_cnt: 0
 vlans:
   - vid: 1
     is_pvid: true

--- a/src/lib/tests/ethtool.rs
+++ b/src/lib/tests/ethtool.rs
@@ -33,6 +33,10 @@ fixed:
   esp-tx-csum-hw-offload: false
   fcoe-mtu: false
   highdma: true
+  hsr-dup-offload: false
+  hsr-fwd-offload: false
+  hsr-tag-ins-offload: false
+  hsr-tag-rm-offload: false
   hw-tc-offload: false
   l2-fwd-offload: false
   loopback: true
@@ -78,6 +82,7 @@ fixed:
 changeable:
   rx-gro: true
   rx-gro-list: false
+  rx-udp-gro-forwarding: false
   tx-generic-segmentation: true
   tx-sctp-segmentation: true
   tx-tcp-ecn-segmentation: true


### PR DESCRIPTION
The correct SONAME should only contain major version number.

User might override `.cargo/config` by using RUSTFLAGS, so we
also use patchelf to set the SONAME during `make install` to ensure
SONAME been set correctly.