### PR TITLE
sriov: do not report VFs info if sriov_numvfs is missing

### DIFF
--- a/src/lib/query/iface.rs
+++ b/src/lib/query/iface.rs
@@ -19,7 +19,7 @@ use super::{
     mac_vlan::get_mac_vlan_info,
     mac_vtap::get_mac_vtap_info,
     macsec::get_macsec_info,
-    sriov::get_sriov_info,
+    sriov::{get_sriov_info, sriov_is_enabled},
     tun::get_tun_info,
     vlan::get_vlan_info,
     vrf::{get_vrf_info, get_vrf_subordinate_info},
@@ -492,7 +492,9 @@ pub(crate) fn parse_nl_msg_to_iface(
             if let Ok(info) =
                 get_sriov_info(&iface_state.name, nlas, &link_layer_type)
             {
-                iface_state.sriov = Some(info);
+                if sriov_is_enabled(&iface_state.name) {
+                    iface_state.sriov = Some(info);
+                }
             }
         } else if let LinkAttribute::NetnsId(id) = nla {
             iface_state.link_netnsid = Some(*id);

--- a/src/lib/query/sriov.rs
+++ b/src/lib/query/sriov.rs
@@ -178,6 +178,14 @@ fn get_vf_iface_name(pf_name: &str, sriov_id: &u32) -> Option<String> {
     read_folder(&sysfs_path).pop()
 }
 
+// SR-IOV can be disabled on BIOS but the VFs netlink attribute will be there. In order to
+// understand if the SR-IOV can be configured we must look at PCI level. If sriov_numvfs is present
+// we can assume that the NIC is SR-IOV capable and it is enabled.
+pub(crate) fn sriov_is_enabled(pf_name: &str) -> bool {
+    let sysfs_path = format!("/sys/class/net/{pf_name}/device/sriov_numvfs");
+    std::fs::File::open(sysfs_path).is_ok()
+}
+
 fn read_folder(folder_path: &str) -> Vec<String> {
     let mut folder_contents = Vec::new();
     let fd = match std::fs::read_dir(folder_path) {


### PR DESCRIPTION
If SR-IOV is disabled on BIOS, the netlink attributes for the VFs are present and therefore nispor is reporting SR-IOV info. To avoid this, we check if the sriov_numvfs sysfs path is present for the device.