### PR TITLE
Ignore WIFI query failure

### DIFF
--- a/src/lib/query/inter_ifaces.rs
+++ b/src/lib/query/inter_ifaces.rs
@@ -120,7 +120,12 @@ pub(crate) async fn get_ifaces(
         };
     }
 
-    fill_wifi_info(&mut iface_states).await?;
+    // The cfg80211 module might not exists or loaded in environments,
+    // we should only log wifi query failure instead of failing the whole
+    // querying
+    if let Err(e) = fill_wifi_info(&mut iface_states).await {
+        log::warn!("Failed to query WIFI information {e}");
+    }
 
     tidy_up(&mut iface_states);
     Ok(iface_states)


### PR DESCRIPTION
In Github CI, ubuntu running azure specific kernel will not able to
load `cfg80211` kernel moduel for nl80211 information query.

Instead of failing the whole query, we log the failure as warning only.