### PR TITLE
Support querying PCI address

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,3 +1,4 @@
 max_width = 80
 reorder_imports = true
+format_strings = true
 edition = "2018"

--- a/src/cli/npc.rs
+++ b/src/cli/npc.rs
@@ -4,8 +4,8 @@ use clap::{crate_authors, crate_version};
 use nispor::{
     Iface, IfaceConf, IfaceState, IfaceType, Mptcp, NetConf, NetState,
     NetStateFilter, NetStateIfaceFilter, NetStateRouteFilter,
-    NetStateRouteRuleFilter, NisporError, Route, RouteProtocol, RouteRule,
-    RouteScope,
+    NetStateRouteRuleFilter, NisporError, PciAddress, Route, RouteProtocol,
+    RouteRule, RouteScope,
 };
 use serde::Serialize;
 use std::collections::HashMap;
@@ -44,6 +44,7 @@ struct CliIfaceBrief {
     name: String,
     iface_type: IfaceType,
     driver: Option<String>,
+    pci_address: Option<PciAddress>,
     controller: Option<String>,
     link_info: String,
     state: IfaceState,
@@ -71,7 +72,12 @@ impl CliIfaceBrief {
                 brief.mtu,
             ));
             if let Some(driver) = brief.driver.as_deref() {
-                ret.push(format!("{INDENT}driver {driver}"));
+                let mut drv_string = format!("{INDENT}driver {driver}");
+                if let Some(pci_addr) = brief.pci_address.as_ref() {
+                    write!(drv_string, " pci {pci_addr}").ok();
+                }
+
+                ret.push(drv_string);
             }
 
             let mut link_string =
@@ -167,6 +173,7 @@ impl CliIfaceBrief {
             ret.push(CliIfaceBrief {
                 index: iface.index,
                 driver: iface.driver.clone(),
+                pci_address: iface.pci_address,
                 iface_type: iface.iface_type.clone(),
                 controller: iface.controller.clone(),
                 link_info: get_link_info(iface),

--- a/src/cli/npc.rs
+++ b/src/cli/npc.rs
@@ -71,7 +71,7 @@ impl CliIfaceBrief {
                 brief.mtu,
             ));
             if let Some(driver) = brief.driver.as_deref() {
-                ret.push(format!("{}driver {}", INDENT, driver));
+                ret.push(format!("{INDENT}driver {driver}"));
             }
 
             let mut link_string =
@@ -193,7 +193,7 @@ impl CliIfaceBrief {
                             ));
                         }
                         if let Some(fwd) = ip_info.forwarding {
-                            addr_strs.push(format!("forwarding {}", fwd));
+                            addr_strs.push(format!("forwarding {fwd}"));
                         }
                         addr_strs
                     }
