### PR TITLE
Support getting bond port priority

### DIFF
--- a/src/lib/ifaces/bond.rs
+++ b/src/lib/ifaces/bond.rs
@@ -633,6 +633,7 @@ pub struct BondSubordinateInfo {
     pub mii_status: BondMiiStatus,
     pub link_failure_count: u32,
     pub perm_hwaddr: String,
+    pub prio: i32,
     pub queue_id: u16,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ad_aggregator_id: Option<u16>,
@@ -666,6 +667,7 @@ pub(crate) fn get_bond_subordinate_info(
             InfoBondPort::PermHwaddr(d) => {
                 ret.perm_hwaddr = parse_as_mac(d.len(), d)?;
             }
+            InfoBondPort::Prio(d) => ret.prio = *d,
             InfoBondPort::QueueId(d) => ret.queue_id = *d,
             InfoBondPort::BondPortState(d) => {
                 ret.subordinate_state = u8::from(*d).into()

--- a/src/python/nispor/bond.py
+++ b/src/python/nispor/bond.py
@@ -148,6 +148,10 @@ class NisporBondSubordinate(NisporBaseSubordinateIface):
         return self._sub_info.get("perm_hwaddr")
 
     @property
+    def prio(self):
+        return self._sub_info.get("prio")
+
+    @property
     def queue_id(self):
         return self._sub_info.get("queue_id")
 


### PR DESCRIPTION
Bond port priority is supported for parsing in netlink-packet-route since v0.16.0.