### PR TITLE
New release 1.2.15

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,17 @@
 # Changelog
+## [1.2.15] - 2023-09-18
+## Break changes
+ * Changed `IfaceFlags` to `IfaceFlag`. (e126d02)
+
+## New features
+ * Support HSR/PRP interface. (010ee32)
+ * Support IPv6 peer address. (9a8211c)
+ * Support VLAN filter on bridge itself. (181c11b)
+ * Support query IPv6 address flags. (196358a)
+
+## Bug fixes
+ * Fix failure on kernel with new VxLAN and Bond options. (e126d02)
+
 ## [1.2.14] - 2023-09-18
 ## Break changes
  * N/A

--- a/DEVEL.md
+++ b/DEVEL.md
@@ -59,12 +59,12 @@ autocmd FileType rust nnoremap <silent> <leader>f :RustFmt<cr>
 ## Release workflow
 
 ```bash
-sed -i -e 's/1.2.13/1.2.14/' \
+sed -i -e 's/1.2.15/1.2.16/' \
     Makefile.inc src/*/Cargo.toml src/python/setup.py
 ```
 
 ```bash
-git log --oneline v1.2.11..HEAD
+git log --oneline v1.2.14..HEAD
 ```
 
 ```bash

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,4 +1,4 @@
-CLIB_VERSION=1.2.14
+CLIB_VERSION=1.2.15
 CLIB_VERSION_MAJOR=$(shell echo $(CLIB_VERSION) | cut -f1 -d.)
 CLIB_VERSION_MINOR=$(shell echo $(CLIB_VERSION) | cut -f2 -d.)
 CLIB_VERSION_MICRO=$(shell echo $(CLIB_VERSION) | cut -f3 -d.)

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nispor-cli"
-version = "1.2.14"
+version = "1.2.15"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2021"
@@ -19,7 +19,7 @@ path = "npc.rs"
 serde_json = "1.0"
 serde = { version = "1.0.136", features = ["derive"] }
 clap = { version = "4.2", features = ["cargo"] }
-nispor = { path = "../lib", version="1.2.14" }
+nispor = { path = "../lib", version="1.2.15" }
 serde_yaml = "0.9"
 env_logger = "0.10.0"
 log = "0.4.14"

--- a/src/clib/Cargo.toml
+++ b/src/clib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nispor-clib"
-version = "1.2.14"
+version = "1.2.15"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nispor"
-version = "1.2.14"
+version = "1.2.15"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2021"

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -4,7 +4,7 @@ import setuptools
 
 setuptools.setup(
     name="nispor",
-    version="1.2.14",
+    version="1.2.15",
     author="Gris Ge",
     author_email="fge@redhat.com",
     description="Python binding of Nispor",


### PR DESCRIPTION
== Break changes
 * Changed `IfaceFlags` to `IfaceFlag`. (e126d02)

== New features
 * Support HSR/PRP interface. (010ee32)
 * Support IPv6 peer address. (9a8211c)
 * Support VLAN filter on bridge itself. (181c11b)
 * Support query IPv6 address flags. (196358a)

== Bug fixes
 * Fix failure on kernel with new VxLAN and Bond options. (e126d02)