@@ -404,8 +404,8 @@ fn main() {
                         .long("dev")
                         .action(clap::ArgAction::Append)
                         .help(
-                            "Show only route entries output to \
-                            the specified interface",
+                            "Show only route entries output to the specified \
+                             interface",
                         ),
                 )
                 .arg(
@@ -414,8 +414,8 @@ fn main() {
                         .long("table")
                         .action(clap::ArgAction::Append)
                         .help(
-                            "Show only route entries output in \
-                            the specified route table",
+                            "Show only route entries output in the specified \
+                             route table",
                         ),
                 )
                 .arg(

--- a/src/lib/conf/iface.rs
+++ b/src/lib/conf/iface.rs
@@ -32,8 +32,8 @@ pub struct IfaceConf {
 impl IfaceConf {
     pub async fn apply(&self, cur_iface: &Iface) -> Result<(), NisporError> {
         log::warn!(
-            "WARN: IfaceConf::apply() is deprecated, \
-            please use NetConf::apply() instead"
+            "WARN: IfaceConf::apply() is deprecated, please use \
+             NetConf::apply() instead"
         );
         let ifaces = vec![self];
         let mut cur_ifaces = HashMap::new();

--- a/src/lib/conf/inter_ifaces.rs
+++ b/src/lib/conf/inter_ifaces.rs
@@ -21,8 +21,8 @@ pub(crate) async fn delete_ifaces(
     for (iface_name, iface_index) in ifaces {
         if let Err(e) = handle.link().del(*iface_index).execute().await {
             return Err(NisporError::bug(format!(
-                "Failed to delete interface {iface_name} \
-                with index {iface_index}: {e}"
+                "Failed to delete interface {iface_name} with index \
+                 {iface_index}: {e}"
             )));
         }
     }

--- a/src/lib/conf/ip.rs
+++ b/src/lib/conf/ip.rs
@@ -208,11 +208,11 @@ fn parse_lft_sec(name: &str, lft_str: &str) -> Result<u32, NisporError> {
     ));
     match lft_str.strip_suffix("sec") {
         Some(a) => a.parse().map_err(|_| {
-            log::error!("{}", e);
+            log::error!("{e}");
             e
         }),
         None => {
-            log::error!("{}", e);
+            log::error!("{e}");
             Err(e)
         }
     }

--- a/src/lib/conf/route.rs
+++ b/src/lib/conf/route.rs
@@ -81,7 +81,7 @@ async fn apply_route_conf(
             let e = NisporError::invalid_argument(format!(
                 "Interface {oif} does not exist"
             ));
-            log::error!("{}", e);
+            log::error!("{e}");
             return Err(e);
         }
     }

--- a/src/lib/filter/route.rs
+++ b/src/lib/filter/route.rs
@@ -71,7 +71,7 @@ pub(crate) fn apply_kernel_route_filter(
                 let e = NisporError::invalid_argument(format!(
                     "Interface {oif} not found"
                 ));
-                log::error!("{}", e);
+                log::error!("{e}");
                 return Err(e);
             }
         }

--- a/src/lib/integ_tests/utils.rs
+++ b/src/lib/integ_tests/utils.rs
@@ -62,14 +62,14 @@ fn _assert_value_match(
 }
 
 pub(crate) fn set_ipv4_forwarding(iface_name: &str, enabled: bool) {
-    let path = format!("/proc/sys/net/ipv4/conf/{}/forwarding", iface_name);
+    let path = format!("/proc/sys/net/ipv4/conf/{iface_name}/forwarding");
     let value = if enabled { "1" } else { "0" };
 
     let mut file = fs::OpenOptions::new()
         .write(true)
         .open(&path)
-        .unwrap_or_else(|_| panic!("Failed to open {}", path));
+        .unwrap_or_else(|_| panic!("Failed to open {path}"));
 
     file.write_all(value.as_bytes())
-        .unwrap_or_else(|_| panic!("Failed to write to {}", path));
+        .unwrap_or_else(|_| panic!("Failed to write to {path}"));
 }

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -41,7 +41,7 @@ pub use crate::query::{
     IpoibMode, Ipv4AddrInfo, Ipv4Info, Ipv6AddrFlag, Ipv6AddrInfo, Ipv6Info,
     MacSecCipherId, MacSecInfo, MacSecOffload, MacSecValidate, MacVlanInfo,
     MacVlanMode, MacVtapInfo, MacVtapMode, Mptcp, MptcpAddress,
-    MptcpAddressFlag, MultipathRoute, MultipathRouteFlags, Route,
+    MptcpAddressFlag, MultipathRoute, MultipathRouteFlags, PciAddress, Route,
     RouteProtocol, RouteRule, RouteScope, RouteType, RuleAction, SriovInfo,
     TunInfo, TunMode, VethInfo, VfInfo, VfLinkState, VfState, VlanInfo,
     VlanProtocol, VlanQosMapping, VrfInfo, VrfSubordinateInfo, VxlanInfo,

--- a/src/lib/netlink/bridge_vlan.rs
+++ b/src/lib/netlink/bridge_vlan.rs
@@ -72,8 +72,8 @@ fn merge_vlan_range(
                     })
                 } else {
                     log::warn!(
-                        "Invalid kernel bridge vlan information: \
-                        missing start VLAN for {}",
+                        "Invalid kernel bridge vlan information: missing \
+                         start VLAN for {}",
                         k_vlan.vid
                     );
                 }

--- a/src/lib/query/bond.rs
+++ b/src/lib/query/bond.rs
@@ -95,8 +95,7 @@ impl From<BondMode> for rtnetlink::packet_route::link::BondMode {
             }
             BondMode::Unknown => {
                 log::warn!(
-                    "Treating BondMode::Unknown as \
-                    BondMode::BalanceRoundRobin"
+                    "Treating BondMode::Unknown as BondMode::BalanceRoundRobin"
                 );
                 rtnetlink::packet_route::link::BondMode::BalanceRr
             }
@@ -366,14 +365,13 @@ impl From<&[link::BondAdInfo]> for BondAdInfo {
                         Ok(m) => ret.partner_mac = m,
                         Err(e) => {
                             log::warn!(
-                                "Failed to parse BondAdInfo.parse_as_mac: {}",
-                                e
+                                "Failed to parse BondAdInfo.parse_as_mac: {e}"
                             );
                         }
                     }
                 }
                 _ => {
-                    log::debug!("Unknown BondAdInfo NLA {:?}", nla);
+                    log::debug!("Unknown BondAdInfo NLA {nla:?}");
                 }
             }
         }
