### PR TITLE
dependency: Upgrade to serde_yaml 0.9

### DIFF
--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -20,6 +20,6 @@ serde_json = "1.0"
 serde = { version = "1.0.136", features = ["derive"] }
 clap = { version = "3.1.2", features = ["cargo"] }
 nispor = { path = "../lib", version="1.2.7" }
-serde_yaml = "0.8"
+serde_yaml = "0.9"
 env_logger = "0.9.0"
 log = "0.4.14"

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -30,5 +30,5 @@ log = "0.4.17"
 mptcp-pm = "0.1.0"
 
 [dev-dependencies]
-serde_yaml = "0.8.24"
+serde_yaml = "0.9"
 pretty_assertions = "1.2.1"

--- a/src/lib/crate_tests/bond.rs
+++ b/src/lib/crate_tests/bond.rs
@@ -64,18 +64,8 @@ fn test_get_iface_bond_yaml() {
 
         assert_value_match(EXPECTED_BOND_IFACE, &iface);
 
-        assert_eq!(
-            serde_yaml::to_string(&port1.bond_subordinate)
-                .unwrap()
-                .trim(),
-            EXPECTED_PORT1_INFO
-        );
-        assert_eq!(
-            serde_yaml::to_string(&port2.bond_subordinate)
-                .unwrap()
-                .trim(),
-            EXPECTED_PORT2_INFO
-        );
+        assert_value_match(EXPECTED_PORT1_INFO, &port1.bond_subordinate);
+        assert_value_match(EXPECTED_PORT2_INFO, &port2.bond_subordinate);
         assert_eq!(port1.controller, Some("bond99".to_string()));
         assert_eq!(port2.controller, Some("bond99".to_string()));
         assert_eq!(port1.controller_type, Some(crate::ControllerType::Bond));

--- a/src/lib/crate_tests/bridge.rs
+++ b/src/lib/crate_tests/bridge.rs
@@ -175,14 +175,8 @@ fn test_get_br_iface_yaml() {
         assert_eq!(iface.iface_type, crate::IfaceType::Bridge);
 
         assert_value_match(EXPECTED_BRIDGE_INFO, iface);
-        assert_eq!(
-            serde_yaml::to_string(&port1.bridge_port).unwrap().trim(),
-            EXPECTED_PORT1_BRIDGE_INFO,
-        );
-        assert_eq!(
-            serde_yaml::to_string(&port2.bridge_port).unwrap().trim(),
-            EXPECTED_PORT2_BRIDGE_INFO,
-        );
+        assert_value_match(EXPECTED_PORT1_BRIDGE_INFO, &port1.bridge_port);
+        assert_value_match(EXPECTED_PORT2_BRIDGE_INFO, &port2.bridge_port);
     });
 }
 

--- a/src/lib/crate_tests/bridge_vlan_filter.rs
+++ b/src/lib/crate_tests/bridge_vlan_filter.rs
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::NetState;
+use std::panic;
+
 use pretty_assertions::assert_eq;
 
-use std::panic;
+use crate::NetState;
+
+use super::utils::assert_value_match;
 
 const IFACE_NAME: &str = "br0";
 const PORT1_NAME: &str = "eth1";
@@ -118,14 +121,8 @@ fn test_get_br_vlan_filter_iface_yaml() {
 
         let port1 = &state.ifaces[PORT1_NAME];
         let port2 = &state.ifaces[PORT2_NAME];
-        assert_eq!(
-            serde_yaml::to_string(&port1.bridge_port).unwrap().trim(),
-            EXPECTED_PORT1_BRIDGE_INFO,
-        );
-        assert_eq!(
-            serde_yaml::to_string(&port2.bridge_port).unwrap().trim(),
-            EXPECTED_PORT2_BRIDGE_INFO,
-        );
+        assert_value_match(EXPECTED_PORT1_BRIDGE_INFO, &port1.bridge_port);
+        assert_value_match(EXPECTED_PORT2_BRIDGE_INFO, &port2.bridge_port);
     });
 }
 

--- a/src/lib/crate_tests/ethtool.rs
+++ b/src/lib/crate_tests/ethtool.rs
@@ -5,6 +5,8 @@ use pretty_assertions::assert_eq;
 
 use std::panic;
 
