### PR TITLE
sriov: include maximum supported VF count

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ members = [
 platforms = ["*-unknown-linux-gnu"]
 tier = "2"
 all-features = true
+
+[workspace.package]
+rust-version = "1.77"

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://github.com/nispor/nispor"
 repository = "https://github.com/nispor/nispor"
 keywords = ["network"]
 categories = ["network-programming", "os"]
+rust-version.workspace = true
 
 
 [[bin]]

--- a/src/clib/Cargo.toml
+++ b/src/clib/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/nispor/nispor"
 keywords = ["network"]
 categories = ["network-programming", "os"]
 build = "build.rs"
+rust-version.workspace = true
 
 [lib]
 name = "nispor"

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://github.com/nispor/nispor"
 repository = "https://github.com/nispor/nispor"
 keywords = ["network"]
 categories = ["network-programming", "os"]
-rust-version = "1.58"
+rust-version.workspace = true
 
 [lib]
 name = "nispor"

--- a/src/lib/query/sriov.rs
+++ b/src/lib/query/sriov.rs
@@ -54,6 +54,8 @@ pub struct VfState {
 pub struct SriovInfo {
     pub vfs: Vec<VfInfo>,
     pub num_vfs: Option<u32>,
+    /// The maximum supported number of VFs.
+    pub max_num_vfs: Option<u32>,
     pub drivers_autoprobe: Option<bool>,
 }
 
@@ -100,6 +102,7 @@ pub(crate) fn get_sriov_info(
         _ => MAX_ADDR_LEN,
     };
     sriov_info.num_vfs = get_num_vfs(pf_iface_name);
+    sriov_info.max_num_vfs = get_max_num_vfs(pf_iface_name);
     sriov_info.drivers_autoprobe = is_drivers_autoprobe(pf_iface_name);
     for port_nlas in nlas {
         let mut vf_info = VfInfo::default();
@@ -196,6 +199,14 @@ fn is_drivers_autoprobe(pf_name: &str) -> Option<bool> {
 
 fn get_num_vfs(pf_name: &str) -> Option<u32> {
     let sysfs_path = format!("/sys/class/net/{pf_name}/device/sriov_numvfs");
+    match std::fs::read_to_string(sysfs_path) {
+        Ok(s) => s.trim().parse::<u32>().ok(),
+        _ => None,
+    }
+}
+
+fn get_max_num_vfs(pf_name: &str) -> Option<u32> {
+    let sysfs_path = format!("/sys/class/net/{pf_name}/device/sriov_totalvfs");
     match std::fs::read_to_string(sysfs_path) {
         Ok(s) => s.trim().parse::<u32>().ok(),
         _ => None,


### PR DESCRIPTION
Introducing `VfState::max_num_vfs` for maximum number of Virtual
Functions (VFs) a SR-IOV PF(physical function).

No test code include because this require special hardware. Manually
tested.