### PR TITLE
macsec: add base_iface property

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,9 @@ jobs:
       run: sudo apt-get -y install valgrind
 
     - name: Install extra kernel module(like netdevsim)
-      run: sudo apt-get -y install linux-modules-extra-azure
+      run: |
+        sudo apt-get update;
+        sudo apt-get -y install "linux-modules-extra-$(uname -r)"
 
     - name: Build
       run: cargo build --verbose --all

--- a/src/lib/crate_tests/macsec.rs
+++ b/src/lib/crate_tests/macsec.rs
@@ -26,7 +26,8 @@ macsec:
   end_station: false
   scb: false
   replay_protect: false
-  validate: strict"#;
+  validate: strict
+  base_iface: eth1"#;
 
 #[test]
 fn test_get_macsec_iface_yaml() {

--- a/src/lib/ifaces/iface.rs
+++ b/src/lib/ifaces/iface.rs
@@ -459,6 +459,11 @@ pub(crate) fn parse_nl_msg_to_iface(
             ib_info.base_iface = Some(format!("{base_iface_index}"));
         }
     }
+    if let Some(ref mut macsec_info) = iface_state.macsec {
+        if let Some(base_iface_index) = link {
+            macsec_info.base_iface = Some(format!("{base_iface_index}"));
+        }
+    }
     if let Some(iface_index) = link {
         match iface_state.iface_type {
             IfaceType::Veth => {

--- a/src/lib/ifaces/inter_ifaces.rs
+++ b/src/lib/ifaces/inter_ifaces.rs
@@ -17,6 +17,7 @@ use super::{
     iface::{change_iface_mac, change_iface_state},
     ipoib::ipoib_iface_tidy_up,
     mac_vlan::mac_vlan_iface_tidy_up,
+    macsec::macsec_iface_tidy_up,
     parse_nl_msg_to_iface, parse_nl_msg_to_name_and_index,
     sriov::sriov_vf_iface_tidy_up,
     veth::veth_iface_tidy_up,
@@ -133,6 +134,7 @@ fn tidy_up(iface_states: &mut HashMap<String, Iface>) {
     veth_iface_tidy_up(iface_states);
     vrf_iface_tidy_up(iface_states);
     mac_vlan_iface_tidy_up(iface_states);
+    macsec_iface_tidy_up(iface_states);
     ipoib_iface_tidy_up(iface_states);
     sriov_vf_iface_tidy_up(iface_states);
 }

--- a/src/python/nispor/macsec.py
+++ b/src/python/nispor/macsec.py
@@ -63,3 +63,7 @@ class NisporMacsec(NisporBaseIface):
     @property
     def offload(self):
         return self._macsec_info["offload"]
+
+    @property
+    def base_iface(self):
+        return self._macsec_info["base_iface"]


### PR DESCRIPTION
MACsec needs a base_iface to be created. show the `base_iface` for its parent.