+use super::utils::assert_value_match;
+
 const IFACE_NAME0: &str = "sim0";
 const IFACE_NAME1: &str = "sim1";
 
@@ -85,17 +87,13 @@ fn test_get_ethtool_pause_yaml() {
         let iface1 = &state.ifaces[IFACE_NAME1];
         assert_eq!(&iface0.iface_type, &crate::IfaceType::Ethernet);
         assert_eq!(&iface1.iface_type, &crate::IfaceType::Ethernet);
-        assert_eq!(
-            serde_yaml::to_string(&iface0.ethtool.as_ref().unwrap().pause)
-                .unwrap()
-                .trim(),
-            EXPECTED_PAUSE_INFO
+        assert_value_match(
+            EXPECTED_PAUSE_INFO,
+            &iface0.ethtool.as_ref().unwrap().pause,
         );
-        assert_eq!(
-            serde_yaml::to_string(&iface1.ethtool.as_ref().unwrap().pause)
-                .unwrap()
-                .trim(),
-            EXPECTED_PAUSE_INFO
+        assert_value_match(
+            EXPECTED_PAUSE_INFO,
+            &iface1.ethtool.as_ref().unwrap().pause,
         );
     });
 }
@@ -134,11 +132,9 @@ fn test_get_ethtool_feature_yaml_of_loopback() {
         .as_mut()
         .map(|features| features.changeable.remove("tx-udp-segmentation"));
     assert_eq!(&iface.iface_type, &crate::IfaceType::Loopback);
-    assert_eq!(
-        serde_yaml::to_string(&iface.ethtool.as_ref().unwrap().features)
-            .unwrap()
-            .trim(),
-        EXPECTED_FEATURE_INFO
+    assert_value_match(
+        EXPECTED_FEATURE_INFO,
+        &iface.ethtool.as_ref().unwrap().features,
     );
 }
 
@@ -172,11 +168,9 @@ fn test_get_ethtool_coalesce_yaml() {
     with_tun_iface(|| {
         let state = NetState::retrieve().unwrap();
         let iface = &state.ifaces[IFACE_TUN_NAME];
-        assert_eq!(
-            serde_yaml::to_string(&iface.ethtool.as_ref().unwrap().coalesce)
-                .unwrap()
-                .trim(),
-            EXPECTED_ETHTOOL_COALESCE
+        assert_value_match(
+            EXPECTED_ETHTOOL_COALESCE,
+            &iface.ethtool.as_ref().unwrap().coalesce,
         );
     });
 }
@@ -186,11 +180,9 @@ fn test_get_ethtool_link_mode_yaml() {
     with_tun_iface(|| {
         let state = NetState::retrieve().unwrap();
         let iface = &state.ifaces[IFACE_TUN_NAME];
-        assert_eq!(
-            serde_yaml::to_string(&iface.ethtool.as_ref().unwrap().link_mode)
-                .unwrap()
-                .trim(),
-            EXPECTED_ETHTOOL_LINK_MODE
+        assert_value_match(
+            EXPECTED_ETHTOOL_LINK_MODE,
+            &iface.ethtool.as_ref().unwrap().link_mode,
         );
     });
 }

--- a/src/lib/crate_tests/ip.rs
+++ b/src/lib/crate_tests/ip.rs
@@ -5,6 +5,8 @@ use pretty_assertions::assert_eq;
 
 use std::panic;
 
+use super::utils::assert_value_match;
+
 const IFACE_NAME: &str = "veth1";
 
 fn with_veth_iface<T>(test: T)
@@ -115,14 +117,8 @@ fn test_add_and_remove_ip() {
         let iface = &state.ifaces[IFACE_NAME];
         let iface_type = &iface.iface_type;
         assert_eq!(iface_type, &crate::IfaceType::Veth);
-        assert_eq!(
-            serde_yaml::to_string(&iface.ipv4).unwrap().trim(),
-            EXPECTED_IPV4_INFO
-        );
-        assert_eq!(
-            serde_yaml::to_string(&iface.ipv6).unwrap().trim(),
-            EXPECTED_IPV6_INFO
-        );
+        assert_value_match(EXPECTED_IPV4_INFO, &iface.ipv4);
+        assert_value_match(EXPECTED_IPV6_INFO, &iface.ipv6);
         let conf: NetConf = serde_yaml::from_str(DEL_IP_CONF).unwrap();
         conf.apply().unwrap();
         let state = NetState::retrieve().unwrap();
@@ -130,10 +126,7 @@ fn test_add_and_remove_ip() {
         let iface_type = &iface.iface_type;
         assert_eq!(iface_type, &crate::IfaceType::Veth);
         assert_eq!(iface.ipv4, None);
-        assert_eq!(
-            serde_yaml::to_string(&iface.ipv6).unwrap().trim(),
-            EXPECTED_EMPTY_IPV6_INFO
-        );
+        assert_value_match(EXPECTED_EMPTY_IPV6_INFO, &iface.ipv6);
     });
 }
 
@@ -146,14 +139,8 @@ fn test_add_and_remove_dynamic_ip() {
         let iface = &state.ifaces[IFACE_NAME];
         let iface_type = &iface.iface_type;
         assert_eq!(iface_type, &crate::IfaceType::Veth);
-        assert_eq!(
-            serde_yaml::to_string(&iface.ipv4).unwrap().trim(),
-            EXPECTED_IPV4_DYNAMIC_INFO
-        );
-        assert_eq!(
-            serde_yaml::to_string(&iface.ipv6).unwrap().trim(),
-            EXPECTED_IPV6_DYNAMIC_INFO
-        );
+        assert_value_match(EXPECTED_IPV4_DYNAMIC_INFO, &iface.ipv4);
+        assert_value_match(EXPECTED_IPV6_DYNAMIC_INFO, &iface.ipv6);
         let conf: NetConf = serde_yaml::from_str(DEL_IP_CONF).unwrap();
         conf.apply().unwrap();
         let state = NetState::retrieve().unwrap();
@@ -161,10 +148,7 @@ fn test_add_and_remove_dynamic_ip() {
         let iface_type = &iface.iface_type;
         assert_eq!(iface_type, &crate::IfaceType::Veth);
         assert_eq!(iface.ipv4, None);
-        assert_eq!(
-            serde_yaml::to_string(&iface.ipv6).unwrap().trim(),
-            EXPECTED_EMPTY_IPV6_INFO
-        );
+        assert_value_match(EXPECTED_EMPTY_IPV6_INFO, &iface.ipv6);
     });
 }
 
@@ -180,13 +164,7 @@ fn test_add_dynamic_ip_repeat() {
         let iface = &state.ifaces[IFACE_NAME];
         let iface_type = &iface.iface_type;
         assert_eq!(iface_type, &crate::IfaceType::Veth);
-        assert_eq!(
-            serde_yaml::to_string(&iface.ipv4).unwrap().trim(),
-            EXPECTED_IPV4_DYNAMIC_INFO
-        );
-        assert_eq!(
-            serde_yaml::to_string(&iface.ipv6).unwrap().trim(),
-            EXPECTED_IPV6_DYNAMIC_INFO
-        );
+        assert_value_match(EXPECTED_IPV4_DYNAMIC_INFO, &iface.ipv4);
+        assert_value_match(EXPECTED_IPV6_DYNAMIC_INFO, &iface.ipv6);
     });
 }

