### PR TITLE
[th/fix-sriov-mac-addrs] fix regression for parsing SR-IOV VFs from netlink

### DIFF
--- a/src/lib/ifaces/mac_vlan.rs
+++ b/src/lib/ifaces/mac_vlan.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::mac::parse_as_mac;
+use crate::mac::{parse_as_mac, ETH_ALEN};
 use crate::Iface;
 use crate::IfaceType;
 use crate::NisporError;
@@ -21,8 +21,6 @@ use netlink_packet_route::rtnl::link::nlas::InfoMacVlan;
 use netlink_packet_route::rtnl::link::nlas::InfoMacVtap;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-
-const ETH_ALEN: usize = 6;
 
 const MACVLAN_MODE_PRIVATE: u32 = 1;
 const MACVLAN_MODE_VEPA: u32 = 2;

--- a/src/lib/mac.rs
+++ b/src/lib/mac.rs
@@ -16,6 +16,8 @@ use std::fmt::Write;
 
 use crate::NisporError;
 
+pub(crate) const ETH_ALEN: usize = libc::ETH_ALEN as usize;
+
 pub(crate) fn parse_as_mac(
     mac_len: usize,
     data: &[u8],

--- a/src/lib/mac.rs
+++ b/src/lib/mac.rs
@@ -17,6 +17,7 @@ use std::fmt::Write;
 use crate::NisporError;
 
 pub(crate) const ETH_ALEN: usize = libc::ETH_ALEN as usize;
+pub(crate) const INFINIBAND_ALEN: usize = 20;
 
 pub(crate) fn parse_as_mac(
     mac_len: usize,

--- a/src/lib/mac.rs
+++ b/src/lib/mac.rs
@@ -20,12 +20,12 @@ pub(crate) fn parse_as_mac(
     mac_len: usize,
     data: &[u8],
 ) -> Result<String, NisporError> {
-    if data.len() != mac_len {
+    if data.len() < mac_len {
         return Err(NisporError::bug("wrong size at mac parsing".into()));
     }
     let mut rt = String::new();
-    for (i, &val) in data.iter().enumerate() {
-        write!(rt, "{:02x}", val).ok();
+    for (i, m) in data.iter().enumerate().take(mac_len) {
+        write!(rt, "{:02x}", m).ok();
         if i != mac_len - 1 {
             rt.push(':');
         }

--- a/src/lib/netlink/bridge.rs
+++ b/src/lib/netlink/bridge.rs
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::mac::parse_as_mac;
+use crate::mac::{parse_as_mac, ETH_ALEN};
 use crate::BridgeInfo;
 use crate::NisporError;
 use netlink_packet_route::rtnl::link::nlas::InfoBridge;
-
-const ETH_ALEN: usize = 6;
 
 pub(crate) fn parse_bridge_info(
     infos: &[InfoBridge],


### PR DESCRIPTION
Commit 25f186819f0e changes `mac::parse_as_mac()` to be strict. However, SR-IOV VFs (`IFLA_VF_MAC`, `IFLA_VF_BROADCAST`) are not only 6 bytes long. Hence, the entire VF failed to parse. The effect is, that it appears as if there is no VF.

Fix that by relaxing the check. Also a few followup patches for consideration.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2090678