### PR TITLE
New release 1.2.8

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,23 @@
 # Changelog
+## [1.2.8] - 2022-10-06
+
+## Break changes
+
+ * N/A
+
+## New features
+
+ * Add support of filtering via `NetStateFilter`. (f128da4, c130bb6)
+ * SR-IOV: Include SRIOV VF information per VF interface. (fd3c489)
+ * New bond options: (77ede43)
+   * `BondInfo.lacp_active`
+   * `BondInfo.missed_max`
+   * `BondInfo.ns_ip6_target`
+
+## Bug fixes
+
+ * Expose `MptcpAddressFlag`. (dd2a427)
+
 ## [1.2.7] - 2022-06-29
 
 ## Break changes

--- a/DEVEL.md
+++ b/DEVEL.md
@@ -59,12 +59,12 @@ autocmd FileType rust nnoremap <silent> <leader>f :RustFmt<cr>
 ## Release workflow
 
 ```bash
-sed -i -e 's/1.2.7/1.2.8/' \
+sed -i -e 's/1.2.8/1.2.9/' \
     Makefile.inc src/*/Cargo.toml src/python/setup.py
 ```
 
 ```bash
-git log --oneline v1.2.7..HEAD
+git log --oneline v1.2.8..HEAD
 ```
 
 ```bash

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,4 +1,4 @@
-CLIB_VERSION=1.2.7
+CLIB_VERSION=1.2.8
 CLIB_VERSION_MAJOR=$(shell echo $(CLIB_VERSION) | cut -f1 -d.)
 CLIB_VERSION_MINOR=$(shell echo $(CLIB_VERSION) | cut -f2 -d.)
 CLIB_VERSION_MICRO=$(shell echo $(CLIB_VERSION) | cut -f3 -d.)

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nispor-cli"
-version = "1.2.7"
+version = "1.2.8"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2018"
@@ -19,7 +19,7 @@ path = "npc.rs"
 serde_json = "1.0"
 serde = { version = "1.0.136", features = ["derive"] }
 clap = { version = "4.0", features = ["cargo"] }
-nispor = { path = "../lib", version="1.2.7" }
+nispor = { path = "../lib", version="1.2.8" }
 serde_yaml = "0.9"
 env_logger = "0.9.0"
 log = "0.4.14"

--- a/src/clib/Cargo.toml
+++ b/src/clib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nispor-clib"
-version = "1.2.7"
+version = "1.2.8"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nispor"
-version = "1.2.7"
+version = "1.2.8"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2018"

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 setuptools.setup(
     name="nispor",
-    version="1.2.7",
+    version="1.2.8",
     author="Gris Ge",
     author_email="fge@redhat.com",
     description="Python binding of Nispor",


### PR DESCRIPTION
== Break changes

 * N/A

== New features

 * Add support of filtering via `NetStateFilter`. (f128da4, c130bb6)
 * SR-IOV: Include SRIOV VF information per VF interface. (fd3c489)
 * New bond options: (77ede43)
   * `BondInfo.lacp_active`
   * `BondInfo.missed_max`
   * `BondInfo.ns_ip6_target`

== Bug fixes

 * Expose `MptcpAddressFlag`. (dd2a427)