--- a/src/lib/crate_tests/mac_vlan.rs
+++ b/src/lib/crate_tests/mac_vlan.rs
@@ -5,6 +5,8 @@ use pretty_assertions::assert_eq;
 
 use std::panic;
 
+use super::utils::assert_value_match;
+
 const IFACE_NAME: &str = "mac0";
 
 const EXPECTED_MAC_VLAN_STATE: &str = r#"---
@@ -21,10 +23,7 @@ fn test_get_macvlan_iface_yaml() {
         let state = NetState::retrieve().unwrap();
         let iface = &state.ifaces[IFACE_NAME];
         assert_eq!(iface.iface_type, crate::IfaceType::MacVlan);
-        assert_eq!(
-            serde_yaml::to_string(&iface.mac_vlan).unwrap().trim(),
-            EXPECTED_MAC_VLAN_STATE
-        );
+        assert_value_match(EXPECTED_MAC_VLAN_STATE, &iface.mac_vlan);
     });
 }
 

--- a/src/lib/crate_tests/mac_vtap.rs
+++ b/src/lib/crate_tests/mac_vtap.rs
@@ -5,6 +5,8 @@ use pretty_assertions::assert_eq;
 
 use std::panic;
 
+use super::utils::assert_value_match;
+
 const IFACE_NAME: &str = "macvtap0";
 
 const EXPECTED_MAC_VTAP_INFO: &str = r#"---
