### PR TITLE
veth: fix report of veth peer on a different netns

### DIFF
--- a/src/lib/ifaces/iface.rs
+++ b/src/lib/ifaces/iface.rs
@@ -224,6 +224,8 @@ pub struct Iface {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub controller_type: Option<ControllerType>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub link_netnsid: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ethtool: Option<EthtoolInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bond: Option<BondInfo>,
@@ -406,6 +408,8 @@ pub(crate) fn parse_nl_msg_to_iface(
             if let Ok(info) = get_sriov_info(&iface_state.name, data, mac_len) {
                 iface_state.sriov = Some(info);
             }
+        } else if let Nla::NetnsId(id) = nla {
+            iface_state.link_netnsid = Some(*id);
         } else {
             // println!("{} {:?}", name, nla);
         }

--- a/src/lib/ifaces/veth.rs
+++ b/src/lib/ifaces/veth.rs
@@ -61,6 +61,11 @@ pub(crate) fn veth_iface_tidy_up(iface_states: &mut HashMap<String, Iface>) {
         if iface.iface_type != IfaceType::Veth {
             continue;
         }
+        // If the link_netnsid is set, the veth peer is on a different netns
+        // and therefore Nispor should use the ifindex instead.
+        if iface.link_netnsid.is_some() {
+            continue;
+        }
 
         if let Some(VethInfo { peer }) = &iface.veth {
             if let Some(peer_iface_name) = index_to_name.get(peer) {


### PR DESCRIPTION
When the veth peer is on a different netns, the ifindex counting start
from "1" again. That means, if the veth has ifindex 30 one could expect
the peer will have ifindex 31 but if it is on a different netns, the
ifindex could be completetly different, e.g "2".

Signed-off-by: Fernando Fernandez Mancera <ffmancera@riseup.net>