### PR TITLE
route: Support kernel side filter for route dump

### DIFF
--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -21,6 +21,7 @@ mod net_conf;
 mod net_state;
 mod netlink;
 mod route;
+mod route_filter;
 mod route_rule;
 
 pub use crate::error::NisporError;
@@ -44,9 +45,10 @@ pub use crate::ip::{
 };
 pub use crate::mptcp::{Mptcp, MptcpAddress, MptcpAddressFlag};
 pub use crate::net_conf::NetConf;
-pub use crate::net_state::NetState;
+pub use crate::net_state::{retrieve_routes_with_filter, NetState};
 pub use crate::route::{
     AddressFamily, MultipathRoute, MultipathRouteFlags, Route, RouteConf,
     RouteProtocol, RouteScope, RouteType,
 };
+pub use crate::route_filter::NetStateRouteFilter;
 pub use crate::route_rule::{RouteRule, RuleAction};

--- a/tools/test_env
+++ b/tools/test_env
@@ -9,12 +9,13 @@ TEST_MAC4="00:23:45:67:89:1d"
 TEST_MAC5="00:23:45:67:89:1f"
 TEST_MAC_SIM0="00:23:45:67:89:20"
 TEST_MAC_SIM1="00:23:45:67:89:21"
+TEST_ROUTE_TABLE_ID=100
 
 sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0 1>/dev/null
 
 if [ "CHK$1" == "CHK" ];then
     echo 'Need argument: bond, br, brv, vlan, dummy, vxlan, veth, vrf, sriov,'
-    echo 'rm, route, rule, sim, mptcp'
+    echo 'rm, route, rule, sim, mptcp, bgp'
     exit 1
 fi
 
@@ -38,6 +39,7 @@ function clean_up {
     sudo ip -6 rule del priority 999
     sudo modprobe -r netdevsim
     sudo ip mptcp endpoint flush
+    sudo ip route flush table $TEST_ROUTE_TABLE_ID
 }
 
 function create_nics {
@@ -204,6 +206,17 @@ elif [ "CHK$1" == "CHKmptcp" ];then
     sudo ip mptcp limits set subflow 1 add_addr_accepted 1
     sudo ip mptcp endpoint add 192.0.2.2 dev eth2 signal
     sudo ip mptcp endpoint add 2001:db8:f::1 dev eth2 backup
+elif [ "CHK$1" == "CHKbgp" ];then
+    create_nics
+    sudo ip link set eth1 up
+    sudo ip addr add 192.0.2.2/24 dev eth1
+    sudo ip -6 addr add 2001:db8:f::1/64 dev eth1
+    for x in $(seq 2 254); do
+        for y in $(seq 2 254); do
+            echo -n "route add 192.0.${x}.${y}/32 dev eth1 proto "
+            echo "186 table $TEST_ROUTE_TABLE_ID"
+        done
+    done | sudo ip -b -
 elif [ "CHK$1" == "CHKrm" ];then
     clean_up 2>/dev/null
 fi


### PR DESCRIPTION
With `NETLINK_GET_STRICT_CHK` enabled via `setsockopt()`, the kernel
will not include unmatch route in route dumping, this save the
usespace from filtering it afterwards.

User may use `nispor::retrieve_routes_with_filter()` for this kernel
filter.

The CLI tool updated to use this for command like `npc route -p static`.