### PR TITLE
ipv6: Support peer address

### DIFF
--- a/src/lib/netlink/ip.rs
+++ b/src/lib/netlink/ip.rs
@@ -101,8 +101,20 @@ fn parse_ipv6_nlas(
     };
 
     for nla in &nl_msg.nlas {
-        if let Nla::Address(addr_vec) = nla {
+        if let Nla::Local(addr_vec) = nla {
             addr.address = parse_as_ipv6(addr_vec.as_slice())?.to_string();
+            addr.peer_prefix_len = Some(addr.prefix_len);
+            addr.prefix_len = 128;
+        }
+    }
+
+    for nla in &nl_msg.nlas {
+        if let Nla::Address(addr_vec) = nla {
+            if addr.peer_prefix_len.is_some() {
+                addr.peer = Some(parse_as_ipv6(addr_vec.as_slice())?);
+            } else {
+                addr.address = parse_as_ipv6(addr_vec.as_slice())?.to_string();
+            }
         } else if let Nla::CacheInfo(cache_info_vec) = nla {
             let cache_info = CacheInfo::parse(&CacheInfoBuffer::new(
                 cache_info_vec.as_slice(),

--- a/src/lib/query/ip.rs
+++ b/src/lib/query/ip.rs
@@ -47,6 +47,10 @@ pub struct Ipv6AddrInfo {
     pub preferred_lft: String,
     /// IPv6 Address Flags
     pub flags: Vec<Ipv6AddrFlag>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peer: Option<Ipv6Addr>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peer_prefix_len: Option<u8>,
 }
 
 pub(crate) fn parse_ip_addr_str(

--- a/tools/test_env
+++ b/tools/test_env
@@ -15,7 +15,7 @@ sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0 1>/dev/null
 
 if [ "CHK$1" == "CHK" ];then
     echo 'Need argument: bond, br, brv, vlan, dummy, vxlan, veth, vrf, sriov,'
-    echo 'rm, route, rule, sim, mptcp, bgp, macsec'
+    echo 'rm, route, rule, sim, mptcp, bgp, macsec, ipv6token, ipv6p2p'
     exit 1
 fi
 
@@ -234,6 +234,12 @@ elif [ "CHK$1" == "CHKipv6token" ];then
             echo "186 table $TEST_ROUTE_TABLE_ID"
         done
     done | sudo ip -b -
+elif [ "CHK$1" == "CHKipv6p2p" ];then
+    create_nics
+    sudo ip link set eth1 up
+    sudo sysctl -w net.ipv6.conf.eth1.accept_ra=1
+    sudo ip -6 addr add 2001:db8:f::1/128 peer 2001:db8:f::2/64 dev eth1
+    sudo ip token set ::fac1 dev eth1
 elif [ "CHK$1" == "CHKmacsec" ];then
     create_nics
     sudo ip link add link eth1 macsec0 type macsec encrypt on


### PR DESCRIPTION
When using with IPv6 peer address, nispor is incorrectly treating peer
address as local.

In kernel, we have netlink code of ipv6 address which store peer address
to `IFA_ADDRESS` and local address to `IFA_LOCAL`.

```c
if (!ipv6_addr_any(&ifa->peer_addr)) {
	if (nla_put_in6_addr(skb, IFA_LOCAL, &ifa->addr) < 0 ||
	    nla_put_in6_addr(skb, IFA_ADDRESS, &ifa->peer_addr) < 0)
		goto error;
} else
	if (nla_put_in6_addr(skb, IFA_ADDRESS, &ifa->addr) < 0)
		goto error;
```

This patch fixed it by introducing new property to ipv6 address: `peer`
and `peer_prefix_len`. YAML example for command
`ip -6 addr add 2001:db8:f::1/128 peer 2001:db8:f::2/64 dev eth1`

```yml
  - address: "2001:db8:f::1"
    prefix_len: 128
    valid_lft: forever
    preferred_lft: forever
    flags:
    - permanent
    peer: 2001:db8:f::2
    peer_prefix_len: 64
```

Integration test case included.