@@ -595,7 +593,7 @@ impl From<&[InfoBond]> for BondInfo {
                 }
                 InfoBond::NsIp6Target(v) => ret.ns_ip6_target = Some(v.clone()),
                 _ => {
-                    log::warn!("Unsupported InfoBond: {:?}", nla);
+                    log::warn!("Unsupported InfoBond: {nla:?}");
                 }
             }
         }
@@ -714,7 +712,7 @@ pub(crate) fn get_bond_subordinate_info(
                 ret.subordinate_state = u8::from(*d).into()
             }
             _ => {
-                log::info!("Unknown bond port info {:?}", nla);
+                log::info!("Unknown bond port info {nla:?}");
             }
         }
     }

--- a/src/lib/query/bridge.rs
+++ b/src/lib/query/bridge.rs
@@ -385,7 +385,7 @@ pub(crate) fn get_bridge_port_info(
                 ret.backup_nexthop_id = Some(*d)
             }
             _ => {
-                log::info!("Unknown bridge port info {:?}", nla);
+                log::info!("Unknown bridge port info {nla:?}");
             }
         }
     }

--- a/src/lib/query/ethtool.rs
+++ b/src/lib/query/ethtool.rs
@@ -498,8 +498,7 @@ async fn dump_coalesce_infos(
                         coalesce_info.rate_sample_interval = Some(*d)
                     }
                     _ => log::warn!(
-                        "WARN: Unsupported EthtoolCoalesceAttr {:?}",
-                        nla
+                        "WARN: Unsupported EthtoolCoalesceAttr {nla:?}"
                     ),
                 }
             }
@@ -540,10 +539,9 @@ async fn dump_ring_infos(
                         ring_info.rx_jumbo = Some(*d)
                     }
                     EthtoolRingAttr::Tx(d) => ring_info.tx = Some(*d),
-                    _ => log::warn!(
-                        "WARN: Unsupported EthtoolRingAttr {:?}",
-                        nla
-                    ),
+                    _ => {
+                        log::warn!("WARN: Unsupported EthtoolRingAttr {nla:?}")
+                    }
                 }
             }
         }
@@ -596,8 +594,7 @@ async fn dump_link_mode_infos(
                     }
 
                     _ => log::warn!(
-                        "WARN: Unsupported EthtoolLinkModeAttr {:?}",
-                        nla
+                        "WARN: Unsupported EthtoolLinkModeAttr {nla:?}"
                     ),
                 }
             }

--- a/src/lib/query/hsr.rs
+++ b/src/lib/query/hsr.rs
@@ -80,7 +80,7 @@ pub(crate) fn get_hsr_info(data: &InfoData) -> Option<HsrInfo> {
                     hsr_info.protocol = u8::from(d).into();
                 }
                 _ => {
-                    log::warn!("Unknown HSR info {:?}", info);
+                    log::warn!("Unknown HSR info {info:?}");
                 }
             }
         }

--- a/src/lib/query/iface.rs
+++ b/src/lib/query/iface.rs
@@ -412,7 +412,7 @@ pub(crate) fn parse_nl_msg_to_iface(
                                 iface_state.tun = Some(info);
                             }
                             Err(e) => {
-                                log::warn!("Error parsing TUN info: {}", e);
+                                log::warn!("Error parsing TUN info: {e}");
                             }
                         },
                         IfaceType::Vlan => iface_state.vlan = get_vlan_info(d),
@@ -468,7 +468,7 @@ pub(crate) fn parse_nl_msg_to_iface(
                                 Some(s.as_str().into())
                         }
                         _ => {
-                            log::info!("Unknown port kind {:?}", info);
+                            log::info!("Unknown port kind {info:?}");
                         }
                     }
                 }
