### PR TITLE
Add support MPTCP

### DIFF
--- a/src/cli/npc.rs
+++ b/src/cli/npc.rs
@@ -14,8 +14,8 @@
 
 use clap::{crate_authors, crate_version};
 use nispor::{
-    Iface, IfaceConf, IfaceState, IfaceType, NetConf, NetState, NisporError,
-    Route, RouteRule,
+    Iface, IfaceConf, IfaceState, IfaceType, Mptcp, NetConf, NetState,
+    NisporError, Route, RouteRule,
 };
 use serde::Serialize;
 use std::collections::HashMap;
@@ -223,6 +223,7 @@ enum CliResult {
     Ifaces(Vec<Iface>),
     Routes(Vec<Route>),
     RouteRules(Vec<RouteRule>),
+    Mptcp(Mptcp),
     CliError(CliError),
     NisporError(NisporError),
 }
@@ -255,6 +256,10 @@ macro_rules! npc_print {
             }
             CliResult::RouteRules(rules) => {
                 writeln!(stdout(), "{}", $display_func(&rules).unwrap()).ok();
+                process::exit(0);
+            }
+            CliResult::Mptcp(mptcp) => {
+                writeln!(stdout(), "{}", $display_func(&mptcp).unwrap()).ok();
                 process::exit(0);
             }
             CliResult::NisporError(e) => {
@@ -394,6 +399,7 @@ fn main() {
                 ),
         )
         .subcommand(clap::Command::new("rule").about("Show route route"))
+        .subcommand(clap::Command::new("mptcp").about("Show mptcp state"))
         .subcommand(
             clap::Command::new("set")
                 .about("Set network state from file")
@@ -462,6 +468,9 @@ fn main() {
                 } else if let Some(m) = matches.subcommand_matches("rule") {
                     output_format = parse_arg_output_format(m);
                     CliResult::RouteRules(state.rules)
+                } else if let Some(m) = matches.subcommand_matches("mptcp") {
+                    output_format = parse_arg_output_format(m);
+                    CliResult::Mptcp(state.mptcp.unwrap_or_default())
                 } else if let Some(iface_name) = matches.value_of("iface_name")
                 {
                     if state.ifaces.get(iface_name).is_some() {

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -27,6 +27,7 @@ tokio = { version = "1.19.2", features = ["macros", "rt"] }
 futures = "0.3.21"
 libc = "0.2.126"
 log = "0.4.17"
+mptcp-pm = "0.1.0"
 
 [dev-dependencies]
 serde_yaml = "0.8.24"

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -150,3 +150,12 @@ impl std::convert::From<std::net::AddrParseError> for NisporError {
         }
     }
 }
+
+impl std::convert::From<mptcp_pm::MptcpPathManagerError> for NisporError {
+    fn from(e: mptcp_pm::MptcpPathManagerError) -> Self {
+        NisporError {
+            kind: ErrorKind::NetlinkError,
+            msg: e.to_string(),
+        }
+    }
+}

--- a/src/lib/ifaces/iface.rs
+++ b/src/lib/ifaces/iface.rs
@@ -38,6 +38,7 @@ use crate::{
     },
     ip::{IpConf, Ipv4Info, Ipv6Info},
     mac::{mac_str_to_raw, parse_as_mac},
+    mptcp::MptcpAddress,
     NisporError,
 };
 
@@ -257,6 +258,8 @@ pub struct Iface {
     pub sriov: Option<SriovInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ipoib: Option<IpoibInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mptcp: Option<Vec<MptcpAddress>>,
 }
 
 // TODO: impl From Iface to IfaceConf

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -16,6 +16,7 @@ mod error;
 mod ifaces;
 mod ip;
 mod mac;
+mod mptcp;
 mod net_conf;
 mod net_state;
 mod netlink;
@@ -41,6 +42,7 @@ pub use crate::ip::{
     IpAddrConf, IpConf, IpFamily, Ipv4AddrInfo, Ipv4Info, Ipv6AddrInfo,
     Ipv6Info,
 };
