### PR TITLE
Add support of XFRM interface

### DIFF
--- a/src/lib/integ_tests/mod.rs
+++ b/src/lib/integ_tests/mod.rs
@@ -40,3 +40,5 @@ mod vlan;
 mod vrf;
 #[cfg(test)]
 mod vxlan;
+#[cfg(test)]
+mod xfrm;

--- a/src/lib/integ_tests/xfrm.rs
+++ b/src/lib/integ_tests/xfrm.rs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::panic;
+
+use pretty_assertions::assert_eq;
+
+use crate::NetState;
+
+use super::utils::assert_value_match;
+
+const IFACE_NAME: &str = "xfrm1";
+
+const EXPECTED_XFRM_INFO: &str = r#"---
+name: xfrm1
+iface_type: xfrm
+xfrm:
+  base_iface: eth1
+  iface_id: 99"#;
+
+#[test]
+fn test_get_xfrm_iface_yaml() {
+    with_xfrm_iface(|| {
+        let state = NetState::retrieve().unwrap();
+        let iface = &state.ifaces[IFACE_NAME];
+
+        assert_eq!(iface.iface_type, crate::IfaceType::Xfrm);
+
+        assert_value_match(EXPECTED_XFRM_INFO, iface);
+    });
+}
+
+fn with_xfrm_iface<T>(test: T)
+where
+    T: FnOnce() + panic::UnwindSafe,
+{
+    super::utils::set_network_environment("xfrm");
+
+    let result = panic::catch_unwind(|| {
+        test();
+    });
+
+    super::utils::clear_network_environment();
+    assert!(result.is_ok())
+}

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -43,5 +43,5 @@ pub use crate::query::{
     MptcpAddressFlag, MultipathRoute, MultipathRouteFlags, Route,
     RouteProtocol, RouteRule, RouteScope, RouteType, RuleAction, SriovInfo,
     TunInfo, TunMode, VethInfo, VfInfo, VfLinkState, VfState, VlanInfo,
-    VlanProtocol, VrfInfo, VrfSubordinateInfo, VxlanInfo,
+    VlanProtocol, VrfInfo, VrfSubordinateInfo, VxlanInfo, XfrmInfo,
 };

--- a/src/lib/query/inter_ifaces.rs
+++ b/src/lib/query/inter_ifaces.rs
@@ -24,6 +24,7 @@ use super::{
     vlan::vlan_iface_tidy_up,
     vrf::vrf_iface_tidy_up,
     vxlan::vxlan_iface_tidy_up,
+    xfrm::xfrm_iface_tidy_up,
 };
 use crate::{EthtoolInfo, Iface, NetStateIfaceFilter, NisporError};
 
@@ -134,6 +135,7 @@ fn tidy_up(iface_states: &mut HashMap<String, Iface>) {
     hsr_iface_tidy_up(iface_states);
     ipoib_iface_tidy_up(iface_states);
     sriov_vf_iface_tidy_up(iface_states);
+    xfrm_iface_tidy_up(iface_states);
 }
 
 fn controller_iface_index_to_name(iface_states: &mut HashMap<String, Iface>) {

--- a/src/lib/query/mod.rs
+++ b/src/lib/query/mod.rs
@@ -5,6 +5,7 @@ mod bridge;
 mod hsr;
 mod ip;
 mod mptcp;
+mod xfrm;
 // Disable `needless_pass_by_ref_mut` check due to upstream issue:
 // https://github.com/rust-netlink/ethtool/issues/12
 #[allow(clippy::needless_pass_by_ref_mut)]
@@ -64,6 +65,7 @@ pub use self::veth::VethInfo;
 pub use self::vlan::{VlanInfo, VlanProtocol};
 pub use self::vrf::{VrfInfo, VrfSubordinateInfo};
 pub use self::vxlan::VxlanInfo;
+pub use self::xfrm::XfrmInfo;
 
 pub(crate) use self::{
     inter_ifaces::{get_iface_name2index, get_ifaces},

--- a/src/lib/query/xfrm.rs
+++ b/src/lib/query/xfrm.rs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+use std::collections::HashMap;
+
+use netlink_packet_route::link::{InfoData, InfoXfrm};
+use serde::{Deserialize, Serialize};
+
+use crate::{Iface, IfaceType};
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
+#[non_exhaustive]
+pub struct XfrmInfo {
+    pub base_iface: String,
+    pub iface_id: u32,
+}
+
+pub(crate) fn get_xfrm_info(data: &InfoData) -> Option<XfrmInfo> {
+    if let InfoData::Xfrm(infos) = data {
+        let mut xfrm_info = XfrmInfo::default();
+        for info in infos {
+            match *info {
+                InfoXfrm::Link(i) => {
+                    xfrm_info.base_iface = i.to_string();
+                }
+                InfoXfrm::IfId(d) => {
+                    xfrm_info.iface_id = d;
+                }
+                _ => {
+                    log::debug!("Unknown XFRM info {:?}", info);
+                }
+            }
+        }
+        Some(xfrm_info)
+    } else {
+        None
+    }
+}
+
+pub(crate) fn xfrm_iface_tidy_up(iface_states: &mut HashMap<String, Iface>) {
+    fill_port_iface_names(iface_states);
+}
+
+fn fill_port_iface_names(iface_states: &mut HashMap<String, Iface>) {
+    let mut index_to_name = HashMap::new();
+    for iface in iface_states.values() {
+        index_to_name.insert(iface.index.to_string(), iface.name.clone());
+    }
+    for iface in iface_states
+        .values_mut()
+        .filter(|i| i.iface_type == IfaceType::Xfrm)
+    {
+        if let Some(xfrm_info) = iface.xfrm.as_mut() {
+            if let Some(base_iface) = index_to_name.get(&xfrm_info.base_iface) {
+                xfrm_info.base_iface = base_iface.to_string();
+            }
+        }
+    }
+}

--- a/tools/test_env
+++ b/tools/test_env
@@ -15,7 +15,8 @@ sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0 1>/dev/null
 
 if [ "CHK$1" == "CHK" ];then
     echo 'Need argument: bond, br, brv, vlan, dummy, vxlan, veth, vrf, sriov,'
-    echo 'rm, route, rule, sim, mptcp, bgp, macsec, ipv6token, ipv6p2p, hsr'
+    echo 'rm, route, rule, sim, mptcp, bgp, macsec, ipv6token, ipv6p2p, hsr,'
+    echo 'xfrm'
     exit 1
 fi
 
@@ -37,6 +38,7 @@ function clean_up {
     sudo ip link del tap1
     sudo ip link del macsec0
     sudo ip link del hsr0
+    sudo ip link del xfrm1
     sudo ip rule del priority 999
     sudo ip -6 rule del priority 999
     sudo modprobe -r netdevsim
@@ -255,6 +257,13 @@ elif [ "CHK$1" == "CHKhsr" ];then
     sudo ip link set eth1 up
     sudo ip link set eth2 up
     sudo ip link set hsr0 up
+    sleep $LINK_WAIT_TIME
+elif [ "CHK$1" == "CHKxfrm" ];then
+    create_nics
+    sudo ip link add xfrm1 type xfrm dev eth1 if_id 99
+    sudo ip link set eth1 up
+    sudo ip link set eth2 up
+    sudo ip link set xfrm1 up
     sleep $LINK_WAIT_TIME
 elif [ "CHK$1" == "CHKrm" ];then
     clean_up 2>/dev/null


### PR DESCRIPTION
Example YAML:

```
- name: xfrm1
  iface_type: xfrm
  xfrm:
    base_iface: eth1
    iface_id: 99
```

Integration test case included.