### PR TITLE
query: add IPv4 sysctl forwarding support

### DIFF
--- a/src/cli/npc.rs
+++ b/src/cli/npc.rs
@@ -192,6 +192,9 @@ impl CliIfaceBrief {
                                 addr.preferred_lft,
                             ));
                         }
+                        if let Some(fwd) = ip_info.forwarding {
+                            addr_strs.push(format!("forwarding {}", fwd));
+                        }
                         addr_strs
                     }
                     None => Vec::new(),

--- a/src/lib/integ_tests/ip.rs
+++ b/src/lib/integ_tests/ip.rs
@@ -4,7 +4,7 @@ use std::panic;
 
 use pretty_assertions::assert_eq;
 
-use super::utils::assert_value_match;
+use super::utils::{assert_value_match, set_ipv4_forwarding};
 use crate::{NetConf, NetState};
 
 const IFACE_NAME: &str = "veth1";
@@ -71,6 +71,22 @@ addresses:
     prefix_len: 24
     valid_lft: forever
     preferred_lft: forever"#;
+
+const EXPECTED_IPV4_INFO_WITH_FORWADRDING_ENABLED: &str = r#"---
+addresses:
+  - address: 192.0.2.1
+    prefix_len: 24
+    valid_lft: forever
+    preferred_lft: forever
+forwarding: true"#;
+
+const EXPECTED_IPV4_INFO_WITH_FORWADRDING_DISABLED: &str = r#"---
+addresses:
+  - address: 192.0.2.1
+    prefix_len: 24
+    valid_lft: forever
+    preferred_lft: forever
+forwarding: false"#;
 
 const EXPECTED_IPV4_DYNAMIC_INFO: &str = r#"---
 addresses:
@@ -252,4 +268,27 @@ fn test_ipv6_p2p() {
 
 fn wait_ipv6_dad() {
     std::thread::sleep(std::time::Duration::from_secs(5));
+}
+
+#[test]
+fn test_read_ip_forwarding() {
+    with_veth_iface(|| {
+        let conf: NetConf = serde_yaml::from_str(ADD_IP_CONF).unwrap();
+        conf.apply().unwrap();
+        wait_ipv6_dad();
+        set_ipv4_forwarding(IFACE_NAME, true);
+        let state = NetState::retrieve().unwrap();
+        let iface = &state.ifaces[IFACE_NAME];
+        assert_value_match(
+            EXPECTED_IPV4_INFO_WITH_FORWADRDING_ENABLED,
+            &iface.ipv4,
+        );
+        set_ipv4_forwarding(IFACE_NAME, false);
+        let state = NetState::retrieve().unwrap();
+        let iface = &state.ifaces[IFACE_NAME];
+        assert_value_match(
+            EXPECTED_IPV4_INFO_WITH_FORWADRDING_DISABLED,
+            &iface.ipv4,
+        );
+    });
 }

--- a/src/lib/integ_tests/utils.rs
+++ b/src/lib/integ_tests/utils.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::fs;
+use std::io::Write;
 use std::process::Command;
 
 use pretty_assertions::assert_eq;
@@ -57,4 +59,17 @@ fn _assert_value_match(
             assert_eq!(expected, current)
         }
     }
+}
+
+pub(crate) fn set_ipv4_forwarding(iface_name: &str, enabled: bool) {
+    let path = format!("/proc/sys/net/ipv4/conf/{}/forwarding", iface_name);
+    let value = if enabled { "1" } else { "0" };
+
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .open(&path)
+        .unwrap_or_else(|_| panic!("Failed to open {}", path));
+
+    file.write_all(value.as_bytes())
+        .unwrap_or_else(|_| panic!("Failed to write to {}", path));
 }

--- a/src/lib/netlink/ip.rs
+++ b/src/lib/netlink/ip.rs
@@ -4,9 +4,10 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 
 use crate::{
-    Iface, Ipv4AddrInfo, Ipv4Info, Ipv6AddrFlag, Ipv6AddrInfo, Ipv6Info,
-    NisporError,
+    query::read_ipv4_forwarding, Iface, Ipv4AddrInfo, Ipv4Info, Ipv6AddrFlag,
+    Ipv6AddrInfo, Ipv6Info, NisporError,
 };
