### PR TITLE
iface: add driver field

### DIFF
--- a/src/lib/integ_tests/base_info.rs
+++ b/src/lib/integ_tests/base_info.rs
@@ -13,6 +13,7 @@ fn test_iface_info_loopback() {
     assert_eq!(&iface.mac_address, "00:00:00:00:00:00");
     assert_eq!(iface.max_mtu, None);
     assert_eq!(iface.min_mtu, None);
+    assert_eq!(iface.driver, None); // loopback device is driver-less
     assert_eq!(
         iface.flags,
         &[


### PR DESCRIPTION
This commits adds a `driver` field to the base interface. It is meant to provide an information about the driver used by the specific interface if available. As some interfaces do not have any driver assigned (e.g. loopback), this field will not be always present.

As per https://docs.kernel.org/admin-guide/sysfs-rules.html, we are using sysfs and read the "driver"-link to get what's needed.