### PR TITLE
New release 1.2.6

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,18 @@
 # Changelog
+## [1.2.6] - 2022-06-24
+
+## Break changes
+ * clib: Change SONAME from libnispor.1.2 to libnispor.so.1
+
+## New features
+
+ * N/A
+
+## Bug fixes
+
+ * drop the need of serde_derive. (4857775)
+ * Use latest rust-netlink crates. (45ba94a)
+
 ## [1.2.5] - 2022-03-30
 
 ## Break changes

--- a/DEVEL.md
+++ b/DEVEL.md
@@ -59,8 +59,8 @@ autocmd FileType rust nnoremap <silent> <leader>f :RustFmt<cr>
 ## Release workflow
 
 ```bash
-sed -i -e 's/1.2.5/1.2.6/' \
-    Makefile.inc src/*/Cargo.toml src/python/setup.py .cargo/config.toml
+sed -i -e 's/1.2.6/1.2.7/' \
+    Makefile.inc src/*/Cargo.toml src/python/setup.py
 ```
 
 ```bash

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,4 +1,4 @@
-CLIB_VERSION=1.2.5
+CLIB_VERSION=1.2.6
 CLIB_VERSION_MAJOR=$(shell echo $(CLIB_VERSION) | cut -f1 -d.)
 CLIB_VERSION_MINOR=$(shell echo $(CLIB_VERSION) | cut -f2 -d.)
 CLIB_VERSION_MICRO=$(shell echo $(CLIB_VERSION) | cut -f3 -d.)

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nispor-cli"
-version = "1.2.5"
+version = "1.2.6"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2018"
@@ -19,7 +19,7 @@ path = "npc.rs"
 serde_json = "1.0"
 serde = { version = "1.0.136", features = ["derive"] }
 clap = { version = "3.1.2", features = ["cargo"] }
-nispor = { path = "../lib", version="1.2.5" }
+nispor = { path = "../lib", version="1.2.6" }
 serde_yaml = "0.8"
 env_logger = "0.9.0"
 log = "0.4.14"

--- a/src/clib/Cargo.toml
+++ b/src/clib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nispor-clib"
-version = "1.2.5"
+version = "1.2.6"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nispor"
-version = "1.2.5"
+version = "1.2.6"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="nispor",
-    version="1.2.5",
+    version="1.2.6",
     author="Gris Ge",
     author_email="fge@redhat.com",
     description="Python binding of Nispor",


### PR DESCRIPTION
== Break changes

 * clib: Change SONAME from libnispor.1.2 to libnispor.so.1

== New features

 * N/A

== Bug fixes

 * drop the need of serde_derive. (4857775)
 * Use latest rust-netlink crates. (45ba94a)