@@ -21,10 +23,7 @@ fn test_get_macvtap_iface_yaml() {
         let state = NetState::retrieve().unwrap();
         let iface = &state.ifaces[IFACE_NAME];
         assert_eq!(iface.iface_type, crate::IfaceType::MacVtap);
-        assert_eq!(
-            serde_yaml::to_string(&iface.mac_vtap).unwrap().trim(),
-            EXPECTED_MAC_VTAP_INFO
-        );
+        assert_value_match(EXPECTED_MAC_VTAP_INFO, &iface.mac_vtap);
     });
 }
 

--- a/src/lib/crate_tests/route.rs
+++ b/src/lib/crate_tests/route.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{NetConf, NetState, RouteProtocol};
-use pretty_assertions::assert_eq;
+
+use super::utils::assert_value_match;
 
 const TEST_ROUTE_DST_V4: &str = "198.51.100.0/24";
 const TEST_ROUTE_DST_V6: &str = "2001:db8:e::/64";
@@ -193,10 +194,7 @@ fn test_add_remove_route_yaml() {
             }
         }
         expected_routes.sort_unstable_by_key(|r| r.metric);
-        assert_eq!(
-            serde_yaml::to_string(&expected_routes).unwrap().trim(),
-            EXPECTED_YAML_OUTPUT
-        );
+        assert_value_match(EXPECTED_YAML_OUTPUT, &expected_routes);
 
         let net_conf: NetConf = serde_yaml::from_str(REMOVE_ROUTE_YML).unwrap();
         net_conf.apply().unwrap();
@@ -262,10 +260,7 @@ fn test_get_route_yaml() {
                 expected_routes.push(route)
             }
         }
-        assert_eq!(
-            serde_yaml::to_string(&expected_routes).unwrap().trim(),
-            EXPECTED_MULTIPATH_YAML_OUTPUT
-        );
+        assert_value_match(EXPECTED_MULTIPATH_YAML_OUTPUT, &expected_routes);
     });
 }
 

--- a/src/lib/crate_tests/route_rule.rs
+++ b/src/lib/crate_tests/route_rule.rs
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::NetState;
-use pretty_assertions::assert_eq;
 
 use std::panic;
+
+use super::utils::assert_value_match;
 
 const TEST_TABLE_ID: u32 = 100;
 
@@ -41,10 +42,7 @@ fn test_get_route_rule_yaml() {
                 expected_rules.push(rule)
             }
         }
-        assert_eq!(
-            serde_yaml::to_string(&expected_rules).unwrap().trim(),
-            EXPECTED_YAML_OUTPUT
-        );
+        assert_value_match(EXPECTED_YAML_OUTPUT, &expected_rules);
     });
 }
 

--- a/src/lib/crate_tests/tap.rs
+++ b/src/lib/crate_tests/tap.rs
@@ -5,6 +5,8 @@ use pretty_assertions::assert_eq;
 
 use std::panic;
 
+use super::utils::assert_value_match;
+
 const IFACE_NAME: &str = "tap1";
 
 const EXPECTED_TAP_INFO: &str = r#"---
@@ -24,10 +26,7 @@ fn test_get_tap_iface_yaml() {
         let state = NetState::retrieve().unwrap();
         let iface = &state.ifaces[IFACE_NAME];
         assert_eq!(iface.iface_type, crate::IfaceType::Tun);
-        assert_eq!(
-            serde_yaml::to_string(&iface.tun).unwrap().trim(),
-            EXPECTED_TAP_INFO
-        );
+        assert_value_match(EXPECTED_TAP_INFO, &iface.tun);
     });
 }
 

--- a/src/lib/crate_tests/tun.rs
+++ b/src/lib/crate_tests/tun.rs
@@ -5,6 +5,8 @@ use pretty_assertions::assert_eq;
 
 use std::panic;
 
+use super::utils::assert_value_match;
+
 const IFACE_NAME: &str = "tun1";
 
 const EXPECTED_TUN_INFO: &str = r#"---