@@ -492,12 +492,12 @@ pub(crate) fn parse_nl_msg_to_iface(
                             }
                             InfoPortData::Other(_) => {
                                 log::warn!(
-                                    "Unknown controller type {:?}",
-                                    controller_type
+                                    "Unknown controller type \
+                                     {controller_type:?}"
                                 );
                             }
                             _ => {
-                                log::debug!("Unknown InfoPortData {:?}", d);
+                                log::debug!("Unknown InfoPortData {d:?}");
                             }
                         }
                     }

--- a/src/lib/query/iface.rs
+++ b/src/lib/query/iface.rs
@@ -30,9 +30,9 @@ use super::{
 use crate::{
     BondInfo, BondSubordinateInfo, BridgeInfo, BridgePortInfo, BridgeVlanEntry,
     EthtoolInfo, HsrInfo, IpVlanInfo, IpoibInfo, Ipv4Info, Ipv6Info,
-    MacSecInfo, MacVlanInfo, MacVtapInfo, MptcpAddress, NisporError, SriovInfo,
-    TunInfo, VethInfo, VfInfo, VlanInfo, VrfInfo, VrfSubordinateInfo,
-    VxlanInfo, WifiInfo, XfrmInfo,
+    MacSecInfo, MacVlanInfo, MacVtapInfo, MptcpAddress, NisporError,
+    PciAddress, SriovInfo, TunInfo, VethInfo, VfInfo, VlanInfo, VrfInfo,
+    VrfSubordinateInfo, VxlanInfo, WifiInfo, XfrmInfo,
 };
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
@@ -247,6 +247,8 @@ pub struct Iface {
     pub ipv6: Option<Ipv6Info>,
     #[serde(skip_serializing_if = "String::is_empty")]
     pub mac_address: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pci_address: Option<PciAddress>,
     #[serde(skip_serializing_if = "String::is_empty")]
     pub permanent_mac_address: String,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/lib/query/inter_ifaces.rs
+++ b/src/lib/query/inter_ifaces.rs
@@ -115,7 +115,7 @@ pub(crate) async fn get_ifaces(
             }
             Err(e) => {
                 // Ethtool is considered as optional
-                log::warn!("Failed to query ethtool info: {}", e);
+                log::warn!("Failed to query ethtool info: {e}");
             }
         };
     }

--- a/src/lib/query/inter_ifaces.rs
+++ b/src/lib/query/inter_ifaces.rs
@@ -120,6 +120,10 @@ pub(crate) async fn get_ifaces(
         };
     }
 
+    for iface in iface_states.values_mut() {
+        iface.fill_pci_address();
+    }
+
     // The cfg80211 module might not exists or loaded in environments,
     // we should only log wifi query failure instead of failing the whole
     // querying

--- a/src/lib/query/ip.rs
+++ b/src/lib/query/ip.rs
@@ -65,7 +65,7 @@ pub(crate) fn parse_ip_addr_str(
         let e = NisporError::invalid_argument(format!(
             "Invalid IP address {ip_addr_str}: {e}"
         ));
-        log::error!("{}", e);
+        log::error!("{e}");
         e
     })
 }
@@ -78,7 +78,7 @@ pub(crate) fn parse_ip_net_addr_str(
         let e = NisporError::invalid_argument(format!(
             "Invalid IP network address {ip_net_str}",
         ));
-        log::error!("{}", e);
+        log::error!("{e}");
         return Err(e);
     }
     let addr_str = splits[0];
