### PR TITLE
wifi: Introduce support of query WIFI status

### DIFF
--- a/src/cli/npc.rs
+++ b/src/cli/npc.rs
@@ -590,6 +590,18 @@ fn get_link_info(iface: &Iface) -> String {
             vxlan.dst_port,
             vxlan.local
         )
+    } else if let Some(wifi) = iface.wifi.as_ref() {
+        let mut ret = String::new();
+        if let Some(ssid) = wifi.ssid.as_ref() {
+            write!(ret, "ssid {ssid}").ok();
+        }
+        if let Some(gen) = wifi.generation.as_ref() {
+            write!(ret, " gen {gen}").ok();
+        }
+        if let Some(freq) = wifi.frequency.as_ref() {
+            write!(ret, " freq {freq}").ok();
+        }
+        ret
     } else {
         "".into()
     }

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -29,6 +29,7 @@ tokio = { version = "1.19.2", features = ["macros", "rt"] }
 futures = "0.3.21"
 libc = "0.2.126"
 log = "0.4.17"
+wl-nl80211 = "0.1.2"
 
 [dev-dependencies]
 serde_yaml = "0.9"

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -58,7 +58,7 @@ impl std::error::Error for NisporError {
     /* TODO */
 }
 
-impl std::convert::From<rtnetlink::Error> for NisporError {
+impl From<rtnetlink::Error> for NisporError {
     fn from(e: rtnetlink::Error) -> Self {
         match e {
             rtnetlink::Error::NetlinkError(netlink_err) => {
@@ -84,7 +84,7 @@ impl std::convert::From<rtnetlink::Error> for NisporError {
     }
 }
 
-impl std::convert::From<EthtoolError> for NisporError {
+impl From<EthtoolError> for NisporError {
     fn from(e: EthtoolError) -> Self {
         NisporError {
             kind: ErrorKind::NetlinkError,
@@ -93,7 +93,7 @@ impl std::convert::From<EthtoolError> for NisporError {
     }
 }
 
-impl std::convert::From<std::ffi::FromBytesWithNulError> for NisporError {
+impl From<std::ffi::FromBytesWithNulError> for NisporError {
     fn from(e: std::ffi::FromBytesWithNulError) -> Self {
         NisporError {
             kind: ErrorKind::NisporBug,
@@ -102,7 +102,7 @@ impl std::convert::From<std::ffi::FromBytesWithNulError> for NisporError {
     }
 }
 
-impl std::convert::From<std::str::Utf8Error> for NisporError {
+impl From<std::str::Utf8Error> for NisporError {
     fn from(e: std::str::Utf8Error) -> Self {
         NisporError {
             kind: ErrorKind::NisporBug,
@@ -111,7 +111,7 @@ impl std::convert::From<std::str::Utf8Error> for NisporError {
     }
 }
 
-impl std::convert::From<DecodeError> for NisporError {
+impl From<DecodeError> for NisporError {
     fn from(e: DecodeError) -> Self {
         NisporError {
             kind: ErrorKind::NetlinkError,
@@ -120,7 +120,7 @@ impl std::convert::From<DecodeError> for NisporError {
     }
 }
 
-impl std::convert::From<std::io::Error> for NisporError {
+impl From<std::io::Error> for NisporError {
     fn from(e: std::io::Error) -> Self {
         NisporError {
             kind: ErrorKind::NisporBug,
@@ -129,7 +129,7 @@ impl std::convert::From<std::io::Error> for NisporError {
     }
 }
 
-impl std::convert::From<std::net::AddrParseError> for NisporError {
+impl From<std::net::AddrParseError> for NisporError {
     fn from(e: std::net::AddrParseError) -> Self {
         NisporError {
             kind: ErrorKind::InvalidArgument,
@@ -138,8 +138,17 @@ impl std::convert::From<std::net::AddrParseError> for NisporError {
     }
 }
 
-impl std::convert::From<mptcp_pm::MptcpPathManagerError> for NisporError {
+impl From<mptcp_pm::MptcpPathManagerError> for NisporError {
     fn from(e: mptcp_pm::MptcpPathManagerError) -> Self {
+        NisporError {
+            kind: ErrorKind::NetlinkError,
+            msg: e.to_string(),
+        }
+    }
+}
+
+impl From<wl_nl80211::Nl80211Error> for NisporError {
+    fn from(e: wl_nl80211::Nl80211Error) -> Self {
         NisporError {
             kind: ErrorKind::NetlinkError,
             msg: e.to_string(),

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -44,5 +44,5 @@ pub use crate::query::{
     MultipathRouteFlags, Route, RouteProtocol, RouteRule, RouteScope,
     RouteType, RuleAction, SriovInfo, TunInfo, TunMode, VethInfo, VfInfo,
     VfLinkState, VfState, VlanInfo, VlanProtocol, VrfInfo, VrfSubordinateInfo,
-    VxlanInfo, XfrmInfo,
+    VxlanInfo, WifiInfo, XfrmInfo,
 };

--- a/src/lib/query/iface.rs
+++ b/src/lib/query/iface.rs
@@ -32,7 +32,7 @@ use crate::{
     EthtoolInfo, HsrInfo, IpVlanInfo, IpoibInfo, Ipv4Info, Ipv6Info,
     MacSecInfo, MacVlanInfo, MacVtapInfo, MptcpAddress, NisporError, SriovInfo,
     TunInfo, VethInfo, VfInfo, VlanInfo, VrfInfo, VrfSubordinateInfo,
-    VxlanInfo, XfrmInfo,
+    VxlanInfo, WifiInfo, XfrmInfo,
 };
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
@@ -59,6 +59,7 @@ pub enum IfaceType {
     Hsr,
     Unknown,
     Xfrm,
+    Wifi,
     Other(String),
 }
 
@@ -94,6 +95,7 @@ impl std::fmt::Display for IfaceType {
                 Self::Hsr => "hsr",
                 Self::Unknown => "unknown",
                 Self::Xfrm => "xfrm",
+                Self::Wifi => "wifi",
                 Self::Other(s) => s,
             }
         )
@@ -299,6 +301,8 @@ pub struct Iface {
     pub driver: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ip_vlan: Option<IpVlanInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wifi: Option<WifiInfo>,
 }
 
 // TODO: impl From Iface to IfaceConf

--- a/src/lib/query/inter_ifaces.rs
+++ b/src/lib/query/inter_ifaces.rs
@@ -25,6 +25,7 @@ use super::{
     vlan::vlan_iface_tidy_up,
     vrf::vrf_iface_tidy_up,
     vxlan::vxlan_iface_tidy_up,
+    wifi::fill_wifi_info,
     xfrm::xfrm_iface_tidy_up,
 };
 use crate::{EthtoolInfo, Iface, NetStateIfaceFilter, NisporError};
@@ -118,6 +119,8 @@ pub(crate) async fn get_ifaces(
             }
         };
     }
+
+    fill_wifi_info(&mut iface_states).await?;
 
     tidy_up(&mut iface_states);
     Ok(iface_states)

--- a/src/lib/query/mod.rs
+++ b/src/lib/query/mod.rs
@@ -5,6 +5,7 @@ mod bridge;
 mod hsr;
 mod ip;
 mod mptcp;
+mod wifi;
 mod xfrm;
 // Disable `needless_pass_by_ref_mut` check due to upstream issue:
 // https://github.com/rust-netlink/ethtool/issues/12
@@ -67,6 +68,7 @@ pub use self::veth::VethInfo;
 pub use self::vlan::{VlanInfo, VlanProtocol};
 pub use self::vrf::{VrfInfo, VrfSubordinateInfo};
 pub use self::vxlan::VxlanInfo;
+pub use self::wifi::WifiInfo;
 pub use self::xfrm::XfrmInfo;
 
 pub(crate) use self::{

--- a/src/lib/query/wifi.rs
+++ b/src/lib/query/wifi.rs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use futures::TryStreamExt;
+use serde::{Deserialize, Serialize};
+use wl_nl80211::Nl80211Attr;
+
+use crate::{Iface, IfaceType, NisporError};
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub struct WifiInfo {
+    pub ssid: Option<String>,
+    /// Frequency in MHz
+    pub frequency: Option<u32>,
+    /// WIFI generation, e.g. 6 for WIFI-6.
+    pub generation: Option<u32>,
+}
+
+pub(crate) async fn fill_wifi_info(
+    iface_states: &mut HashMap<String, Iface>,
+) -> Result<(), NisporError> {
+    let (connection, handle, _) = wl_nl80211::new_connection()?;
+    tokio::spawn(connection);
+
+    let mut interface_handle = handle.interface().get().execute().await;
+
+    while let Some(msg) = interface_handle.try_next().await? {
+        let attrs = &msg.payload.nlas;
+        let iface_name = if let Some(iface_name) =
+            attrs.iter().find_map(|attr| {
+                if let Nl80211Attr::IfName(n) = attr {
+                    Some(n)
+                } else {
+                    None
+                }
+            }) {
+            iface_name
+        } else {
+            continue;
+        };
+        let iface = if let Some(i) = iface_states.get_mut(iface_name) {
+            i
+        } else {
+            continue;
+        };
+        let mut info = WifiInfo::default();
+        for attr in attrs {
+            match attr {
+                Nl80211Attr::Generation(g) => info.generation = Some(*g),
+                Nl80211Attr::WiPhyFreq(f) => info.frequency = Some(*f),
+                Nl80211Attr::Ssid(s) => info.ssid = Some(s.to_string()),
+                _ => (),
+            }
+        }
+        // TODO: Use station info to set BSSID(MAC of Station) and signal level.
+        iface.wifi = Some(info);
+        iface.iface_type = IfaceType::Wifi;
+    }
+    Ok(())
+}


### PR DESCRIPTION
Through `wl-nl80211` crate(also maintained by Gris Ge), this patch
introduce support of querying WIFI status, example output:

```yml
wifi:
  ssid: ExampleWifi
  frequency: 5745
  generation: 6
```

Introduced interface type `IfaceType::Wifi`. The `npc` brief information
expand to:

```
link wifi ssid ExampleWifi gen 6 freq 5745
```
No integration test included as no way to simulate a wifi connection yet.