### PR TITLE
tools: Add nispor-in-container

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,3 +70,12 @@ jobs:
     - name: Run clib test
       if: matrix.rust_version == 'stable'
       run: sudo make check -C test/clib
+  
+  container:
+    name: container
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Test nispor-in-container
+      run: make check_in_container

--- a/DEVEL.md
+++ b/DEVEL.md
@@ -32,6 +32,23 @@
 
 `./tools/test_env rm`
 
+## Run the tests
+
+### Locally
+
+`make check`
+
+Warning: this will make changes to your system's network configuration, so this
+is not recommended.
+
+### In a container
+
+`make check_in_container`
+
+### Manual testing and experimenting in a container
+
+`./tools/nispor-in-container` (see help with `--help`)
+
 ## Design
 
 ### Rust module

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,9 @@ check:
 	fi
 	make check -C test/clib
 
+check_in_container:
+	./tools/nispor-in-container -- make check
+
 clean:
 	cargo clean
 	make clean -C test/clib

--- a/tools/nispor-in-container
+++ b/tools/nispor-in-container
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# exit on error
+set -e
+
+# default variables
+PODMAN="${PODMAN:=podman}"
+IMG="${IMG:=nispor-test}"
+
+# other variables
+current_dir="$(realpath -- "$(dirname -- "${BASH_SOURCE[0]}")")"
+root_dir="$(realpath -- "$current_dir/..")"
+containerfile_content="\
+FROM fedora:latest
+RUN dnf install -y cargo ethtool iproute procps-ng
+"
+
+# parse args
+if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+    cmd="$(basename -- "${BASH_SOURCE[0]}")"
+    echo "$cmd [--help | args_for_podman_run...]"
+    echo "Set up a container to test nispor in isolation."
+    echo "Example: $cmd -v /other/path/to/mount:/mount/point:z"
+    echo "Note: tests using netdevsim will fail if executed in the container."
+    exit
+fi
+
+# Build image if doesn't exist
+if ! "$PODMAN" image exists "$IMG"; then
+    "$PODMAN" build -t "$IMG" -f <(echo "$containerfile_content")
+fi
+
+# Run the container
+echo "To run integration tests: 'make check'"
+echo "For manual testing: 'make install', 'tools/test_env' to prepare environment"
+"$PODMAN" run --privileged --rm -it "$@"  \
+    -v "$root_dir:/nispor:z" -w "/nispor" \
+    "$IMG" \
+    /bin/bash

--- a/tools/nispor-in-container
+++ b/tools/nispor-in-container
@@ -10,30 +10,52 @@ IMG="${IMG:=nispor-test}"
 # other variables
 current_dir="$(realpath -- "$(dirname -- "${BASH_SOURCE[0]}")")"
 root_dir="$(realpath -- "$current_dir/..")"
+
+# Containerfile
 containerfile_content="\
 FROM fedora:latest
 RUN dnf install -y cargo ethtool iproute procps-ng
+WORKDIR /nispor
+CMD /bin/bash
 "
 
-# parse args
+# show help and exit, if requested
 if [[ "$1" == "-h" || "$1" == "--help" ]]; then
     cmd="$(basename -- "${BASH_SOURCE[0]}")"
-    echo "$cmd [--help | args_for_podman_run...]"
+    echo "$cmd [--help | args_for_podman_run...] [-- command_to_run]"
     echo "Set up a container to test nispor in isolation."
-    echo "Example: $cmd -v /other/path/to/mount:/mount/point:z"
+    echo "Example: $cmd -v /other/path/to/mount:/mount/point:z -- make check"
+    echo "If command_to_run is empty, a bash shell is open in the container"
     echo "Note: tests using netdevsim will fail if executed in the container."
     exit
 fi
+
+# parse args
+args=()
+cmd=()
+while (( $# > 0 )); do
+    if [[ $1 == "--" ]]; then
+        in_cmd=yes
+    else
+        [[ $in_cmd == "yes" ]] && cmd+=("$1") || args+=("$1")
+    fi
+    shift
+done
 
 # Build image if doesn't exist
 if ! "$PODMAN" image exists "$IMG"; then
     "$PODMAN" build -t "$IMG" -f <(echo "$containerfile_content")
 fi
 
+# If we are openning a bash shell, show a few help messages
+if [[ -z "$cmd" ]]; then  
+    echo "To run integration tests: 'make check'"
+    echo "For manual testing: 'make install', 'tools/test_env' to prepare environment"
+fi
+
 # Run the container
-echo "To run integration tests: 'make check'"
-echo "For manual testing: 'make install', 'tools/test_env' to prepare environment"
-"$PODMAN" run --privileged --rm -it "$@"  \
-    -v "$root_dir:/nispor:z" -w "/nispor" \
+"$PODMAN" run --privileged --rm -it  \
+    -v "$root_dir:/nispor:z" \
+    "${args[@]}" \
     "$IMG" \
-    /bin/bash
+    "${cmd[@]}"

--- a/tools/nispor-in-container
+++ b/tools/nispor-in-container
@@ -3,9 +3,19 @@
 # exit on error
 set -e
 
-# default variables
-PODMAN="${PODMAN:=podman}"
+# default variables, can be overwriten by the environment
 IMG="${IMG:=nispor-test}"
+
+if [[ -z $PODMAN ]]; then
+    if command -v podman &>/dev/null; then
+        PODMAN=podman
+    elif command -v docker &>/dev/null; then
+        PODMAN=docker  # why not?
+    else
+        echo "You need Podman or Docker to use this script" >&2
+        exit 1
+    fi
+fi
 
 # other variables
 current_dir="$(realpath -- "$(dirname -- "${BASH_SOURCE[0]}")")"


### PR DESCRIPTION
Script to create a container where nispor can easily be tested. It has some small limitations, like not being able to load kernel modules or creating netdevsim devices. The first problem can be workarounded loading the modules in the host before. I haven't found any solution for the second, so far.