@@ -87,7 +87,7 @@ pub(crate) fn parse_ip_net_addr_str(
             let e = NisporError::invalid_argument(format!(
                 "Invalid IP network prefix {ip_net_str}: {e}"
             ));
-            log::error!("{}", e);
+            log::error!("{e}");
             e
         })?
     } else if is_ipv6_addr(addr_str) {
@@ -119,17 +119,14 @@ pub(crate) fn fill_af_spec_inet_info(iface: &mut Iface, nlas: &[AfSpecUnspec]) {
 }
 
 pub(crate) fn read_ipv4_forwarding(iface_name: &str) -> Option<bool> {
-    let path = format!("/proc/sys/net/ipv4/conf/{}/forwarding", iface_name);
+    let path = format!("/proc/sys/net/ipv4/conf/{iface_name}/forwarding");
 
     let file = match File::open(&path) {
         Ok(f) => f,
         Err(e) => {
             log::warn!(
-                "Failed to read IPv4 forwarding value for interface '{}': \
-                 could not open '{}': {}",
-                iface_name,
-                path,
-                e
+                "Failed to read IPv4 forwarding value for interface \
+                 '{iface_name}': could not open '{path}': {e}"
             );
             return None;
         }
@@ -140,10 +137,8 @@ pub(crate) fn read_ipv4_forwarding(iface_name: &str) -> Option<bool> {
 
     if let Err(e) = reader.read_line(&mut line) {
         log::warn!(
-            "Failed to read IPv4 forwarding value from '{}', for interface '{}': {}",
-            path,
-            iface_name,
-            e
+            "Failed to read IPv4 forwarding value from '{path}', for \
+             interface '{iface_name}': {e}"
         );
         return None;
     }
@@ -153,10 +148,8 @@ pub(crate) fn read_ipv4_forwarding(iface_name: &str) -> Option<bool> {
         "0" => Some(false),
         other => {
             log::warn!(
-                "Unexpected IPv4 forwarding value '{}' in '{}', for interface '{}'",
-                other,
-                path,
-                iface_name
+                "Unexpected IPv4 forwarding value '{other}' in '{path}', for \
+                 interface '{iface_name}'"
             );
             None
         }

--- a/src/lib/query/ipoib.rs
+++ b/src/lib/query/ipoib.rs
@@ -59,7 +59,7 @@ pub(crate) fn get_ipoib_info(data: &InfoData) -> Option<IpoibInfo> {
             } else if let InfoIpoib::UmCast(d) = *info {
                 ipoib_info.umcast = d > 0;
             } else {
-                log::debug!("Unknown IPoIB info {:?}", info)
+                log::debug!("Unknown IPoIB info {info:?}")
             }
         }
         Some(ipoib_info)

--- a/src/lib/query/ipvlan.rs
+++ b/src/lib/query/ipvlan.rs
@@ -70,7 +70,7 @@ pub(crate) fn get_ip_vlan_info(data: &InfoData) -> Option<IpVlanInfo> {
                 InfoIpVlan::Flags(d) => {
                     ipv_info.flags = d.iter().map(IpVlanFlag::from).collect()
                 }
-                _ => log::debug!("Unkwnown IP VLAN info {:?}", info),
+                _ => log::debug!("Unkwnown IP VLAN info {info:?}"),
             }
         }
         return Some(ipv_info);

--- a/src/lib/query/mac_vlan.rs
+++ b/src/lib/query/mac_vlan.rs
@@ -81,7 +81,7 @@ pub(crate) fn get_mac_vlan_info(
                 }
                 macv_info.allowed_mac_addresses = Some(addrs);
             } else {
-                log::debug!("Unknown MAC VLAN info {:?}", info)
+                log::debug!("Unknown MAC VLAN info {info:?}")
             }
         }
         Ok(Some(macv_info))
@@ -100,7 +100,7 @@ pub(crate) fn get_mac_vlan_info(
                 }
                 macv_info.allowed_mac_addresses = Some(addrs);
             } else {
-                log::debug!("Unknown MAC VTAP info {:?}", info)
+                log::debug!("Unknown MAC VTAP info {info:?}")
             }
         }
         Ok(Some(macv_info))

--- a/src/lib/query/macsec.rs
+++ b/src/lib/query/macsec.rs
@@ -175,7 +175,7 @@ pub(crate) fn get_macsec_info(data: &InfoData) -> Option<MacSecInfo> {
                     macsec_info.offload = u8::from(d).into();
                 }
                 _ => {
-                    log::debug!("Unknown MACsec info {:?}", info)
+                    log::debug!("Unknown MACsec info {info:?}")
                 }
             }
         }

--- a/src/lib/query/mod.rs
+++ b/src/lib/query/mod.rs
@@ -5,6 +5,7 @@ mod bridge;
 mod hsr;
 mod ip;
 mod mptcp;
+mod pci;
 mod wifi;
 mod xfrm;
 // Disable `needless_pass_by_ref_mut` check due to upstream issue:
