### PR TITLE
clib: Change SONAME to libnispor.so.1

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [build]
-rustflags = "-Clink-arg=-Wl,-soname=libnispor.so.1.2.5"
+rustflags = "-Clink-arg=-Wl,-soname=libnispor.so.1"
 
 [target.x86_64-unknown-linux-gnu]
 runner = 'sudo -E'


### PR DESCRIPTION
The correct SONAME should only contain major version number.