### PR TITLE
vlan: Add query support of QoS mapping

### DIFF
--- a/src/lib/integ_tests/vlan.rs
+++ b/src/lib/integ_tests/vlan.rs
@@ -17,7 +17,22 @@ is_reorder_hdr: true
 is_gvrp: false
 is_loose_binding: false
 is_mvrp: false
-is_bridge_binding: false"#;
+is_bridge_binding: false
+ingress_qos_map:
+- from: 2
+  to: 9
+- from: 3
+  to: 8
+- from: 4
+  to: 7
+egress_qos_map:
+- from: 7
+  to: 4
+- from: 8
+  to: 3
+- from: 9
+  to: 2
+"#;
 
 #[test]
 fn test_get_vlan_iface_yaml() {

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -43,6 +43,6 @@ pub use crate::query::{
     MacVtapMode, Mptcp, MptcpAddress, MptcpAddressFlag, MultipathRoute,
     MultipathRouteFlags, Route, RouteProtocol, RouteRule, RouteScope,
     RouteType, RuleAction, SriovInfo, TunInfo, TunMode, VethInfo, VfInfo,
-    VfLinkState, VfState, VlanInfo, VlanProtocol, VrfInfo, VrfSubordinateInfo,
-    VxlanInfo, WifiInfo, XfrmInfo,
+    VfLinkState, VfState, VlanInfo, VlanProtocol, VlanQosMapping, VrfInfo,
+    VrfSubordinateInfo, VxlanInfo, WifiInfo, XfrmInfo,
 };

--- a/src/lib/query/mod.rs
+++ b/src/lib/query/mod.rs
@@ -65,7 +65,7 @@ pub use self::route_rule::{RouteRule, RuleAction};
 pub use self::sriov::{SriovInfo, VfInfo, VfLinkState, VfState};
 pub use self::tun::{TunInfo, TunMode};
 pub use self::veth::VethInfo;
-pub use self::vlan::{VlanInfo, VlanProtocol};
+pub use self::vlan::{VlanInfo, VlanProtocol, VlanQosMapping};
 pub use self::vrf::{VrfInfo, VrfSubordinateInfo};
 pub use self::vxlan::VxlanInfo;
 pub use self::wifi::WifiInfo;

--- a/tools/test_env
+++ b/tools/test_env
@@ -111,6 +111,8 @@ elif [ "CHK$1" == "CHKvlan" ];then
     sudo ip link add link eth1 name eth1.101 type vlan id 101
     sudo ip link set eth1.101 address $TEST_MAC3
     sudo ip link set eth1.101 up
+    sudo ip link set eth1.101 type vlan ingress-qos-map 2:9 3:8 4:7
+    sudo ip link set eth1.101 type vlan egress-qos-map 7:4 8:3 9:2
     sleep $LINK_WAIT_TIME
 elif [ "CHK$1" == "CHKdummy" ];then
     sudo ip link add dummy1 type dummy


### PR DESCRIPTION
Introduce `VlanInfo.ingress_qos_map` and `VlanInfo.egress_qos_map` for
QoS mapping between linux internal packet priority to VLAN header QoS
priority.

Integration test case included.