### PR TITLE
bridge: Add support VLAN filter on bridge itself

### DIFF
--- a/src/lib/integ_tests/bridge_vlan_filter.rs
+++ b/src/lib/integ_tests/bridge_vlan_filter.rs
@@ -98,6 +98,14 @@ vlans:
     is_pvid: false
     is_egress_untagged: false"#;
 
+static BR_SELF_VLAN: &str = r#"
+  - vid: 1
+    is_pvid: false
+    is_egress_untagged: true
+  - vid: 11
+    is_pvid: true
+    is_egress_untagged: true"#;
+
 #[test]
 fn test_get_br_vlan_filter_iface_yaml() {
     with_br_with_vlan_filter_iface(|| {
@@ -118,6 +126,7 @@ fn test_get_br_vlan_filter_iface_yaml() {
         if let Some(bridge_info) = &iface.bridge {
             assert_eq!(bridge_info.vlan_filtering, Some(true))
         }
+        assert_value_match(BR_SELF_VLAN, iface.bridge_vlan.as_ref().unwrap());
 
         let port1 = &state.ifaces[PORT1_NAME];
         let port2 = &state.ifaces[PORT2_NAME];

--- a/src/lib/query/bridge.rs
+++ b/src/lib/query/bridge.rs
@@ -10,7 +10,7 @@ use crate::{
     netlink::{
         parse_af_spec_bridge_info, parse_bridge_info, parse_bridge_port_info,
     },
-    ControllerType, Iface, NisporError,
+    ControllerType, Iface, IfaceType, NisporError,
 };
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
@@ -381,6 +381,12 @@ pub(crate) fn parse_bridge_vlan_info(
                 Some(vlans) => vlans.extend(cur_vlans),
                 None => port_info.vlans = Some(cur_vlans),
             };
+        }
+    } else if iface_state.iface_type == IfaceType::Bridge {
+        let br_vlan = iface_state.bridge_vlan.get_or_insert(Vec::new());
+        // It's the VLAN of the bridge itself
+        if let Some(cur_vlans) = parse_af_spec_bridge_info(nlas)? {
+            br_vlan.extend(cur_vlans);
         }
     }
     Ok(())

--- a/src/lib/query/iface.rs
+++ b/src/lib/query/iface.rs
@@ -26,10 +26,10 @@ use super::{
     vxlan::get_vxlan_info,
 };
 use crate::{
-    BondInfo, BondSubordinateInfo, BridgeInfo, BridgePortInfo, EthtoolInfo,
-    IpoibInfo, Ipv4Info, Ipv6Info, MacSecInfo, MacVlanInfo, MacVtapInfo,
-    MptcpAddress, NisporError, SriovInfo, TunInfo, VethInfo, VfInfo, VlanInfo,
-    VrfInfo, VrfSubordinateInfo, VxlanInfo,
+    BondInfo, BondSubordinateInfo, BridgeInfo, BridgePortInfo, BridgeVlanEntry,
+    EthtoolInfo, IpoibInfo, Ipv4Info, Ipv6Info, MacSecInfo, MacVlanInfo,
+    MacVtapInfo, MptcpAddress, NisporError, SriovInfo, TunInfo, VethInfo,
+    VfInfo, VlanInfo, VrfInfo, VrfSubordinateInfo, VxlanInfo,
 };
 
 const IFF_PORT: u32 = 0x800;
@@ -220,6 +220,8 @@ pub struct Iface {
     pub bond_subordinate: Option<BondSubordinateInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bridge: Option<BridgeInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bridge_vlan: Option<Vec<BridgeVlanEntry>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bridge_port: Option<BridgePortInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tools/test_env
+++ b/tools/test_env
@@ -96,6 +96,7 @@ elif [ "CHK$1" == "CHKbrv" ];then
     sudo ip link set br0 address $TEST_MAC3
     sudo ip link set br0 up
     sudo bridge vlan add vid 10 pvid untagged dev eth1
+    sudo bridge vlan add vid 11 pvid untagged self dev br0
     sudo bridge vlan add vid 2-4094 dev eth2
     sudo ip link set br0 type bridge vlan_filtering 1
     sleep $LINK_WAIT_TIME


### PR DESCRIPTION
The command `bridge vlan add vid 11 pvid untagged self dev br0` will
set VLAN filtering on bridge itself, to support that, introduced
`bridge_vlan: Option<Vec<BridgeVlanEntry>>` to bridge interface. For example:

```yml
- name: br0
  iface_type: bridge
  state: up
  bridge_vlan:
  - vid: 1
    is_pvid: false
    is_egress_untagged: true
  - vid: 11
    is_pvid: true
    is_egress_untagged: true
```

Integration test case included.