### PR TITLE
clib: Use build.rs to fix SONAME

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,2 @@
-[build]
-rustflags = "-Clink-arg=-Wl,-soname=libnispor.so.1"
-
 [target.x86_64-unknown-linux-gnu]
 runner = 'sudo -E'

--- a/src/clib/Cargo.toml
+++ b/src/clib/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://github.com/nispor/nispor"
 repository = "https://github.com/nispor/nispor"
 keywords = ["network"]
 categories = ["network-programming", "os"]
+build = "build.rs"
 
 [lib]
 name = "nispor"

--- a/src/clib/build.rs
+++ b/src/clib/build.rs
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() {
+    #[cfg(target_os = "linux")]
+    println!("cargo:rustc-cdylib-link-arg=-Wl,-soname=libnispor.so.1");
+}

--- a/test/clib/Makefile
+++ b/test/clib/Makefile
@@ -34,6 +34,7 @@ nispor_test: nispor_test.c nispor.h libnispor.so
 	$(CC) $(CFLAGS) $(LDFLAGS) -o nispor_test nispor_test.c $(LIBS)
 
 check: nispor_test
+	./check_clib_soname.sh $(TMPDIR)/$(CLIB_SO_DEV)
 	LD_LIBRARY_PATH=$(TMPDIR) \
 		valgrind --trace-children=yes --leak-check=full \
 		--error-exitcode=1 \

--- a/test/clib/check_clib_soname.sh
+++ b/test/clib/check_clib_soname.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -ex
+# SPDX-License-Identifier: Apache-2.0
+
+if [ "$(objdump -p $1 |sed -ne 's/.*SONAME \+\(libnispor.\+\)/\1/p')" \
+    != "libnispor.so.1" ];then
+    exit 1
+fi


### PR DESCRIPTION
Use [`cargo:rustc-cdylib-link-arg`][1] to `build.rs` to fix the SONAME issue
of cargo.

Removed workarounds in rpm spec and `.cargo/config.toml`.

Test case included.

[1]: https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-cdylib-link-arg