@@ -57,6 +58,7 @@ pub use self::macsec::{
     MacSecCipherId, MacSecInfo, MacSecOffload, MacSecValidate,
 };
 pub use self::mptcp::{Mptcp, MptcpAddress, MptcpAddressFlag};
+pub use self::pci::PciAddress;
 pub use self::route::{
     AddressFamily, MultipathRoute, MultipathRouteFlags, Route, RouteProtocol,
     RouteScope, RouteType,

--- a/src/lib/query/mptcp.rs
+++ b/src/lib/query/mptcp.rs
@@ -84,7 +84,7 @@ pub(crate) async fn get_mptcp() -> Result<Mptcp, NisporError> {
                     ret.subflows_limit = Some(*d);
                 }
                 _ => {
-                    log::info!("Unsupported MPTCP netlink attribute {:?}", nla)
+                    log::info!("Unsupported MPTCP netlink attribute {nla:?}")
                 }
             }
         }
@@ -146,7 +146,7 @@ pub(crate) fn merge_mptcp_info(
                         addr.iface = Some(iface_index.to_string());
                     }
                 } else {
-                    log::error!("BUG: Got invalid iface index in  {:?}", addr);
+                    log::error!("BUG: Got invalid iface index in  {addr:?}");
                 }
             }
         }
@@ -236,7 +236,7 @@ fn mptcp_flags_to_nispor(
                 Some(MptcpAddressFlag::Implicit)
             }
             _ => {
-                log::info!("Unsupported address flag {:?}", flag);
+                log::info!("Unsupported address flag {flag:?}");
                 None
             }
         } {

--- a/src/lib/query/pci.rs
+++ b/src/lib/query/pci.rs
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{Iface, NisporError};
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(into = "String")]
+#[serde(try_from = "String")]
+pub struct PciAddress {
+    pub domain: u32,
+    pub bus: u8,
+    pub slot: u8,
+    pub function: u8,
+}
+
+impl std::fmt::Display for PciAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}:{:02x}:{:02x}.{}",
+            if self.domain > u16::MAX.into() {
+                format!("{:08x}", self.domain)
+            } else {
+                format!("{:04x}", self.domain)
+            },
+            self.bus,
+            self.slot,
+            self.function
+        )
+    }
+}
+
+impl TryFrom<String> for PciAddress {
+    type Error = NisporError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::from_str(value.as_str())
+    }
+}
+
+impl From<PciAddress> for String {
+    fn from(v: PciAddress) -> String {
+        v.to_string()
+    }
+}
+
+fn parse_pci_addr(pci_addr_str: &str) -> Option<PciAddress> {
+    let mut items: Vec<&str> = pci_addr_str.split(":").collect();
+    if items.len() == 2 || items.len() == 3 {
+        // It is safe to unwrap as we already checked the length.
+        let slot_function_str: Vec<&str> =
+            items.pop().unwrap().split(".").collect();
+        if slot_function_str.len() != 2 {
+            return None;
+        }
+
+        let slot = u8::from_str_radix(slot_function_str[0], 16).ok()?;
+
+        let function = slot_function_str[1].parse::<u8>().ok()?;
+
+        let bus = u8::from_str_radix(items.pop().unwrap(), 16).ok()?;
+
+        let domain = if let Some(item) = items.pop() {
+            u32::from_str_radix(item, 16).ok()?
+        } else {
+            0
+        };
+        Some(PciAddress {
+            domain,
+            bus,
+            slot,
+            function,
+        })
+    } else {
+        None
+    }
+}
+
+impl FromStr for PciAddress {
+    type Err = NisporError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse_pci_addr(s).ok_or_else(|| {
+            NisporError::invalid_argument(format!(
+                "Invalid PCI address, expecting string like 00:1b.0 or \
+                 0000:07:00.1, but got {s}"
+            ))
+        })
+    }
+}
+
+impl Iface {
+    // The PCI address only available via ethtool IOCTL `ETHTOOL_GDRVINFO`,
+    // there is no netlink API for this yet. Hence using sysfs required.
+    // The systemd `src/udev/udev-builtin-path_id.c` is also using this
+    // information for ID_PATH.
+    pub(crate) fn fill_pci_address(&mut self) {
+        if let Some(dev_path) =
+            PathBuf::from(format!("/sys/class/net/{}/device", self.name))
+                .read_link()
+                .ok()
+                .as_deref()
+                .and_then(Path::file_name)
+                .and_then(std::ffi::OsStr::to_str)
+        {
+            if let Ok(pci_addr) = PciAddress::from_str(dev_path) {
+                self.pci_address = Some(pci_addr);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::PciAddress;
+
+    #[test]
+    fn parse_pci_addr() {
+        let expected = PciAddress {
+            domain: 0,
+            bus: 0x0a,
+            slot: 0x9,
+            function: 7,
+        };
+        let expected_str = "0000:0a:09.7";
+
+        let parsed = PciAddress::from_str("0a:09.7").unwrap();
+        let parsed2 = PciAddress::from_str("0000:0a:09.7").unwrap();
+        assert_eq!(expected, parsed);
+        assert_eq!(expected, parsed2);
+        assert_eq!(expected_str, parsed.to_string());
+        assert_eq!(expected_str, parsed2.to_string());
+    }
+}

--- a/src/lib/query/route.rs
+++ b/src/lib/query/route.rs
@@ -462,9 +462,9 @@ pub(crate) async fn get_routes(
                 .set_netlink_get_strict_chk(true)
             {
                 log::warn!(
-                    "Failed to set kernel space route filter: {e}, \
-                    falling back to user space route filtering which would \
-                    lead to performance penalty"
+                    "Failed to set kernel space route filter: {e}, falling \
+                     back to user space route filtering which would lead to \
+                     performance penalty"
                 );
                 has_kernel_filter = false;
             }
@@ -619,10 +619,7 @@ fn get_route(
                             rt.fastopen_no_cookie = Some(*d);
                         }
                         _ => {
-                            log::debug!(
-                                "Unknown RTA_METRICS message {:?}",
-                                nla
-                            );
+                            log::debug!("Unknown RTA_METRICS message {nla:?}");
                         }
                     }
                 }
@@ -690,7 +687,7 @@ fn get_route(
                 rt.multipath = Some(next_hops);
             }
             RouteAttribute::Preference(d) => rt.preference = Some((*d).into()),
-            _ => log::debug!("Unknown NLA message for route {:?}", nla),
+            _ => log::debug!("Unknown NLA message for route {nla:?}"),
         }
     }
 
