### PR TITLE
veth: Use `LinkNetNsId` instead of `IfNetnsId`

### DIFF
--- a/src/lib/query/iface.rs
+++ b/src/lib/query/iface.rs
@@ -511,7 +511,7 @@ pub(crate) fn parse_nl_msg_to_iface(
                     iface_state.sriov = Some(info);
                 }
             }
-        } else if let LinkAttribute::IfNetnsId(id) = nla {
+        } else if let LinkAttribute::LinkNetNsId(id) = nla {
             iface_state.link_netnsid = Some(*id);
         } else if let LinkAttribute::AfSpecUnspec(nlas) = nla {
             fill_af_spec_inet_info(&mut iface_state, nlas);


### PR DESCRIPTION
The correct netlink attribute for veth peer in another namespace is
`LinkNetNsId`.

The `IfNetnsId` (IFLA_IF_NETNSID, aka IFLA_TARGET_NETNSID) is used for
creating interface and assign that new interface to namepsace directly
without the use of `setns()`.