+
 use rtnetlink::packet_route::address::{AddressAttribute, AddressMessage};
 
 pub(crate) fn fill_ip_addr(
@@ -21,7 +22,11 @@ pub(crate) fn fill_ip_addr(
                 let iface_name = i.to_string();
                 if let Some(iface) = iface_states.get_mut(iface_name.as_str()) {
                     if iface.ipv4.is_none() {
-                        iface.ipv4 = Some(Ipv4Info::default());
+                        let forwarding = read_ipv4_forwarding(&iface.name);
+                        iface.ipv4 = Some(Ipv4Info {
+                            forwarding,
+                            ..Default::default()
+                        });
                     }
                     if let Some(ipv4_info) = iface.ipv4.as_mut() {
                         ipv4_info.addresses.push(addr);

--- a/src/lib/query/ip.rs
+++ b/src/lib/query/ip.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::fs::File;
+use std::io::{BufRead, BufReader};
 use std::net::{IpAddr, Ipv6Addr};
 use std::str::FromStr;
 
@@ -14,6 +16,8 @@ use crate::{Iface, NisporError};
 #[non_exhaustive]
 pub struct Ipv4Info {
     pub addresses: Vec<Ipv4AddrInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub forwarding: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
@@ -110,6 +114,51 @@ pub(crate) fn fill_af_spec_inet_info(iface: &mut Iface, nlas: &[AfSpecUnspec]) {
                     }
                 }
             }
+        }
+    }
+}
+
+pub(crate) fn read_ipv4_forwarding(iface_name: &str) -> Option<bool> {
+    let path = format!("/proc/sys/net/ipv4/conf/{}/forwarding", iface_name);
+
+    let file = match File::open(&path) {
+        Ok(f) => f,
+        Err(e) => {
+            log::warn!(
+                "Failed to read IPv4 forwarding value for interface '{}': \
+                 could not open '{}': {}",
+                iface_name,
+                path,
+                e
+            );
+            return None;
+        }
+    };
+
+    let mut reader = BufReader::new(file);
+    let mut line = String::new();
+
+    if let Err(e) = reader.read_line(&mut line) {
+        log::warn!(
+            "Failed to read IPv4 forwarding value from '{}', for interface '{}': {}",
+            path,
+            iface_name,
+            e
+        );
+        return None;
+    }
+
+    match line.trim() {
+        "1" => Some(true),
+        "0" => Some(false),
+        other => {
+            log::warn!(
+                "Unexpected IPv4 forwarding value '{}' in '{}', for interface '{}'",
+                other,
+                path,
+                iface_name
+            );
+            None
         }
     }
 }

--- a/src/lib/query/mod.rs
+++ b/src/lib/query/mod.rs
@@ -73,7 +73,10 @@ pub use self::xfrm::XfrmInfo;
 
 pub(crate) use self::{
     inter_ifaces::{get_iface_name2index, get_ifaces},
-    ip::{is_ipv6_addr, parse_ip_addr_str, parse_ip_net_addr_str},
+    ip::{
+        is_ipv6_addr, parse_ip_addr_str, parse_ip_net_addr_str,
+        read_ipv4_forwarding,
+    },
     mptcp::{get_mptcp, merge_mptcp_info},
     route::get_routes,
     route_rule::get_route_rules,


### PR DESCRIPTION
Add functionality to retrieve and display the IPv4 forwarding state for network interfaces. The forwarding state is read from: /proc/sys/net/ipv4/conf/<iface>/forwarding.

The feature allows monitoring interface-level IPv4 forwarding configuration which is useful in scenarios such as MetalLB load balancing, where forwarding is needed on specific interfaces without enabling global ip_forward=1.

Example `npc iface dummy0` output:

```
  ipv4:
    addresses:
    - address: 192.168.120.8
      prefix_len: 24
      valid_lft: forever
      preferred_lft: forever
    forwarding: true
```

Integration test case included.