@@ -24,10 +26,7 @@ fn test_get_tun_iface_yaml() {
         let state = NetState::retrieve().unwrap();
         let iface = &state.ifaces[IFACE_NAME];
         assert_eq!(iface.iface_type, crate::IfaceType::Tun);
-        assert_eq!(
-            serde_yaml::to_string(&iface.tun).unwrap().trim(),
-            EXPECTED_TUN_INFO
-        );
+        assert_value_match(EXPECTED_TUN_INFO, &iface.tun);
     });
 }
 

--- a/src/lib/crate_tests/veth.rs
+++ b/src/lib/crate_tests/veth.rs
@@ -5,6 +5,8 @@ use pretty_assertions::assert_eq;
 
 use std::panic;
 
+use super::utils::assert_value_match;
+
 const IFACE_NAME: &str = "veth1";
 
 const EXPECTED_VETH_INFO: &str = r#"---
@@ -17,10 +19,7 @@ fn test_get_veth_iface_yaml() {
         let iface = &state.ifaces[IFACE_NAME];
         let iface_type = &iface.iface_type;
         assert_eq!(iface_type, &crate::IfaceType::Veth);
-        assert_eq!(
-            serde_yaml::to_string(&iface.veth).unwrap().trim(),
-            EXPECTED_VETH_INFO
-        );
+        assert_value_match(EXPECTED_VETH_INFO, &iface.veth);
     });
 }
 

--- a/src/lib/crate_tests/vlan.rs
+++ b/src/lib/crate_tests/vlan.rs
@@ -5,6 +5,8 @@ use pretty_assertions::assert_eq;
 
 use std::panic;
 
+use super::utils::assert_value_match;
+
 const IFACE_NAME: &str = "eth1.101";
 
 const EXPECTED_VLAN_INFO: &str = r#"---
@@ -23,10 +25,7 @@ fn test_get_vlan_iface_yaml() {
         let state = NetState::retrieve().unwrap();
         let iface = &state.ifaces[IFACE_NAME];
         assert_eq!(iface.iface_type, crate::IfaceType::Vlan);
-        assert_eq!(
-            serde_yaml::to_string(&iface.vlan).unwrap().trim(),
-            EXPECTED_VLAN_INFO
-        );
+        assert_value_match(EXPECTED_VLAN_INFO, &iface.vlan);
     });
 }
 

--- a/src/lib/crate_tests/vrf.rs
+++ b/src/lib/crate_tests/vrf.rs
@@ -5,6 +5,8 @@ use pretty_assertions::assert_eq;
 
 use std::panic;
 
+use super::utils::assert_value_match;
+
 const IFACE_NAME: &str = "vrf0";
 
 const EXPECTED_VRF_INFO: &str = r#"---
@@ -20,10 +22,7 @@ fn test_get_vrf_iface_yaml() {
         let state = NetState::retrieve().unwrap();
         let iface = &state.ifaces[IFACE_NAME];
         assert_eq!(iface.iface_type, crate::IfaceType::Vrf);
-        assert_eq!(
-            serde_yaml::to_string(&iface.vrf).unwrap().trim(),
-            EXPECTED_VRF_INFO
-        );
+        assert_value_match(EXPECTED_VRF_INFO, &iface.vrf);
     });
 }
 

--- a/src/lib/crate_tests/vxlan.rs
+++ b/src/lib/crate_tests/vxlan.rs
@@ -5,6 +5,8 @@ use pretty_assertions::assert_eq;
 
 use std::panic;
 
+use super::utils::assert_value_match;
+
 const IFACE_NAME: &str = "vxlan0";
 
 const EXPECTED_VXLAN_INFO: &str = r#"---
@@ -43,10 +45,7 @@ fn test_get_vxlan_iface_yaml() {
         let state = NetState::retrieve().unwrap();
         let iface = &state.ifaces[IFACE_NAME];
         assert_eq!(iface.iface_type, crate::IfaceType::Vxlan);
-        assert_eq!(
-            serde_yaml::to_string(&iface.vxlan).unwrap().trim(),
-            EXPECTED_VXLAN_INFO
-        );
+        assert_value_match(EXPECTED_VXLAN_INFO, &iface.vxlan);
     });
 }
 


### PR DESCRIPTION
Fix the tests by using `assert_value_match` instead of hard yaml equal
check as `serde_yaml` changed its output.