### PR TITLE
ipv6: Change `token` from Ipv6Addr to String

### DIFF
--- a/src/lib/crate_tests/ip.rs
+++ b/src/lib/crate_tests/ip.rs
@@ -194,7 +194,7 @@ fn test_ipv6_token() {
                 .as_ref()
                 .and_then(|i| i.token.as_ref())
                 .map(|i| i.to_string()),
-            Some("::1".to_string())
+            Some("::fac1".to_string())
         );
     })
 }

--- a/tools/test_env
+++ b/tools/test_env
@@ -226,7 +226,7 @@ elif [ "CHK$1" == "CHKipv6token" ];then
     sudo ip link set eth1 up
     sudo sysctl -w net.ipv6.conf.eth1.accept_ra=1
     sudo ip -6 addr add 2001:db8:f::1/64 dev eth1
-    sudo ip token set ::1 dev eth1
+    sudo ip token set ::fac1 dev eth1
     for x in $(seq 2 254); do
         for y in $(seq 2 254); do
             echo -n "route add 192.0.${x}.${y}/32 dev eth1 proto "


### PR DESCRIPTION
The Ipv6Addr::to_string() will convert `::fac1` to `::0.0.250.193`
Which is no ideal for presenting IPv6 token.

This patch change the `token` property to `Option<String>` by set the
leading 64 bites to '2001:db8::', and then trip it out from string.

Integration test case updated for this special token `::fac1`.