### PR TITLE
Makefile: fix python install path for Python >= 3.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,7 @@ SYSTEMD_SYS_UNIT_DIR ?= $(shell \
 	pkg-config --variable=systemdsystemunitdir systemd)
 
 PYTHON3_SITE_DIR ?=$(shell \
-	python3 -c \
-		"from distutils.sysconfig import get_python_lib; \
-		 print(get_python_lib())")
+	python3 -c "import sysconfig; print(sysconfig.get_path('purelib'))")
 
 # Always invoke cargo build for debug
 .PHONY: $(CLI_EXEC_DEBUG)


### PR DESCRIPTION
The module distutils has been removed in Python 3.12. This causes that the command to get the install path for Python files fails, returning an empty string and causing the files to be installed in the root folder of the project.

Replace distutil's get_python_lib with sysconfig.get_path('purelib').