### PR TITLE
SR-IOV: Include SRIOV VF information per VF interface

### DIFF
--- a/src/lib/ifaces/iface.rs
+++ b/src/lib/ifaces/iface.rs
@@ -39,7 +39,7 @@ use crate::{
     ip::{IpConf, Ipv4Info, Ipv6Info},
     mac::{mac_str_to_raw, parse_as_mac},
     mptcp::MptcpAddress,
-    NisporError,
+    NisporError, VfInfo,
 };
 
 use netlink_packet_route::rtnl::{
@@ -256,6 +256,8 @@ pub struct Iface {
     pub mac_vtap: Option<MacVtapInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sriov: Option<SriovInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sriov_vf: Option<VfInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ipoib: Option<IpoibInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/lib/ifaces/mod.rs
+++ b/src/lib/ifaces/mod.rs
@@ -49,6 +49,7 @@ use crate::ifaces::iface::{
 };
 use crate::ifaces::ipoib::ipoib_iface_tidy_up;
 use crate::ifaces::mac_vlan::mac_vlan_iface_tidy_up;
+use crate::ifaces::sriov::sriov_vf_iface_tidy_up;
 use crate::ifaces::veth::veth_iface_tidy_up;
 use crate::ifaces::vlan::vlan_iface_tidy_up;
 use crate::ifaces::vrf::vrf_iface_tidy_up;
@@ -118,6 +119,7 @@ fn tidy_up(iface_states: &mut HashMap<String, Iface>) {
     vrf_iface_tidy_up(iface_states);
     mac_vlan_iface_tidy_up(iface_states);
     ipoib_iface_tidy_up(iface_states);
+    sriov_vf_iface_tidy_up(iface_states);
 }
 
 fn controller_iface_index_to_name(iface_states: &mut HashMap<String, Iface>) {

--- a/src/lib/mac.rs
+++ b/src/lib/mac.rs
@@ -37,7 +37,7 @@ pub(crate) fn parse_as_mac(
 }
 
 pub(crate) fn mac_str_to_raw(mac_addr: &str) -> Result<Vec<u8>, NisporError> {
-    let mac_addr = mac_addr.to_string().replace(':', "").replace('-', "");
+    let mac_addr = mac_addr.to_string().replace([':', '-'], "");
 
     let mut mac_raw: Vec<u8> = Vec::new();
 

--- a/src/python/nispor/base_iface.py
+++ b/src/python/nispor/base_iface.py
@@ -15,6 +15,7 @@
 from .ip import NisporIPv4
 from .ip import NisporIPv6
 from .sr_iov import NisporSriov
+from .sr_iov import NisporSriovVf
 from .ethtool import NisporEthtool
 
 
@@ -28,6 +29,8 @@ class NisporBaseIface:
             self._sr_iov = NisporSriov(self._info["sriov"])
         if "ethtool" in self._info:
             self._ethtool = NisporEthtool(self._info["ethtool"])
+        if "sriov_vf" in self._info:
+            self._sr_iov_vf = NisporSriovVf(self._info["sriov_vf"])
 
     def __str__(self):
         return f"{self._info}"
@@ -93,6 +96,10 @@ class NisporBaseIface:
     @property
     def sr_iov(self):
         return self._sr_iov
+
+    @property
+    def sr_iov_vf(self):
+        return self._sr_iov_vf
 
     @property
     def ethtool(self):

--- a/src/python/nispor/bridge.py
+++ b/src/python/nispor/bridge.py
@@ -33,17 +33,13 @@ class NisporBridge(NisporBaseIface):
     def options(self):
         if self._br_info:
             return {
-                key: value
-                for key, value in self._br_info.items()
-                if key != "ports"
+                key: value for key, value in self._br_info.items() if key != "ports"
             }
         return None
 
 
 class NisporBridgePortVlan:
-    def __init__(
-        self, vid=None, vid_range=None, is_pvid=None, is_egress_untagged=None
-    ):
+    def __init__(self, vid=None, vid_range=None, is_pvid=None, is_egress_untagged=None):
         self.vid = vid
         self.vid_range = vid_range
         self.is_pvid = is_pvid

--- a/src/python/nispor/ethtool.py
+++ b/src/python/nispor/ethtool.py
@@ -60,6 +60,7 @@ class NisporEthtool:
     def link_mode(self):
         return self._link_mode
 
+
 class NisporEthtoolPause:
     def __init__(self, info):
         self._info = info

--- a/src/python/nispor/ipoib.py
+++ b/src/python/nispor/ipoib.py
@@ -14,6 +14,7 @@
 
 from .base_iface import NisporBaseIface
 
+
 class NisporIpoib(NisporBaseIface):
     def __init__(self, info):
         super().__init__(info)

--- a/src/python/nispor/mptcp.py
+++ b/src/python/nispor/mptcp.py
@@ -16,8 +16,7 @@
 class NisporMptcpState:
     def __init__(self, info):
         self._addrs = [
-            NisporMptcpAddress(addr_info)
-            for addr_info in info.get("addresses", [])
+            NisporMptcpAddress(addr_info) for addr_info in info.get("addresses", [])
         ]
 
     @property

--- a/src/python/nispor/sr_iov.py
+++ b/src/python/nispor/sr_iov.py
@@ -31,6 +31,10 @@ class NisporSriovVf:
         return self._info.get("iface_name")
 
     @property
+    def pf_name(self):
+        return self._info.get("pf_name")
+
+    @property
     def vf_id(self):
         return self._info["id"]
 

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -10,11 +10,10 @@ setuptools.setup(
     url="https://github.com/nispor/nispor/",
     packages=setuptools.find_packages(),
     license="ASL2.0+",
-    python_requires='>=3.6',
+    python_requires=">=3.6",
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: POSIX :: Linux",
     ],
 )
-


### PR DESCRIPTION
Added `pf_name: Option<String>` property to `struct VfInfo`. Included
`VfInfo` to VF interface as `pub sriov_vf: Option<VfInfo>`.

Also updated python binding:

 * `NisporSriovVf.pf_name`  -> String or None
 * `NisporBaseIface.sr_iov_vf` -> NisporSriovVf or None