@@ -702,7 +699,7 @@ fn _rt_addr_to_string(addr: &RouteAddress) -> String {
         RouteAddress::Inet(v) => v.to_string(),
         RouteAddress::Inet6(v) => v.to_string(),
         _ => {
-            log::debug!("Unknown RouteAddress type {:?}", addr);
+            log::debug!("Unknown RouteAddress type {addr:?}");
             String::new()
         }
     }

--- a/src/lib/query/route_rule.rs
+++ b/src/lib/query/route_rule.rs
@@ -123,10 +123,10 @@ fn get_rule(rule_msg: RuleMessage) -> Result<RouteRule, NisporError> {
     for nla in &rule_msg.attributes {
         match nla {
             RuleAttribute::Destination(d) => {
-                rl.dst = Some(format!("{}/{}", d, dst_prefix_len,));
+                rl.dst = Some(format!("{d}/{dst_prefix_len}",));
             }
             RuleAttribute::Source(d) => {
-                rl.src = Some(format!("{}/{}", d, src_prefix_len,));
+                rl.src = Some(format!("{d}/{src_prefix_len}",));
             }
             RuleAttribute::Iifname(d) => {
                 rl.iif = Some(d.clone().to_string());
@@ -176,7 +176,7 @@ fn get_rule(rule_msg: RuleMessage) -> Result<RouteRule, NisporError> {
             RuleAttribute::L3MDev(d) => {
                 rl.l3mdev = Some(*d);
             }
-            _ => log::debug!("Unknown NLA message for route rule {:?}", nla),
+            _ => log::debug!("Unknown NLA message for route rule {nla:?}"),
         }
     }
 

--- a/src/lib/query/sriov.rs
+++ b/src/lib/query/sriov.rs
@@ -167,7 +167,7 @@ fn parse_vf_stats(nlas: &[link::VfStats]) -> Result<VfState, NisporError> {
             link::VfStats::Multicast(d) => state.multicast = *d,
             link::VfStats::RxDropped(d) => state.rx_dropped = *d,
             link::VfStats::TxDropped(d) => state.tx_dropped = *d,
-            _ => log::debug!("Unhandled IFLA_VF_STATS {:?}", nla),
+            _ => log::debug!("Unhandled IFLA_VF_STATS {nla:?}"),
         }
     }
     Ok(state)
@@ -215,7 +215,7 @@ fn read_folder(folder_path: &str) -> Vec<String> {
     let fd = match std::fs::read_dir(folder_path) {
         Ok(f) => f,
         Err(e) => {
-            log::warn!("Failed to read dir {}: {}", folder_path, e);
+            log::warn!("Failed to read dir {folder_path}: {e}");
             return folder_contents;
         }
     };
@@ -223,7 +223,7 @@ fn read_folder(folder_path: &str) -> Vec<String> {
         let entry = match entry {
             Ok(e) => e,
             Err(e) => {
-                log::warn!("Failed to read dir {}: {}", folder_path, e);
+                log::warn!("Failed to read dir {folder_path}: {e}");
                 continue;
             }
         };

--- a/src/lib/query/tun.rs
+++ b/src/lib/query/tun.rs
@@ -61,7 +61,7 @@ impl From<u8> for TunMode {
             IFF_TUN => TunMode::Tun,
             IFF_TAP => TunMode::Tap,
             _ => {
-                log::warn!("Unhandled TUN mode {}", d);
+                log::warn!("Unhandled TUN mode {d}");
                 TunMode::Unknown
             }
         }

--- a/src/lib/query/vlan.rs
+++ b/src/lib/query/vlan.rs
@@ -116,7 +116,7 @@ pub(crate) fn get_vlan_info(data: &InfoData) -> Option<VlanInfo> {
                     .filter_map(VlanQosMapping::from_netlink)
                     .collect();
             } else {
-                log::debug!("Unknown VLAN info: {:?}", info);
+                log::debug!("Unknown VLAN info: {info:?}");
             }
         }
         Some(vlan_info)

--- a/src/lib/query/vrf.rs
+++ b/src/lib/query/vrf.rs
@@ -27,7 +27,7 @@ pub(crate) fn get_vrf_info(data: &InfoData) -> Option<VrfInfo> {
             if let InfoVrf::TableId(d) = *info {
                 vrf_info.table_id = d;
             } else {
-                log::debug!("Unknown VRF info {:?}", info)
+                log::debug!("Unknown VRF info {info:?}")
             }
         }
         Some(vrf_info)
@@ -45,7 +45,7 @@ pub(crate) fn get_vrf_subordinate_info(
         match nla {
             InfoVrfPort::TableId(d) => ret.table_id = *d,
             _ => {
-                log::info!("Unknown VRF port info {:?}", nla);
+                log::info!("Unknown VRF port info {nla:?}");
             }
         }
     }

--- a/src/lib/query/vxlan.rs
+++ b/src/lib/query/vxlan.rs
@@ -104,7 +104,7 @@ pub(crate) fn get_vxlan_info(
             } else if let InfoVxlan::Df(d) = *info {
                 vxlan_info.df = d;
             } else {
-                log::debug!("Unknown VXLAN info {:?}", info)
+                log::debug!("Unknown VXLAN info {info:?}")
             }
         }
         Ok(Some(vxlan_info))

--- a/src/lib/query/xfrm.rs
+++ b/src/lib/query/xfrm.rs
@@ -25,7 +25,7 @@ pub(crate) fn get_xfrm_info(data: &InfoData) -> Option<XfrmInfo> {
                     xfrm_info.iface_id = d;
                 }
                 _ => {
-                    log::debug!("Unknown XFRM info {:?}", info);
+                    log::debug!("Unknown XFRM info {info:?}");
                 }
             }
         }


### PR DESCRIPTION
By reading link of `/sys/class/net/<nic_name>/device`, we include
`PciAddress` to `Iface`.

Example output of `npc iface enp7s0`:

```
pci_address: 0000:07:00.0
```

Example output of `npc enp7s0`:

```
3: enp7s0: <UP,BROADCAST,RUNNING,MULTICAST,LOWERUP> state up mtu 1500
  driver e1000e pci 0000:07:00.0
  link ethernet
  mac 00:bb:cc:dd:ee:ff permanent_mac 00:bb:cc:dd:ee:ff
```

No test case included as this require PCI device which does exists in CI
environment.