### PR TITLE
Use `netlink_sys::Socket::set_netlink_get_strict_chk`

### DIFF
--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 rtnetlink = "0.14.0"
 netlink-packet-route = "0.19.0"
-netlink-sys = "0.8.4"
+netlink-sys = "0.8.6"
 netlink-packet-utils = "0.5.2"
 ethtool = "0.2.5"
 mptcp-pm = "0.1.3"

--- a/src/lib/filter/mod.rs
+++ b/src/lib/filter/mod.rs
@@ -5,7 +5,6 @@ mod net_state;
 mod route;
 mod route_rule;
 
-pub(crate) use self::net_state::enable_kernel_strict_check;
 pub(crate) use self::route::{
     apply_kernel_route_filter, should_drop_by_filter,
 };

--- a/src/lib/filter/net_state.rs
+++ b/src/lib/filter/net_state.rs
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::os::unix::io::RawFd;
-
 use crate::{
     NetStateIfaceFilter, NetStateRouteFilter, NetStateRouteRuleFilter,
-    NisporError,
 };
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -49,26 +46,4 @@ impl NetStateFilter {
             route_rule: None,
         }
     }
-}
-
-const NETLINK_GET_STRICT_CHK: i32 = 12;
-
-pub(crate) fn enable_kernel_strict_check(fd: RawFd) -> Result<(), NisporError> {
-    if unsafe {
-        libc::setsockopt(
-            fd,
-            libc::SOL_NETLINK,
-            NETLINK_GET_STRICT_CHK,
-            1u32.to_ne_bytes().as_ptr() as *const _,
-            4,
-        )
-    } != 0
-    {
-        let e = NisporError::bug(format!(
-            "Failed to set socket option NETLINK_GET_STRICT_CHK: error {}",
-            std::io::Error::last_os_error()
-        ));
-        return Err(e);
-    }
-    Ok(())
 }

--- a/src/lib/query/ethtool.rs
+++ b/src/lib/query/ethtool.rs
@@ -560,7 +560,7 @@ async fn dump_link_mode_infos(
                     }
                     EthtoolLinkModeAttr::Speed(d) => {
                         link_mode_info.speed =
-                            if *d == std::u32::MAX { 0 } else { *d }
+                            if *d == u32::MAX { 0 } else { *d }
                     }
                     EthtoolLinkModeAttr::Duplex(d) => {
                         link_mode_info.duplex = d.into()

--- a/src/lib/query/route_rule.rs
+++ b/src/lib/query/route_rule.rs
@@ -153,12 +153,12 @@ fn get_rule(rule_msg: RuleMessage) -> Result<RouteRule, NisporError> {
                 rl.tun_id = Some(*d);
             }
             RuleAttribute::SuppressIfGroup(d) => {
-                if *d != std::u32::MAX {
+                if *d != u32::MAX {
                     rl.suppress_ifgroup = Some(*d);
                 }
             }
             RuleAttribute::SuppressPrefixLen(d) => {
-                if *d != std::u32::MAX {
+                if *d != u32::MAX {
                     rl.suppress_prefix_len = Some(*d);
                 }
             }


### PR DESCRIPTION
With netlink_sys 0.8.6,
`netlink_sys::Socket::set_netlink_get_strict_chk()` can replace our unsafe
code for `libc::setsocketopt`.