### PR TITLE
Support querying and changing alt-names of interface

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [target.x86_64-unknown-linux-gnu]
-runner = 'sudo -E'
+runner = 'sudo'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ futures = "0.3.21"
 libc = "0.2.155"
 log = "0.4.17"
 mptcp-pm = "0.1.3"
-rtnetlink = "0.17.0"
+rtnetlink = "0.18.0"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 serde_yaml = "0.9"

--- a/src/lib/conf/alt_name.rs
+++ b/src/lib/conf/alt_name.rs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{Iface, IfaceConf, NisporError};
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
+pub struct AltNameConf {
+    #[serde(default)]
+    remove: bool,
+    name: String,
+}
+
+pub(crate) async fn change_alt_names(
+    handle: &rtnetlink::Handle,
+    ifaces: &[&IfaceConf],
+    cur_ifaces: &HashMap<String, Iface>,
+) -> Result<(), NisporError> {
+    for iface in ifaces.iter().filter(|i| !i.alt_names.is_empty()) {
+        if let Some(cur_iface) = cur_ifaces.get(&iface.name) {
+            let index = cur_iface.index;
+
+            if is_all_remove(&iface.alt_names) {
+                let names: Vec<&str> =
+                    iface.alt_names.iter().map(|c| c.name.as_str()).collect();
+                handle
+                    .link()
+                    .property_del(index)
+                    .alt_ifname(&names)
+                    .execute()
+                    .await?;
+            } else if is_all_add(&iface.alt_names) {
+                let names: Vec<&str> =
+                    iface.alt_names.iter().map(|c| c.name.as_str()).collect();
+                handle
+                    .link()
+                    .property_add(index)
+                    .alt_ifname(&names)
+                    .execute()
+                    .await?;
+            } else {
+                for alt_name_conf in iface.alt_names.iter() {
+                    if alt_name_conf.remove {
+                        handle
+                            .link()
+                            .property_del(index)
+                            .alt_ifname(&[alt_name_conf.name.as_str()])
+                            .execute()
+                            .await?;
+                    } else {
+                        handle
+                            .link()
+                            .property_add(index)
+                            .alt_ifname(&[alt_name_conf.name.as_str()])
+                            .execute()
+                            .await?;
+                    }
+                }
+            }
+        } else {
+            return Err(NisporError::invalid_argument(format!(
+                "Interface {} not found",
+                iface.name
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn is_all_remove(confs: &[AltNameConf]) -> bool {
+    confs.iter().all(|c| c.remove)
+}
+
+fn is_all_add(confs: &[AltNameConf]) -> bool {
+    confs.iter().all(|c| !c.remove)
+}

--- a/src/lib/conf/iface.rs
+++ b/src/lib/conf/iface.rs
@@ -7,8 +7,8 @@ use serde::{Deserialize, Serialize};
 
 use super::{super::mac::mac_str_to_raw, inter_ifaces::change_ifaces};
 use crate::{
-    BondConf, BridgeConf, Iface, IfaceState, IfaceType, IpConf, NisporError,
-    VethConf, VlanConf,
+    AltNameConf, BondConf, BridgeConf, Iface, IfaceState, IfaceType, IpConf,
+    NisporError, VethConf, VlanConf,
 };
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
@@ -19,6 +19,8 @@ pub struct IfaceConf {
     pub state: IfaceState,
     #[serde(rename = "type")]
     pub iface_type: Option<IfaceType>,
+    #[serde(default)]
+    pub alt_names: Vec<AltNameConf>,
     pub controller: Option<String>,
     pub ipv4: Option<IpConf>,
     pub ipv6: Option<IpConf>,

--- a/src/lib/conf/inter_ifaces.rs
+++ b/src/lib/conf/inter_ifaces.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use rtnetlink::{new_connection, LinkUnspec};
 
 use super::{
+    alt_name::change_alt_names,
     iface::{change_iface_mac, change_iface_state},
     ip::change_ips,
 };
@@ -105,6 +106,7 @@ pub(crate) async fn change_ifaces(
     change_ifaces_controller(&handle, ifaces, cur_ifaces).await?;
     change_ifaces_state(&handle, ifaces, cur_ifaces).await?;
     change_ips(&handle, ifaces, cur_ifaces).await?;
+    change_alt_names(&handle, ifaces, cur_ifaces).await?;
     Ok(())
 }
 

--- a/src/lib/conf/mod.rs
+++ b/src/lib/conf/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+mod alt_name;
 mod bond;
 mod bridge;
 mod iface;
@@ -9,6 +10,7 @@ mod route;
 mod veth;
 mod vlan;
 
+pub use self::alt_name::AltNameConf;
 pub use self::bond::BondConf;
 pub use self::bridge::BridgeConf;
 pub use self::iface::IfaceConf;

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -2,7 +2,7 @@
 
 use ethtool::EthtoolError;
 use libc::{EEXIST, EPERM};
-use rtnetlink::packet_utils::DecodeError;
+use rtnetlink::packet_core::DecodeError;
 use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/lib/integ_tests/alt_name.rs
+++ b/src/lib/integ_tests/alt_name.rs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::panic;
+
+use pretty_assertions::assert_eq;
+
+use crate::{NetConf, NetState};
+
+const IFACE_NAME: &str = "veth1";
+
+fn with_veth_iface<T>(test: T)
+where
+    T: FnOnce() + panic::UnwindSafe,
+{
+    super::utils::set_network_environment("veth");
+
+    let result = panic::catch_unwind(|| {
+        test();
+    });
+
+    super::utils::clear_network_environment();
+    assert!(result.is_ok())
+}
+
+#[test]
+fn test_add_and_remove_alt_name_bulk() {
+    with_veth_iface(|| {
+        let conf: NetConf = serde_yaml::from_str(
+            r#"---
+            ifaces:
+              - name: veth1
+                alt_names:
+                  - name: port1
+                  - name: internal"#,
+        )
+        .unwrap();
+        conf.apply().unwrap();
+        let state = NetState::retrieve().unwrap();
+        let iface = &state.ifaces[IFACE_NAME];
+        assert_eq!(
+            iface.alt_names,
+            vec!["port1".to_string(), "internal".to_string()]
+        );
+
+        let conf: NetConf = serde_yaml::from_str(
+            r#"---
+            ifaces:
+              - name: veth1
+                alt_names:
+                  - name: port1
+                    remove: true
+                  - name: internal
+                    remove: true"#,
+        )
+        .unwrap();
+        conf.apply().unwrap();
+        let state = NetState::retrieve().unwrap();
+        let iface = &state.ifaces[IFACE_NAME];
+        assert_eq!(iface.alt_names, Vec::<String>::new());
+    });
+}
+
+#[test]
+fn test_add_and_remove_alt_name_mixed() {
+    with_veth_iface(|| {
+        let conf: NetConf = serde_yaml::from_str(
+            r#"---
+            ifaces:
+              - name: veth1
+                alt_names:
+                  - name: port1
+                  - name: internal"#,
+        )
+        .unwrap();
+        conf.apply().unwrap();
+        let state = NetState::retrieve().unwrap();
+        let iface = &state.ifaces[IFACE_NAME];
+        assert_eq!(
+            iface.alt_names,
+            vec!["port1".to_string(), "internal".to_string()]
+        );
+
+        let conf: NetConf = serde_yaml::from_str(
+            r#"---
+            ifaces:
+              - name: veth1
+                alt_names:
+                  - name: internal
+                    remove: true
+                  - name: wan0"#,
+        )
+        .unwrap();
+        conf.apply().unwrap();
+        let state = NetState::retrieve().unwrap();
+        let iface = &state.ifaces[IFACE_NAME];
+        assert_eq!(
+            iface.alt_names,
+            vec!["port1".to_string(), "wan0".to_string()]
+        );
+    });
+}

--- a/src/lib/integ_tests/mod.rs
+++ b/src/lib/integ_tests/mod.rs
@@ -3,6 +3,8 @@
 mod utils;
 
 #[cfg(test)]
+mod alt_name;
+#[cfg(test)]
 mod base_info;
 #[cfg(test)]
 mod bond;

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -12,8 +12,8 @@ mod netlink;
 mod query;
 
 pub use crate::conf::{
-    BondConf, BridgeConf, IfaceConf, IpAddrConf, IpConf, RouteConf, VethConf,
-    VlanConf,
+    AltNameConf, BondConf, BridgeConf, IfaceConf, IpAddrConf, IpConf,
+    RouteConf, VethConf, VlanConf,
 };
 pub use crate::error::{ErrorKind, NisporError};
 pub use crate::filter::{

--- a/src/lib/query/iface.rs
+++ b/src/lib/query/iface.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use rtnetlink::packet_route::link::{
     self, InfoKind, InfoPortData, InfoPortKind, LinkAttribute, LinkInfo,
-    LinkLayerType, LinkMessage,
+    LinkLayerType, LinkMessage, Prop,
 };
 use serde::{Deserialize, Serialize};
 
@@ -237,6 +237,8 @@ pub struct Iface {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_mtu: Option<i64>,
     pub flags: Vec<IfaceFlag>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub alt_names: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ipv4: Option<Ipv4Info>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -358,6 +360,17 @@ pub(crate) fn parse_nl_msg_to_iface(
             iface_state.controller = Some(format!("{controller}"));
         } else if let LinkAttribute::Link(l) = nla {
             link = Some(*l);
+        } else if let LinkAttribute::PropList(prop_list) = nla {
+            iface_state.alt_names = prop_list
+                .iter()
+                .filter_map(|p| {
+                    if let Prop::AltIfName(n) = p {
+                        Some(n.to_string())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
         } else if let LinkAttribute::LinkInfo(infos) = nla {
             for info in infos {
                 if let LinkInfo::Kind(t) = info {

--- a/src/lib/query/tun.rs
+++ b/src/lib/query/tun.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use rtnetlink::packet_core::Nla;
 use rtnetlink::packet_route::link::InfoData;
-use rtnetlink::packet_utils::nla::Nla;
 use serde::{Deserialize, Serialize};
 
 use crate::{


### PR DESCRIPTION
Query output:

```
- name: wlan0
  iface_type: wifi
  state: up
  alt_names:
  - wifi0
```

Apply conf:

```
ifaces:
  - name: wlan0
    alt_names:
      - name: wifi0
        remove: true
```

Integration test case included.