### PR TITLE
Use latest rust-netlink crates

### DIFF
--- a/src/cli/npc.rs
+++ b/src/cli/npc.rs
@@ -20,6 +20,7 @@ use nispor::{
 use serde::Serialize;
 use std::collections::HashMap;
 use std::fmt;
+use std::fmt::Write as _FmtWrite;
 use std::io::{stderr, stdout, Write};
 use std::process;
 
@@ -65,20 +66,24 @@ impl CliIfaceBrief {
                 format!("{}link {}", INDENT, brief.iface_type);
 
             if !brief.link_info.is_empty() {
-                link_string += &format!(" {}", brief.link_info.as_str());
+                write!(link_string, " {}", brief.link_info.as_str()).ok();
             }
             if let Some(ctrl) = brief.controller.as_ref() {
-                link_string += &format!(" controller {}", ctrl);
+                write!(link_string, " controller {}", ctrl).ok();
             }
 
             ret.push(link_string);
 
             let mut mac_string = String::new();
             if !&brief.mac.is_empty() {
-                mac_string += &format!("{}mac {}", INDENT, brief.mac);
+                write!(mac_string, "{}mac {}", INDENT, brief.mac).ok();
                 if !&brief.permanent_mac.is_empty() {
-                    mac_string +=
-                        &format!(" permanent_mac {}", brief.permanent_mac);
+                    write!(
+                        mac_string,
+                        " permanent_mac {}",
+                        brief.permanent_mac
+                    )
+                    .ok();
                 }
             }
 
@@ -222,7 +227,7 @@ enum CliResult {
     NisporError(NisporError),
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 enum CliOutputType {
     Json,
     Yaml,
@@ -570,7 +575,7 @@ fn get_link_info(iface: &Iface) -> String {
             bond.subordinates.join(LIST_SPLITER)
         );
         if let Some(p) = bond.primary.as_deref() {
-            bond_line += &format!(" primary {}", p);
+            write!(bond_line, " primary {}", p).ok();
         }
         bond_line
     } else if let Some(bridge) = iface.bridge.as_ref() {

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -16,18 +16,18 @@ path = "lib.rs"
 crate-type = ["lib"]
 
 [dependencies]
-serde = { version = "1.0.136", features = ["derive"] }
-serde_json = "1.0.79"
-rtnetlink = "0.9.1"
-netlink-packet-route = "0.11.0"
-netlink-sys = "0.8.2"
+serde = { version = "1.0.137", features = ["derive"] }
+serde_json = "1.0.81"
+rtnetlink = "0.10.0"
+netlink-packet-route = "0.12.0"
+netlink-sys = "0.8.3"
 netlink-packet-utils = "0.5.1"
 ethtool = "0.2.2"
-tokio = { version = "1.17.0", features = ["macros", "rt"] }
+tokio = { version = "1.19.2", features = ["macros", "rt"] }
 futures = "0.3.21"
-libc = "0.2.117"
-log = "0.4.14"
+libc = "0.2.126"
+log = "0.4.17"
 
 [dev-dependencies]
-serde_yaml = "0.8.23"
-pretty_assertions = "1.1.0"
+serde_yaml = "0.8.24"
+pretty_assertions = "1.2.1"

--- a/src/lib/ifaces/bond.rs
+++ b/src/lib/ifaces/bond.rs
@@ -32,7 +32,7 @@ const BOND_MODE_8023AD: u8 = 4;
 const BOND_MODE_TLB: u8 = 5;
 const BOND_MODE_ALB: u8 = 6;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum BondMode {
@@ -91,7 +91,7 @@ impl std::fmt::Display for BondMode {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum BondModeArpAllTargets {
@@ -122,7 +122,7 @@ const BOND_ARP_FILTER: u32 = BOND_ARP_VALIDATE_ALL + 1;
 const BOND_ARP_FILTER_ACTIVE: u32 = BOND_ARP_VALIDATE_ACTIVE | BOND_ARP_FILTER;
 const BOND_ARP_FILTER_BACKUP: u32 = BOND_ARP_VALIDATE_BACKUP | BOND_ARP_FILTER;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum BondArpValidate {
@@ -157,7 +157,7 @@ const BOND_PRI_RESELECT_ALWAYS: u8 = 0;
 const BOND_PRI_RESELECT_BETTER: u8 = 1;
 const BOND_PRI_RESELECT_FAILURE: u8 = 2;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum BondPrimaryReselect {
@@ -182,7 +182,7 @@ const BOND_FOM_NONE: u8 = 0;
 const BOND_FOM_ACTIVE: u8 = 1;
 const BOND_FOM_FOLLOW: u8 = 2;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum BondFailOverMac {
@@ -210,7 +210,7 @@ const BOND_XMIT_POLICY_ENCAP23: u8 = 3;
 const BOND_XMIT_POLICY_ENCAP34: u8 = 4;
 const BOND_XMIT_POLICY_VLAN_SRCMAC: u8 = 5;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum BondXmitHashPolicy {
@@ -246,7 +246,7 @@ impl From<u8> for BondXmitHashPolicy {
 const BOND_ALL_SUBORDINATES_ACTIVE_DROPPED: u8 = 0;
 const BOND_ALL_SUBORDINATES_ACTIVE_DELIEVERD: u8 = 1;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum BondAllSubordinatesActive {
@@ -268,7 +268,7 @@ impl From<u8> for BondAllSubordinatesActive {
 const AD_LACP_SLOW: u8 = 0;
 const AD_LACP_FAST: u8 = 1;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum BondLacpRate {
@@ -291,7 +291,7 @@ const BOND_AD_STABLE: u8 = 0;
 const BOND_AD_BANDWIDTH: u8 = 1;
 const BOND_AD_COUNT: u8 = 2;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum BondAdSelect {
@@ -322,7 +322,7 @@ pub struct BondAdInfo {
     pub partner_mac: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct BondInfo {
     pub subordinates: Vec<String>,
@@ -383,7 +383,7 @@ pub struct BondInfo {
     pub ad_info: Option<BondAdInfo>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum BondSubordinateState {
@@ -406,7 +406,7 @@ impl From<u8> for BondSubordinateState {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum BondMiiStatus {
@@ -435,7 +435,7 @@ impl From<u8> for BondMiiStatus {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[non_exhaustive]
 pub struct BondSubordinateInfo {
     pub subordinate_state: BondSubordinateState,
@@ -525,7 +525,7 @@ fn primary_index_to_iface_name(iface_states: &mut HashMap<String, Iface>) {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct BondConf {}
 

--- a/src/lib/ifaces/bridge.rs
+++ b/src/lib/ifaces/bridge.rs
@@ -25,7 +25,7 @@ use crate::{
     ControllerType, Iface, NisporError,
 };
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum BridgeStpState {
@@ -51,7 +51,7 @@ impl From<u32> for BridgeStpState {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum BridgeVlanProtocol {
@@ -76,7 +76,7 @@ impl From<u16> for BridgeVlanProtocol {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct BridgeInfo {
     pub ports: Vec<String>,
@@ -170,7 +170,7 @@ pub struct BridgeInfo {
     pub multicast_mld_version: Option<u8>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum BridgePortStpState {
@@ -208,7 +208,7 @@ impl From<u8> for BridgePortStpState {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum BridgePortMulticastRouterType {
@@ -256,7 +256,7 @@ impl From<BridgePortMulticastRouterType> for u8 {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct BridgePortInfo {
     pub stp_state: BridgePortStpState,
@@ -370,7 +370,7 @@ fn convert_back_port_index_to_name(iface_states: &mut HashMap<String, Iface>) {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct BridgeVlanEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -396,7 +396,7 @@ pub(crate) fn parse_bridge_vlan_info(
     Ok(())
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct BridgeConf {}
 

--- a/src/lib/ifaces/bridge.rs
+++ b/src/lib/ifaces/bridge.rs
@@ -383,10 +383,10 @@ pub struct BridgeVlanEntry {
 
 pub(crate) fn parse_bridge_vlan_info(
     iface_state: &mut Iface,
-    data: &[u8],
+    nlas: &[nlas::AfSpecBridge],
 ) -> Result<(), NisporError> {
     if let Some(ref mut port_info) = iface_state.bridge_port {
-        if let Some(cur_vlans) = parse_af_spec_bridge_info(data)? {
+        if let Some(cur_vlans) = parse_af_spec_bridge_info(nlas)? {
             match port_info.vlans.as_mut() {
                 Some(vlans) => vlans.extend(cur_vlans),
                 None => port_info.vlans = Some(cur_vlans),

--- a/src/lib/ifaces/iface.rs
+++ b/src/lib/ifaces/iface.rs
@@ -51,7 +51,7 @@ use rtnetlink::packet::rtnl::link::nlas::Nla;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum IfaceType {
@@ -106,7 +106,7 @@ impl std::fmt::Display for IfaceType {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum IfaceState {
@@ -143,7 +143,7 @@ impl std::fmt::Display for IfaceState {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum IfaceFlags {
@@ -173,7 +173,7 @@ impl Default for IfaceFlags {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum ControllerType {
@@ -197,7 +197,7 @@ impl From<&str> for ControllerType {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct Iface {
     pub name: String,
@@ -536,7 +536,7 @@ fn _parse_iface_flags(flags: u32) -> Vec<IfaceFlags> {
     ret
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct IfaceConf {
     pub name: String,

--- a/src/lib/ifaces/iface.rs
+++ b/src/lib/ifaces/iface.rs
@@ -463,8 +463,8 @@ pub(crate) fn fill_bridge_vlan_info(
     }
     if let Some(iface_state) = iface_states.get_mut(&name) {
         for nla in &nl_msg.nlas {
-            if let Nla::AfSpecBridge(data) = nla {
-                parse_bridge_vlan_info(iface_state, data)?;
+            if let Nla::AfSpecBridge(nlas) = nla {
+                parse_bridge_vlan_info(iface_state, nlas)?;
             }
         }
     }

--- a/src/lib/ifaces/ipoib.rs
+++ b/src/lib/ifaces/ipoib.rs
@@ -9,7 +9,7 @@ use crate::{Iface, IfaceType};
 const IPOIB_MODE_DATAGRAM: u16 = 0;
 const IPOIB_MODE_CONNECTED: u16 = 1;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum IpoibMode {
@@ -37,7 +37,7 @@ impl From<u16> for IpoibMode {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct IpoibInfo {
     pub pkey: u16,

--- a/src/lib/ifaces/mac_vlan.rs
+++ b/src/lib/ifaces/mac_vlan.rs
@@ -30,7 +30,7 @@ const MACVLAN_MODE_BRIDGE: u32 = 4;
 const MACVLAN_MODE_PASSTHRU: u32 = 8;
 const MACVLAN_MODE_SOURCE: u32 = 16;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum MacVlanMode {
@@ -68,7 +68,7 @@ impl From<u32> for MacVlanMode {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct MacVlanInfo {
     pub base_iface: String,

--- a/src/lib/ifaces/mac_vtap.rs
+++ b/src/lib/ifaces/mac_vtap.rs
@@ -19,7 +19,7 @@ use crate::NisporError;
 use netlink_packet_route::rtnl::link::nlas;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum MacVtapMode {
@@ -58,7 +58,7 @@ impl From<MacVlanMode> for MacVtapMode {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct MacVtapInfo {
     pub base_iface: String,

--- a/src/lib/ifaces/sriov.rs
+++ b/src/lib/ifaces/sriov.rs
@@ -47,7 +47,7 @@ const IFLA_VF_STATS_MULTICAST: u16 = 5;
 const IFLA_VF_STATS_RX_DROPPED: u16 = 7;
 const IFLA_VF_STATS_TX_DROPPED: u16 = 8;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum VfLinkState {
@@ -74,7 +74,7 @@ impl From<u32> for VfLinkState {
     }
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Default)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Default)]
 #[non_exhaustive]
 pub struct VfState {
     pub rx_packets: u64,
@@ -87,13 +87,13 @@ pub struct VfState {
     pub tx_dropped: u64,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct SriovInfo {
     pub vfs: Vec<VfInfo>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct VfInfo {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/lib/ifaces/tun.rs
+++ b/src/lib/ifaces/tun.rs
@@ -32,7 +32,7 @@ const IFLA_TUN_MULTI_QUEUE: u16 = 7;
 const IFLA_TUN_NUM_QUEUES: u16 = 8;
 const IFLA_TUN_NUM_DISABLED_QUEUES: u16 = 9;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct TunInfo {
     pub mode: TunMode,
@@ -50,7 +50,7 @@ pub struct TunInfo {
     pub num_disabled_queues: Option<u32>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum TunMode {

--- a/src/lib/ifaces/veth.rs
+++ b/src/lib/ifaces/veth.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{Iface, IfaceType, NisporError};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct VethInfo {
     // Interface name of peer.

--- a/src/lib/ifaces/vlan.rs
+++ b/src/lib/ifaces/vlan.rs
@@ -23,7 +23,7 @@ use crate::{Iface, IfaceType, NisporError};
 const ETH_P_8021Q: u16 = 0x8100;
 const ETH_P_8021AD: u16 = 0x88A8;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum VlanProtocol {
@@ -56,7 +56,7 @@ const VLAN_FLAG_LOOSE_BINDING: u32 = 0x4;
 const VLAN_FLAG_MVRP: u32 = 0x8;
 const VLAN_FLAG_BRIDGE_BINDING: u32 = 0x10;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct VlanInfo {
     pub vlan_id: u16,
@@ -127,7 +127,7 @@ fn convert_base_iface_index_to_name(iface_states: &mut HashMap<String, Iface>) {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct VlanConf {
     pub vlan_id: u16,

--- a/src/lib/ifaces/vrf.rs
+++ b/src/lib/ifaces/vrf.rs
@@ -24,14 +24,14 @@ use std::collections::HashMap;
 
 const IFLA_VRF_PORT_TABLE: u16 = 1;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct VrfInfo {
     pub table_id: u32,
     pub subordinates: Vec<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct VrfSubordinateInfo {
     pub table_id: u32,

--- a/src/lib/ifaces/vxlan.rs
+++ b/src/lib/ifaces/vxlan.rs
@@ -22,7 +22,7 @@ use netlink_packet_route::rtnl::link::nlas::InfoVxlan;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct VxlanInfo {
     pub remote: String,

--- a/src/lib/ip.rs
+++ b/src/lib/ip.rs
@@ -25,13 +25,13 @@ use serde::{Deserialize, Serialize};
 
 use crate::{Iface, IfaceConf, NisporError};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct Ipv4Info {
     pub addresses: Vec<Ipv4AddrInfo>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct Ipv4AddrInfo {
     pub address: String,
@@ -44,13 +44,13 @@ pub struct Ipv4AddrInfo {
     pub preferred_lft: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct Ipv6Info {
     pub addresses: Vec<Ipv6AddrInfo>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct Ipv6AddrInfo {
     pub address: String,
@@ -61,7 +61,7 @@ pub struct Ipv6AddrInfo {
     pub preferred_lft: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct IpConf {
     pub addresses: Vec<IpAddrConf>,

--- a/src/lib/mac.rs
+++ b/src/lib/mac.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt::Write;
+
 use crate::NisporError;
 
 pub(crate) fn parse_as_mac(
@@ -23,7 +25,7 @@ pub(crate) fn parse_as_mac(
     }
     let mut rt = String::new();
     for (i, &val) in data.iter().enumerate() {
-        rt.push_str(&format!("{:02x}", val));
+        write!(rt, "{:02x}", val).ok();
         if i != mac_len - 1 {
             rt.push(':');
         }

--- a/src/lib/net_conf.rs
+++ b/src/lib/net_conf.rs
@@ -22,7 +22,7 @@ use crate::route::{apply_routes_conf, RouteConf};
 use serde::{Deserialize, Serialize};
 use tokio::runtime;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct NetConf {
     pub ifaces: Option<Vec<IfaceConf>>,

--- a/src/lib/net_state.rs
+++ b/src/lib/net_state.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tokio::runtime;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[non_exhaustive]
 pub struct NetState {
     pub ifaces: HashMap<String, Iface>,

--- a/src/lib/netlink/bridge_port.rs
+++ b/src/lib/netlink/bridge_port.rs
@@ -392,7 +392,7 @@ fn parse_as_bridge_id(data: &[u8]) -> Result<String, NisporError> {
     let err_msg = "wrong index at bridge_id parsing";
     Ok(format!(
         "{:02x}{:02x}.{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
-        data.get(0)
+        data.first()
             .ok_or_else(|| NisporError::bug(err_msg.into()))?,
         data.get(1)
             .ok_or_else(|| NisporError::bug(err_msg.into()))?,

--- a/src/lib/netlink/bridge_vlan.rs
+++ b/src/lib/netlink/bridge_vlan.rs
@@ -46,7 +46,7 @@ pub(crate) fn parse_af_spec_bridge_info(
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Default)]
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
 struct KernelBridgeVlanEntry {
     vid: u16,
     is_pvid: bool, // is PVID and ingress untagged

--- a/src/lib/netlink/nla.rs
+++ b/src/lib/netlink/nla.rs
@@ -18,7 +18,7 @@ use std::net::Ipv4Addr;
 use std::net::Ipv6Addr;
 
 pub(crate) fn parse_as_u8(data: &[u8]) -> Result<u8, NisporError> {
-    Ok(*data.get(0).ok_or_else(|| {
+    Ok(*data.first().ok_or_else(|| {
         NisporError::bug("wrong index when parsing as u8".into())
     })?)
 }
@@ -27,7 +27,7 @@ pub(crate) fn parse_as_u16(data: &[u8]) -> Result<u16, NisporError> {
     let err_msg = "wrong index when parsing as u16";
     Ok(u16::from_ne_bytes([
         *data
-            .get(0)
+            .first()
             .ok_or_else(|| NisporError::bug(err_msg.into()))?,
         *data
             .get(1)
@@ -39,7 +39,7 @@ pub(crate) fn parse_as_i32(data: &[u8]) -> Result<i32, NisporError> {
     let err_msg = "wrong index when parsing as i32";
     Ok(i32::from_ne_bytes([
         *data
-            .get(0)
+            .first()
             .ok_or_else(|| NisporError::bug(err_msg.into()))?,
         *data
             .get(1)
@@ -57,7 +57,7 @@ pub(crate) fn parse_as_u32(data: &[u8]) -> Result<u32, NisporError> {
     let err_msg = "wrong index when parsing as u32";
     Ok(u32::from_ne_bytes([
         *data
-            .get(0)
+            .first()
             .ok_or_else(|| NisporError::bug(err_msg.into()))?,
         *data
             .get(1)
@@ -75,7 +75,7 @@ pub(crate) fn parse_as_u64(data: &[u8]) -> Result<u64, NisporError> {
     let err_msg = "wrong index when parsing as u64";
     Ok(u64::from_ne_bytes([
         *data
-            .get(0)
+            .first()
             .ok_or_else(|| NisporError::bug(err_msg.into()))?,
         *data
             .get(1)

--- a/src/lib/route.rs
+++ b/src/lib/route.rs
@@ -41,7 +41,7 @@ use crate::{
 
 const USER_HZ: u32 = 100;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct Route {
     pub address_family: AddressFamily,
@@ -136,7 +136,7 @@ pub struct Route {
     // Missing support of RTA_NH_ID
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum AddressFamily {
     IPv4,
@@ -295,7 +295,7 @@ impl Default for RouteProtocol {
  * Intermediate values are also possible f.e. interior routes
  * could be assigned a value between UNIVERSE and LINK.
  */
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum RouteScope {
     Universe,
@@ -354,7 +354,7 @@ impl From<&str> for RouteScope {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum RouteType {
     UnSpec,
@@ -401,7 +401,7 @@ impl Default for RouteType {
 
 const SIZE_OF_RTNEXTHOP: usize = 8;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub struct MultipathRoute {
@@ -411,7 +411,7 @@ pub struct MultipathRoute {
     pub flags: Vec<MultipathRouteFlags>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum MultipathRouteFlags {
     Dead,

--- a/src/lib/route_rule.rs
+++ b/src/lib/route_rule.rs
@@ -34,7 +34,7 @@ const FR_ACT_PROHIBIT: u8 = 128;
 
 const RT_TABLE_UNSPEC: u8 = 0;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum RuleAction {
     /* Pass to fixed table or l3mdev */
@@ -73,7 +73,7 @@ impl Default for RuleAction {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct RouteRule {
     pub action: RuleAction,

--- a/src/lib/tests/bond.rs
+++ b/src/lib/tests/bond.rs
@@ -14,7 +14,7 @@
 
 use nispor::{NetConf, NetState};
 use pretty_assertions::assert_eq;
-use serde_yaml;
+
 use std::panic;
 
 mod utils;
@@ -85,9 +85,9 @@ fn test_get_iface_bond_yaml() {
     });
 }
 
-fn with_bond_iface<T>(test: T) -> ()
+fn with_bond_iface<T>(test: T)
 where
-    T: FnOnce() -> () + panic::UnwindSafe,
+    T: FnOnce() + panic::UnwindSafe,
 {
     utils::set_network_environment("bond");
 

--- a/src/lib/tests/bridge.rs
+++ b/src/lib/tests/bridge.rs
@@ -14,7 +14,7 @@
 
 use nispor::{NetConf, NetState};
 use pretty_assertions::assert_eq;
-use serde_yaml;
+
 use std::panic;
 
 mod utils;
@@ -191,9 +191,9 @@ fn test_get_br_iface_yaml() {
     });
 }
 
-fn with_br_iface<T>(test: T) -> ()
+fn with_br_iface<T>(test: T)
 where
-    T: FnOnce() -> () + panic::UnwindSafe,
+    T: FnOnce() + panic::UnwindSafe,
 {
     utils::set_network_environment("br");
 

--- a/src/lib/tests/bridge_vlan_filter.rs
+++ b/src/lib/tests/bridge_vlan_filter.rs
@@ -14,7 +14,7 @@
 
 use nispor::NetState;
 use pretty_assertions::assert_eq;
-use serde_yaml;
+
 use std::panic;
 
 mod utils;
@@ -143,9 +143,9 @@ fn test_get_br_vlan_filter_iface_yaml() {
     });
 }
 
-fn with_br_with_vlan_filter_iface<T>(test: T) -> ()
+fn with_br_with_vlan_filter_iface<T>(test: T)
 where
-    T: FnOnce() -> () + panic::UnwindSafe,
+    T: FnOnce() + panic::UnwindSafe,
 {
     utils::set_network_environment("brv");
 

--- a/src/lib/tests/dummy.rs
+++ b/src/lib/tests/dummy.rs
@@ -30,9 +30,9 @@ fn test_get_iface_dummy_yaml() {
     });
 }
 
-fn with_dummy_iface<T>(test: T) -> ()
+fn with_dummy_iface<T>(test: T)
 where
-    T: FnOnce() -> () + panic::UnwindSafe,
+    T: FnOnce() + panic::UnwindSafe,
 {
     utils::set_network_environment("dummy");
 

--- a/src/lib/tests/ethtool.rs
+++ b/src/lib/tests/ethtool.rs
@@ -14,7 +14,7 @@
 
 use nispor::NetState;
 use pretty_assertions::assert_eq;
-use serde_yaml;
+
 use std::panic;
 
 mod utils;
@@ -158,9 +158,9 @@ fn test_get_ethtool_feature_yaml_of_loopback() {
 
 // TODO: There is no way to test the ethtool ring.
 
-fn with_netdevsim_iface<T>(test: T) -> ()
+fn with_netdevsim_iface<T>(test: T)
 where
-    T: FnOnce() -> () + panic::UnwindSafe,
+    T: FnOnce() + panic::UnwindSafe,
 {
     utils::set_network_environment("sim");
 
@@ -209,9 +209,9 @@ fn test_get_ethtool_link_mode_yaml() {
     });
 }
 
-fn with_tun_iface<T>(test: T) -> ()
+fn with_tun_iface<T>(test: T)
 where
-    T: FnOnce() -> () + panic::UnwindSafe,
+    T: FnOnce() + panic::UnwindSafe,
 {
     utils::set_network_environment("tun");
 

--- a/src/lib/tests/ip.rs
+++ b/src/lib/tests/ip.rs
@@ -14,16 +14,16 @@
 
 use nispor::{NetConf, NetState};
 use pretty_assertions::assert_eq;
-use serde_yaml;
+
 use std::panic;
 
 mod utils;
 
 const IFACE_NAME: &str = "veth1";
 
-fn with_veth_iface<T>(test: T) -> ()
+fn with_veth_iface<T>(test: T)
 where
-    T: FnOnce() -> () + panic::UnwindSafe,
+    T: FnOnce() + panic::UnwindSafe,
 {
     utils::set_network_environment("veth");
 

--- a/src/lib/tests/mac_vlan.rs
+++ b/src/lib/tests/mac_vlan.rs
@@ -14,7 +14,7 @@
 
 use nispor::NetState;
 use pretty_assertions::assert_eq;
-use serde_yaml;
+
 use std::panic;
 
 mod utils;
@@ -42,9 +42,9 @@ fn test_get_macvlan_iface_yaml() {
     });
 }
 
-fn with_macvlan_iface<T>(test: T) -> ()
+fn with_macvlan_iface<T>(test: T)
 where
-    T: FnOnce() -> () + panic::UnwindSafe,
+    T: FnOnce() + panic::UnwindSafe,
 {
     utils::set_network_environment("macvlan");
 

--- a/src/lib/tests/mac_vtap.rs
+++ b/src/lib/tests/mac_vtap.rs
@@ -14,7 +14,7 @@
 
 use nispor::NetState;
 use pretty_assertions::assert_eq;
-use serde_yaml;
+
 use std::panic;
 
 mod utils;
@@ -42,9 +42,9 @@ fn test_get_macvtap_iface_yaml() {
     });
 }
 
-fn with_macvtap_iface<T>(test: T) -> ()
+fn with_macvtap_iface<T>(test: T)
 where
-    T: FnOnce() -> () + panic::UnwindSafe,
+    T: FnOnce() + panic::UnwindSafe,
 {
     utils::set_network_environment("macvtap");
 

--- a/src/lib/tests/route.rs
+++ b/src/lib/tests/route.rs
@@ -14,7 +14,6 @@
 
 use nispor::{NetConf, NetState, RouteProtocol};
 use pretty_assertions::assert_eq;
-use serde_yaml;
 
 mod utils;
 
@@ -251,9 +250,9 @@ ifaces:
     type: veth
     state: absent"#;
 
-fn with_veth_static_ip<T>(test: T) -> ()
+fn with_veth_static_ip<T>(test: T)
 where
-    T: FnOnce() -> () + std::panic::UnwindSafe,
+    T: FnOnce() + std::panic::UnwindSafe,
 {
     let net_conf: NetConf = serde_yaml::from_str(VETH_STATIC_IP_CONF).unwrap();
     net_conf.apply().unwrap();
@@ -271,9 +270,9 @@ fn test_get_route_yaml() {
         let state = NetState::retrieve().unwrap();
         let mut expected_routes = Vec::new();
         for route in state.routes {
-            if Some(TEST_ROUTE_DST_V4.into()) == route.dst {
-                expected_routes.push(route)
-            } else if Some(TEST_ROUTE_DST_V6.into()) == route.dst {
+            if Some(TEST_ROUTE_DST_V4.into()) == route.dst
+                || Some(TEST_ROUTE_DST_V6.into()) == route.dst
+            {
                 expected_routes.push(route)
             }
         }
@@ -284,9 +283,9 @@ fn test_get_route_yaml() {
     });
 }
 
-fn with_route_test_iface<T>(test: T) -> ()
+fn with_route_test_iface<T>(test: T)
 where
-    T: FnOnce() -> () + std::panic::UnwindSafe,
+    T: FnOnce() + std::panic::UnwindSafe,
 {
     utils::set_network_environment("route");
 

--- a/src/lib/tests/route_rule.rs
+++ b/src/lib/tests/route_rule.rs
@@ -14,7 +14,7 @@
 
 use nispor::NetState;
 use pretty_assertions::assert_eq;
-use serde_yaml;
+
 use std::panic;
 
 mod utils;
@@ -62,9 +62,9 @@ fn test_get_route_rule_yaml() {
     });
 }
 
-fn with_route_rule_test_iface<T>(test: T) -> ()
+fn with_route_rule_test_iface<T>(test: T)
 where
-    T: FnOnce() -> () + panic::UnwindSafe,
+    T: FnOnce() + panic::UnwindSafe,
 {
     utils::set_network_environment("rule");
 

--- a/src/lib/tests/tap.rs
+++ b/src/lib/tests/tap.rs
@@ -14,7 +14,7 @@
 
 use nispor::NetState;
 use pretty_assertions::assert_eq;
-use serde_yaml;
+
 use std::panic;
 
 mod utils;
@@ -45,9 +45,9 @@ fn test_get_tap_iface_yaml() {
     });
 }
 
-fn with_tap_iface<T>(test: T) -> ()
+fn with_tap_iface<T>(test: T)
 where
-    T: FnOnce() -> () + panic::UnwindSafe,
+    T: FnOnce() + panic::UnwindSafe,
 {
     utils::set_network_environment("tap");
 

--- a/src/lib/tests/tun.rs
+++ b/src/lib/tests/tun.rs
@@ -14,7 +14,7 @@
 
 use nispor::NetState;
 use pretty_assertions::assert_eq;
-use serde_yaml;
+
 use std::panic;
 
 mod utils;
@@ -45,9 +45,9 @@ fn test_get_tun_iface_yaml() {
     });
 }
 
-fn with_tun_iface<T>(test: T) -> ()
+fn with_tun_iface<T>(test: T)
 where
-    T: FnOnce() -> () + panic::UnwindSafe,
+    T: FnOnce() + panic::UnwindSafe,
 {
     utils::set_network_environment("tun");
 

--- a/src/lib/tests/utils.rs
+++ b/src/lib/tests/utils.rs
@@ -29,5 +29,5 @@ pub fn cmd_exec(command: &str, args: Vec<&str>) -> bool {
     }
     let status = proc.status().expect("failed to execute the command");
 
-    return status.success();
+    status.success()
 }

--- a/src/lib/tests/veth.rs
+++ b/src/lib/tests/veth.rs
@@ -14,7 +14,7 @@
 
 use nispor::{IfaceState, NetConf, NetState};
 use pretty_assertions::assert_eq;
-use serde_yaml;
+
 use std::panic;
 
 mod utils;
@@ -38,9 +38,9 @@ fn test_get_veth_iface_yaml() {
     });
 }
 
-fn with_veth_iface<T>(test: T) -> ()
+fn with_veth_iface<T>(test: T)
 where
-    T: FnOnce() -> () + panic::UnwindSafe,
+    T: FnOnce() + panic::UnwindSafe,
 {
     utils::set_network_environment("veth");
 

--- a/src/lib/tests/vlan.rs
+++ b/src/lib/tests/vlan.rs
@@ -14,7 +14,7 @@
 
 use nispor::{NetConf, NetState};
 use pretty_assertions::assert_eq;
-use serde_yaml;
+
 use std::panic;
 
 mod utils;
@@ -44,9 +44,9 @@ fn test_get_vlan_iface_yaml() {
     });
 }
 
-fn with_vlan_iface<T>(test: T) -> ()
+fn with_vlan_iface<T>(test: T)
 where
-    T: FnOnce() -> () + panic::UnwindSafe,
+    T: FnOnce() + panic::UnwindSafe,
 {
     utils::set_network_environment("vlan");
 

--- a/src/lib/tests/vrf.rs
+++ b/src/lib/tests/vrf.rs
@@ -14,7 +14,7 @@
 
 use nispor::NetState;
 use pretty_assertions::assert_eq;
-use serde_yaml;
+
 use std::panic;
 
 mod utils;
@@ -41,9 +41,9 @@ fn test_get_vrf_iface_yaml() {
     });
 }
 
-fn with_vrf_iface<T>(test: T) -> ()
+fn with_vrf_iface<T>(test: T)
 where
-    T: FnOnce() -> () + panic::UnwindSafe,
+    T: FnOnce() + panic::UnwindSafe,
 {
     utils::set_network_environment("vrf");
 

--- a/src/lib/tests/vxlan.rs
+++ b/src/lib/tests/vxlan.rs
@@ -14,7 +14,7 @@
 
 use nispor::NetState;
 use pretty_assertions::assert_eq;
-use serde_yaml;
+
 use std::panic;
 
 mod utils;
@@ -64,9 +64,9 @@ fn test_get_vxlan_iface_yaml() {
     });
 }
 
-fn with_vxlan_iface<T>(test: T) -> ()
+fn with_vxlan_iface<T>(test: T)
 where
-    T: FnOnce() -> () + panic::UnwindSafe,
+    T: FnOnce() + panic::UnwindSafe,
 {
     utils::set_network_environment("vxlan");
 


### PR DESCRIPTION
The `netlink-package-route` 0.12 has `AfSpecBridge` parsed, so we move our code.