### PR TITLE
ipv6: Add IPv6 Tokenized Interface Identifiers support

### DIFF
--- a/src/cli/npc.rs
+++ b/src/cli/npc.rs
@@ -52,6 +52,7 @@ struct CliIfaceBrief {
     mtu: i64,
     ipv4: Vec<String>,
     ipv6: Vec<String>,
+    ipv6_token: Option<String>,
     gw4: Vec<String>,
     gw6: Vec<String>,
 }
@@ -105,6 +106,9 @@ impl CliIfaceBrief {
             }
             for ip in &brief.ipv6 {
                 ret.push(format!("{INDENT}ipv6 {ip}"));
+            }
+            if let Some(token) = brief.ipv6_token.as_ref() {
+                ret.push(format!("{INDENT}ipv6_token {token}"));
             }
             for gw in &brief.gw6 {
                 ret.push(format!("{INDENT}gw6 {gw}"));
@@ -202,6 +206,11 @@ impl CliIfaceBrief {
                     }
                     None => Vec::new(),
                 },
+                ipv6_token: iface
+                    .ipv6
+                    .as_ref()
+                    .and_then(|i| i.token.as_ref())
+                    .map(|t| t.to_string()),
                 gw4: match &iface_to_gw4.get(&iface.name) {
                     Some(gws) => gws.to_vec(),
                     None => Vec::new(),

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://github.com/nispor/nispor"
 repository = "https://github.com/nispor/nispor"
 keywords = ["network"]
 categories = ["network-programming", "os"]
+rust-version = "1.58"
 
 [lib]
 name = "nispor"

--- a/src/lib/ifaces/iface.rs
+++ b/src/lib/ifaces/iface.rs
@@ -12,7 +12,7 @@ use rtnetlink::packet::rtnl::link::nlas::Nla;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    ip::{IpConf, Ipv4Info, Ipv6Info},
+    ip::{fill_af_spec_inet_info, IpConf, Ipv4Info, Ipv6Info},
     mac::{mac_str_to_raw, parse_as_mac},
     mptcp::MptcpAddress,
     NisporError, VfInfo,
@@ -418,8 +418,10 @@ pub(crate) fn parse_nl_msg_to_iface(
             }
         } else if let Nla::NetnsId(id) = nla {
             iface_state.link_netnsid = Some(*id);
+        } else if let Nla::AfSpecInet(inet_nla) = nla {
+            fill_af_spec_inet_info(&mut iface_state, inet_nla.as_slice());
         } else {
-            // println!("{} {:?}", name, nla);
+            // Place holder for paring more Nla
         }
     }
     if let Some(ref mut vlan_info) = iface_state.vlan {

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -5,6 +5,11 @@ mod crate_tests;
 mod error;
 mod filter;
 mod iface_filter;
+// Since rust 1.62, the `#[default]` can be used for setting default value of
+// `#[derive(Default)]` for enum. The cargo clippy will complain if we impl the
+// Default by ourselves. But currently nispor minimum rust version is 1.58,
+// hence we suppress the clippy warning here.
+#[allow(clippy::derivable_impls)]
 mod ifaces;
 mod ip;
 mod mac;

--- a/src/lib/netlink/ip.rs
+++ b/src/lib/netlink/ip.rs
@@ -24,39 +24,31 @@ pub(crate) fn fill_ip_addr(
     match nl_msg.header.family {
         AF_INET => {
             let (iface_index, addr) = parse_ipv4_nlas(nl_msg)?;
-            let iface_name = get_iface_name_by_index(iface_states, iface_index);
-            if !iface_name.is_empty() {
-                let new_ip4_info = match &iface_states[&iface_name].ipv4 {
-                    Some(ip_info) => {
-                        let mut new_ip_info = ip_info.clone();
-                        new_ip_info.addresses.push(addr);
-                        new_ip_info
+            if let Some(i) = get_iface_name_by_index(iface_states, iface_index)
+            {
+                let iface_name = i.to_string();
+                if let Some(iface) = iface_states.get_mut(iface_name.as_str()) {
+                    if iface.ipv4.is_none() {
+                        iface.ipv4 = Some(Ipv4Info::default());
                     }
-                    None => Ipv4Info {
-                        addresses: vec![addr],
-                    },
-                };
-                if let Some(iface) = iface_states.get_mut(&iface_name) {
-                    iface.ipv4 = Some(new_ip4_info);
+                    if let Some(ipv4_info) = iface.ipv4.as_mut() {
+                        ipv4_info.addresses.push(addr);
+                    }
                 }
             }
         }
         AF_INET6 => {
             let (iface_index, addr) = parse_ipv6_nlas(nl_msg)?;
-            let iface_name = get_iface_name_by_index(iface_states, iface_index);
-            if !iface_name.is_empty() {
-                let new_ip6_info = match &iface_states[&iface_name].ipv6 {
-                    Some(ip_info) => {
-                        let mut new_ip_info = ip_info.clone();
-                        new_ip_info.addresses.push(addr);
-                        new_ip_info
+            if let Some(i) = get_iface_name_by_index(iface_states, iface_index)
+            {
+                let iface_name = i.to_string();
+                if let Some(iface) = iface_states.get_mut(iface_name.as_str()) {
+                    if iface.ipv6.is_none() {
+                        iface.ipv6 = Some(Ipv6Info::default());
                     }
-                    None => Ipv6Info {
-                        addresses: vec![addr],
-                    },
-                };
-                if let Some(iface) = iface_states.get_mut(&iface_name) {
-                    iface.ipv6 = Some(new_ip6_info);
+                    if let Some(ipv6_info) = iface.ipv6.as_mut() {
+                        ipv6_info.addresses.push(addr);
+                    }
                 }
             }
         }
@@ -137,11 +129,11 @@ fn left_time_to_string(left_time: i32) -> String {
 fn get_iface_name_by_index(
     iface_states: &HashMap<String, Iface>,
     iface_index: u32,
-) -> String {
+) -> Option<&str> {
     for (iface_name, iface) in iface_states.iter() {
         if iface.index == iface_index {
-            return iface_name.clone();
+            return Some(iface_name.as_str());
         }
     }
-    "".into()
+    None
 }

--- a/src/python/nispor/ip.py
+++ b/src/python/nispor/ip.py
@@ -58,5 +58,9 @@ class NisporIPv6:
     def addresses(self):
         return self._address
 
+    @property
+    def token(self):
+        return self._info.get("token")
+
     def __str__(self):
         return f"{self._info}"

--- a/tools/test_env
+++ b/tools/test_env
@@ -221,6 +221,18 @@ elif [ "CHK$1" == "CHKbgp" ];then
             echo "186 table $TEST_ROUTE_TABLE_ID"
         done
     done | sudo ip -b -
+elif [ "CHK$1" == "CHKipv6token" ];then
+    create_nics
+    sudo ip link set eth1 up
+    sudo sysctl -w net.ipv6.conf.eth1.accept_ra=1
+    sudo ip -6 addr add 2001:db8:f::1/64 dev eth1
+    sudo ip token set ::1 dev eth1
+    for x in $(seq 2 254); do
+        for y in $(seq 2 254); do
+            echo -n "route add 192.0.${x}.${y}/32 dev eth1 proto "
+            echo "186 table $TEST_ROUTE_TABLE_ID"
+        done
+    done | sudo ip -b -
 elif [ "CHK$1" == "CHKrm" ];then
     clean_up 2>/dev/null
 fi


### PR DESCRIPTION
Even the standard draft `draft-chown-6man-tokenised-ipv6-identifiers-02`
expired on 2013 April 25, but this is supported by linux kernel and the
use case is valid.

This patch is storing `IFLA_INET6_TOKEN` as `Ipv6Info.token` as
`Option<Ipv6Addr>`. We are treating all zero token as None as that is
default value of kernel meaning no token.

The CLI tool `npc` has included `ipv6_token` in brief output, for
example:

```
17: eth1: <BROADCAST,LOWERUP,MULTICAST,RUNNING,UP> state up mtu 1500
    link veth peer eth1.ep
    mac 00:23:45:67:89:1a
    ipv6 2001:db8:f::1/64 valid_lft forever preferred_lft forever
    ipv6_token ::1
```

Integration test case included.