+pub use crate::mptcp::{Mptcp, MptcpAddress};
 pub use crate::net_conf::NetConf;
 pub use crate::net_state::NetState;
 pub use crate::route::{

--- a/src/lib/mptcp.rs
+++ b/src/lib/mptcp.rs
@@ -1,0 +1,246 @@
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::io::Read;
+use std::net::IpAddr;
+
+use futures::stream::TryStreamExt;
+use mptcp_pm::{
+    MptcpPathManagerAddressAttr, MptcpPathManagerAddressAttrFlag,
+    MptcpPathManagerAttr, MptcpPathManagerLimitsAttr, MptcpPathManagerMessage,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{Iface, NisporError};
+
+const MPTCP_SYSCTL_PATH: &str = "/proc/sys/net/mptcp/enabled";
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
+#[non_exhaustive]
+pub struct Mptcp {
+    pub enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub add_addr_accepted_limit: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subflows_limit: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub addresses: Option<Vec<MptcpAddress>>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(rename_all = "snake_case")]
+pub enum MptcpAddressFlag {
+    Signal,
+    Subflow,
+    Backup,
+    Fullmesh,
+    Implicit,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[non_exhaustive]
+pub struct MptcpAddress {
+    pub address: IpAddr,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub port: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub flags: Option<Vec<MptcpAddressFlag>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub iface: Option<String>,
+    #[serde(skip)]
+    pub iface_index: Option<i32>,
+}
+
+pub(crate) async fn get_mptcp() -> Result<Mptcp, NisporError> {
+    let mut ret = Mptcp {
+        enabled: is_mptcp_enabled(),
+        ..Default::default()
+    };
+    if !ret.enabled {
+        return Ok(ret);
+    }
+
+    let (connection, handle, _) = mptcp_pm::new_connection()?;
+    tokio::spawn(connection);
+
+    let mut limits_handle = handle.limits().get().execute().await;
+
+    while let Some(genl_msg) = limits_handle.try_next().await? {
+        let mptcp_msg = genl_msg.payload;
+        for nla in &mptcp_msg.nlas {
+            match nla {
+                MptcpPathManagerAttr::Limits(
+                    MptcpPathManagerLimitsAttr::RcvAddAddrs(d),
+                ) => {
+                    ret.add_addr_accepted_limit = Some(*d);
+                }
+                MptcpPathManagerAttr::Limits(
+                    MptcpPathManagerLimitsAttr::Subflows(d),
+                ) => {
+                    ret.subflows_limit = Some(*d);
+                }
+                _ => {
+                    log::info!("Unsupported MPTCP netlink attribute {:?}", nla)
+                }
+            }
+        }
+    }
+
+    let mut address_handle = handle.address().get().execute().await;
+    let mut addresses = Vec::new();
+    while let Some(genl_msg) = address_handle.try_next().await? {
+        if let Some(addr) = mptcp_msg_to_nispor(&genl_msg.payload) {
+            addresses.push(addr);
+        }
+    }
+    ret.addresses = Some(addresses);
+
+    Ok(ret)
+}
+
+fn is_mptcp_enabled() -> bool {
+    if let Ok(mut fd) = std::fs::File::open(MPTCP_SYSCTL_PATH) {
+        let mut content = [0u8; 1];
+        if fd.read_exact(&mut content).is_err() {
+            false
+        } else {
+            content[0] == b'1'
+        }
+    } else {
+        false
+    }
+}
+
+// * Place address with interface to Iface
+// * Replace index to interface name
+pub(crate) fn merge_mptcp_info(
+    iface_states: &mut HashMap<String, Iface>,
+    mptcp: &mut Mptcp,
+) {
+    let mut addr_index: HashMap<String, Vec<MptcpAddress>> = HashMap::new();
+    let mut iface_index_map: HashMap<u32, String> = HashMap::new();
+
+    for iface in iface_states.values() {
+        iface_index_map.insert(iface.index, iface.name.clone());
+    }
+
+    if let Some(addrs) = mptcp.addresses.as_mut() {
+        for addr in addrs {
+            if let Some(iface_index) = addr.iface_index.as_ref() {
+                if let Ok(i) = u32::try_from(*iface_index) {
+                    if let Some(iface_name) = iface_index_map.get(&i) {
+                        addr.iface = Some(iface_name.to_string());
+                        match addr_index.entry(iface_name.to_string()) {
+                            Entry::Occupied(o) => {
+                                o.into_mut().push(addr.clone());
+                            }
+                            Entry::Vacant(v) => {
+                                v.insert(vec![addr.clone()]);
+                            }
+                        };
+                    } else {
+                        addr.iface = Some(iface_index.to_string());
+                    }
+                } else {
+                    log::error!("BUG: Got invalid iface index in  {:?}", addr);
+                }
+            }
+        }
+    }
+
+    for iface in iface_states.values_mut() {
+        if let Some(addrs) = addr_index.remove(iface.name.as_str()) {
+            iface.mptcp = Some(addrs);
+        }
+    }
+}
+
+fn mptcp_msg_to_nispor(
+    mptcp_msg: &MptcpPathManagerMessage,
+) -> Option<MptcpAddress> {
+    let mut address = None;
+    for nla in &mptcp_msg.nlas {
+        if let MptcpPathManagerAttr::Address(
+            MptcpPathManagerAddressAttr::Addr4(ip),
+        ) = nla
+        {
+            address = Some(IpAddr::V4(*ip));
+            break;
+        } else if let MptcpPathManagerAttr::Address(
+            MptcpPathManagerAddressAttr::Addr6(ip),
+        ) = nla
+        {
+            address = Some(IpAddr::V6(*ip));
+            break;
+        }
+    }
+    if let Some(address) = address {
+        let mut ret = MptcpAddress {
+            address,
+            id: None,
+            port: None,
+            flags: None,
+            iface: None,
+            iface_index: None,
+        };
+        for nla in &mptcp_msg.nlas {
+            if let MptcpPathManagerAttr::Address(addr_attr) = nla {
+                match addr_attr {
+                    MptcpPathManagerAddressAttr::Flags(flags) => {
+                        ret.flags = Some(mptcp_flags_to_nispor(flags));
+                    }
+                    MptcpPathManagerAddressAttr::IfIndex(i) => {
+                        ret.iface_index = Some(*i);
+                    }
+                    MptcpPathManagerAddressAttr::Port(i) => {
+                        if *i != 0 {
+                            ret.port = Some(*i);
+                        }
+                    }
+                    MptcpPathManagerAddressAttr::Id(i) => {
+                        ret.id = Some(*i);
+                    }
+                    _ => (),
+                }
+            }
+        }
+        Some(ret)
+    } else {
+        None
+    }
+}
+
+fn mptcp_flags_to_nispor(
+    flags: &[MptcpPathManagerAddressAttrFlag],
+) -> Vec<MptcpAddressFlag> {
+    let mut ret = Vec::new();
+    for flag in flags {
+        if let Some(f) = match flag {
+            MptcpPathManagerAddressAttrFlag::Signal => {
+                Some(MptcpAddressFlag::Signal)
+            }
+            MptcpPathManagerAddressAttrFlag::Subflow => {
+                Some(MptcpAddressFlag::Subflow)
+            }
+            MptcpPathManagerAddressAttrFlag::Backup => {
+                Some(MptcpAddressFlag::Backup)
+            }
+            MptcpPathManagerAddressAttrFlag::Fullmesh => {
+                Some(MptcpAddressFlag::Fullmesh)
+            }
+            MptcpPathManagerAddressAttrFlag::Implicit => {
+                Some(MptcpAddressFlag::Implicit)
+            }
+            _ => {
+                log::info!("Unsupported address flag {:?}", flag);
+                None
+            }
+        } {
+            ret.push(f);
+        }
+    }
+    ret
+}

--- a/src/python/nispor/__init__.py
+++ b/src/python/nispor/__init__.py
@@ -20,6 +20,7 @@ from .bridge import NisporBridgePort
 from .clib_wrapper import NisporError
 from .clib_wrapper import retrieve_net_state_json
 from .iface import NisporIfaceState
+from .mptcp import NisporMptcpState
 from .route import NisporMultipathRoute
 from .route import NisporRoute
 from .route import NisporRouteState
@@ -30,6 +31,5 @@ from .tun import NisporTun
 from .veth import NisporVeth
 from .vlan import NisporVlan
 from .vxlan import NisporVxlan
-
 
 __all__ = []

--- a/src/python/nispor/mptcp.py
+++ b/src/python/nispor/mptcp.py
@@ -1,0 +1,62 @@
+# Copyright 2020 Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class NisporMptcpState:
+    def __init__(self, info):
+        self._addrs = [
+            NisporMptcpAddress(addr_info)
+            for addr_info in info.get("addresses", [])
+        ]
+
+    @property
+    def enabled(self):
+        return self._info["enabled"]
+
+    @property
+    def add_addr_accepted_limit(self):
+        return self._info.get("add_addr_accepted_limit")
+
+    @property
+    def subflows_limit(self):
+        return self._info.get("subflows_limit")
+
+    @property
+    def addresses(self):
+        return self._addrs
+
+
+class NisporMptcpAddress:
+    def __init__(self, info):
+        self._info = info
+
+    @property
+    def address(self):
+        return self._info["address"]
+
+    @property
+    def id(self):
+        return self._info.get("id")
+
+    @property
+    def port(self):
+        return self._info.get("port")
+
+    @property
+    def flags(self):
+        return self._info.get("flags")
+
+    @property
+    def iface(self):
+        return self._info.get("iface")

--- a/src/python/nispor/state.py
+++ b/src/python/nispor/state.py
@@ -16,6 +16,7 @@ import json
 
 from .clib_wrapper import retrieve_net_state_json
 from .iface import NisporIfaceState
+from .mptcp import NisporMptcpState
 from .route import NisporRouteState
 from .route_rule import NisporRouteRuleState
 
@@ -29,6 +30,10 @@ class NisporNetState:
         self._ifaces = NisporIfaceState(info.get("ifaces"))
         self._routes = NisporRouteState(info.get("routes"))
         self._route_rules = NisporRouteRuleState(info.get("rules"))
+        if info.get("mptcp"):
+            self._mptcp = NisporMptcpState(info["mptcp"])
+        else:
+            self._mptcp = None
 
     @property
     def ifaces(self):
@@ -41,6 +46,10 @@ class NisporNetState:
     @property
     def route_rules(self):
         return self._route_rules
+
+    @property
+    def mptcp(self):
+        return self._mptcp
 
     @staticmethod
     def retrieve():

--- a/tools/test_env
+++ b/tools/test_env
@@ -14,7 +14,7 @@ sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0 1>/dev/null
 
 if [ "CHK$1" == "CHK" ];then
     echo 'Need argument: bond, br, brv, vlan, dummy, vxlan, veth, vrf, sriov,'
-    echo 'rm, route, rule, sim'
+    echo 'rm, route, rule, sim, mptcp'
     exit 1
 fi
 
@@ -37,6 +37,7 @@ function clean_up {
     sudo ip rule del priority 999
     sudo ip -6 rule del priority 999
     sudo modprobe -r netdevsim
+    sudo ip mptcp endpoint flush
 }
 
 function create_nics {
@@ -194,6 +195,14 @@ elif [ "CHK$1" == "CHKsim" ];then
     sudo ethtool -A sim0 rx on
     sudo ethtool -A sim1 tx on
     sudo ethtool -A sim1 rx on
+elif [ "CHK$1" == "CHKmptcp" ];then
+    create_nics
+    sudo ip link set eth1 up
+    sudo ip addr add 192.0.2.2/24 dev eth1
+    sudo ip -6 addr add 2001:db8:f::1/64 dev eth1
+    sudo ip mptcp limits set subflow 1 add_addr_accepted 1
+    sudo ip mptcp endpoint add 192.0.2.2 dev eth2 signal
+    sudo ip mptcp endpoint add 2001:db8:f::1 dev eth2 backup
 elif [ "CHK$1" == "CHKrm" ];then
     clean_up 2>/dev/null
 fi


### PR DESCRIPTION
Also include python bonding and CLI support.

Example output of `npc mptcp`:

```yaml
---
enabled: true
add_addr_accepted_limit: 1
subflows_limit: 1
addresses:
  - address: 192.0.2.2
    id: 1
    flags:
      - signal
    iface: eth2
  - address: "2001:db8:f::1"
    id: 2
    flags:
      - backup
    iface: eth2
```

Those address also shown in the interface level, example of
`npc iface eth2`:

```yaml
---
- name: eth2
  iface_type: veth
  #many_lines_omitted
  mptcp:
    - address: 192.0.2.2
      id: 1
      flags:
        - signal
      iface: eth2
    - address: "2001:db8:f::1"
      id: 2
      flags:
        - backup
      iface: eth2
```