### PR TITLE
bond: Rename `missed_max` to `arp_missed_max`

### DIFF
--- a/src/lib/crate_tests/bond.rs
+++ b/src/lib/crate_tests/bond.rs
@@ -27,19 +27,12 @@ bond:
   arp_all_targets: any
   arp_validate: none
   primary_reselect: always
-  fail_over_mac: none
-  xmit_hash_policy: layer2
   resend_igmp: 1
-  num_unsol_na: 1
   all_subordinates_active: dropped
   min_links: 0
   lp_interval: 1
   packets_per_subordinate: 1
-  lacp_rate: slow
-  ad_select: stable
-  tlb_dynamic_lb: true
   peer_notif_delay: 0
-  lacp_active: true
   "#;
 
 const EXPECTED_PORT1_INFO: &str = r#"---


### PR DESCRIPTION
Renaming `missed_max` to `arp_missed_max`, to be consist with kernel
code and document.

Also hide many invalid options due to limitation of kernel code.