### PR TITLE
apply: Skip unrequited query

### DIFF
--- a/src/lib/conf/inter_ifaces.rs
+++ b/src/lib/conf/inter_ifaces.rs
@@ -21,7 +21,8 @@ pub(crate) async fn delete_ifaces(
     for (iface_name, iface_index) in ifaces {
         if let Err(e) = handle.link().del(*iface_index).execute().await {
             return Err(NisporError::bug(format!(
-                "Failed to delete interface {iface_name} with index {iface_index}: {e}"
+                "Failed to delete interface {iface_name} \
+                with index {iface_index}: {e}"
             )));
         }
     }
@@ -36,6 +37,7 @@ pub(crate) async fn create_ifaces(
     let (connection, handle, _) = new_connection()?;
     tokio::spawn(connection);
     for iface in ifaces {
+        log::debug!("Creating interface {}", iface.name);
         match iface.iface_type {
             Some(IfaceType::Bridge) => {
                 BridgeConf::create(&handle, &iface.name).await?;
@@ -96,6 +98,9 @@ pub(crate) async fn change_ifaces(
 ) -> Result<(), NisporError> {
     let (connection, handle, _) = new_connection()?;
     tokio::spawn(connection);
+    for iface in ifaces {
+        log::debug!("Changing interface {}", iface.name);
+    }
     change_ifaces_mac(&handle, ifaces, cur_ifaces).await?;
     change_ifaces_controller(&handle, ifaces, cur_ifaces).await?;
     change_ifaces_state(&handle, ifaces, cur_ifaces).await?;

--- a/src/lib/net_conf.rs
+++ b/src/lib/net_conf.rs
@@ -43,15 +43,21 @@ impl NetConf {
                 }
             }
             delete_ifaces(&del_ifaces).await?;
-            create_ifaces(&new_ifaces, &cur_iface_name_2_index).await?;
+            if !new_ifaces.is_empty() {
+                create_ifaces(&new_ifaces, &cur_iface_name_2_index).await?;
+            }
 
-            let cur_ifaces = get_ifaces(None).await?;
-            change_ifaces(&chg_ifaces, &cur_ifaces).await?;
+            if !chg_ifaces.is_empty() {
+                let cur_ifaces = get_ifaces(None).await?;
+                change_ifaces(&chg_ifaces, &cur_ifaces).await?;
+            }
         }
 
         if let Some(routes) = self.routes.as_ref() {
-            let cur_iface_name_2_index = get_iface_name2index().await?;
-            apply_routes_conf(routes, &cur_iface_name_2_index).await?;
+            if !routes.is_empty() {
+                let cur_iface_name_2_index = get_iface_name2index().await?;
+                apply_routes_conf(routes, &cur_iface_name_2_index).await?;
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
To increase performance, there is no need to query existing interface
for a pure-deletion `NetConf`.