### PR TITLE
bond: Add 3 properties

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   lint:
     name: lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: true
       matrix:
@@ -37,7 +37,7 @@ jobs:
 
   integ:
     name: integ
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/src/lib/crate_tests/bond.rs
+++ b/src/lib/crate_tests/bond.rs
@@ -38,7 +38,9 @@ bond:
   lacp_rate: slow
   ad_select: stable
   tlb_dynamic_lb: true
-  peer_notif_delay: 0"#;
+  peer_notif_delay: 0
+  lacp_active: true
+  "#;
 
 const EXPECTED_PORT1_INFO: &str = r#"---
 subordinate_state: active

--- a/src/lib/crate_tests/utils.rs
+++ b/src/lib/crate_tests/utils.rs
@@ -36,8 +36,8 @@ fn _assert_value_match(
     expected: &serde_json::Value,
     current: &serde_json::Value,
 ) {
-    println!("asserting expected: {:?}", expected);
-    println!("asserting current:  {:?}", current);
+    println!("Asserting expected: {:?}", expected);
+    println!("Asserting current:  {:?}", current);
     match expected {
         serde_json::Value::Object(expected_map) => {
             for (k, v) in expected_map.iter() {

--- a/src/lib/ifaces/bond.rs
+++ b/src/lib/ifaces/bond.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, Ipv6Addr};
 
 use netlink_packet_route::rtnl::link::nlas::{
     self, Info, InfoBond, InfoData, InfoKind,
@@ -397,6 +397,12 @@ pub struct BondInfo {
     pub peer_notif_delay: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ad_info: Option<BondAdInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lacp_active: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub missed_max: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ns_ip6_target: Option<Vec<Ipv6Addr>>,
 }
 
 impl From<&[InfoBond]> for BondInfo {
@@ -452,9 +458,9 @@ impl From<&[InfoBond]> for BondInfo {
                 }
                 InfoBond::TlbDynamicLb(v) => ret.tlb_dynamic_lb = Some(*v > 0),
                 InfoBond::PeerNotifDelay(v) => ret.peer_notif_delay = Some(*v),
-                //InfoBond::AdLacpActive(v) => ret.ad_lacp_active = Some(*v),
-                //InfoBond::MissedMax(v) => ret.missed_max = Some(*v),
-                //InfoBond::NsIp6Target(v) => ret.ns_ip6_target = Some(*v),
+                InfoBond::AdLacpActive(v) => ret.lacp_active = Some(*v > 0),
+                InfoBond::MissedMax(v) => ret.missed_max = Some(*v),
+                InfoBond::NsIp6Target(v) => ret.ns_ip6_target = Some(v.clone()),
                 _ => {
                     log::warn!("Unsupported InfoBond: {:?}", nla);
                 }


### PR DESCRIPTION
Add support of these NLA:

 * `IFLA_BOND_AD_LACP_ACTIVE`: `BondInfo.lacp_active: Option<bool>`
 * `IFLA_BOND_MISSED_MAX`: `BondInfo.missed_max: Option<u8>`
 * `IFLA_BOND_NS_IP6_TARGET`: `BondInfo.ns_ip6_target: Option<Vec<Ipv6Addr>>`

Test case updated for first two. The `ns_ip6_target` does not have sysfs
or iproute support, hence not able to test it yet.