### PR TITLE
Cargo clean up and deprecate C and python binding

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,4 +1,4 @@
 max_width = 80
 reorder_imports = true
 format_strings = true
-edition = "2018"
+edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,29 @@ all-features = true
 
 [workspace.package]
 rust-version = "1.77"
+version = "1.2.26"
+authors = ["Gris Ge <fge@redhat.com>"]
+description = "Unified interface for Linux network state querying"
+edition = "2021"
+license = "Apache-2.0"
+documentation = "https://github.com/nispor/nispor"
+homepage = "https://github.com/nispor/nispor"
+repository = "https://github.com/nispor/nispor"
+keywords = ["network"]
+categories = ["network-programming", "os"]
+
+
+[workspace.dependencies]
+clap = { version = "4.2", features = ["cargo"] }
+env_logger = "0.11.0"
+ethtool = "0.2.8"
+futures = "0.3.21"
+libc = "0.2.155"
+log = "0.4.17"
+mptcp-pm = "0.1.3"
+rtnetlink = "0.17.0"
+serde = { version = "1.0.137", features = ["derive"] }
+serde_json = "1.0.81"
+serde_yaml = "0.9"
+tokio = { version = "1.19.2", features = ["macros", "rt"] }
+wl-nl80211 = "0.2.0"

--- a/src/cli/Cargo.toml
+++ b/src/cli/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nispor-cli"
-version = "1.2.26"
-authors = ["Gris Ge <fge@redhat.com>"]
-license = "Apache-2.0"
-edition = "2021"
 description = "Command line tool for nispor project"
-homepage = "https://github.com/nispor/nispor"
-repository = "https://github.com/nispor/nispor"
-keywords = ["network"]
-categories = ["network-programming", "os"]
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
 rust-version.workspace = true
 
 
@@ -17,10 +17,10 @@ name = "npc"
 path = "npc.rs"
 
 [dependencies]
-serde_json = "1.0"
-serde = { version = "1.0.136", features = ["derive"] }
-clap = { version = "4.2", features = ["cargo"] }
-nispor = { path = "../lib", version="1.2.26" }
-serde_yaml = "0.9"
-env_logger = "0.11.0"
-log = "0.4.14"
+serde_json = { workspace = true }
+serde = { workspace = true }
+clap = { workspace = true }
+serde_yaml = { workspace = true }
+env_logger = { workspace = true }
+log = { workspace = true }
+nispor = { path = "../lib", version="1.2" }

--- a/src/clib/Cargo.toml
+++ b/src/clib/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "nispor-clib"
-version = "1.2.26"
+version = "1.2.26-deprecated"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "Apache-2.0"
 edition = "2021"
-description = "C binding for nispor project"
+description = "C binding for nispor project (deprecated)"
 homepage = "https://github.com/nispor/nispor"
 repository = "https://github.com/nispor/nispor"
 keywords = ["network"]

--- a/src/clib/nispor.h.in
+++ b/src/clib/nispor.h.in
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+#warning "Deprecated, please use rust nispor crate directly"
+
 #ifndef _LIBNISPOR_H_
 #define _LIBNISPOR_H_
 

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "nispor"
-version = "1.2.26"
-authors = ["Gris Ge <fge@redhat.com>"]
-license = "Apache-2.0"
-edition = "2021"
-description = "Unified interface for Linux network state querying"
-homepage = "https://github.com/nispor/nispor"
-repository = "https://github.com/nispor/nispor"
-keywords = ["network"]
-categories = ["network-programming", "os"]
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+description.workspace = true
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
 rust-version.workspace = true
 
 [lib]
@@ -17,17 +17,17 @@ path = "lib.rs"
 crate-type = ["lib"]
 
 [dependencies]
-serde = { version = "1.0.137", features = ["derive"] }
-serde_json = "1.0.81"
-rtnetlink = "0.17.0"
-ethtool = "0.2.8"
-mptcp-pm = "0.1.3"
-tokio = { version = "1.19.2", features = ["macros", "rt"] }
-futures = "0.3.21"
-libc = "0.2.155"
-log = "0.4.17"
-wl-nl80211 = "0.2.0"
+serde = { workspace = true }
+serde_json = { workspace = true }
+rtnetlink = { workspace = true }
+ethtool = { workspace = true }
+mptcp-pm = { workspace = true }
+tokio = { workspace = true }
+futures = { workspace = true }
+libc = { workspace = true }
+log = { workspace = true }
+wl-nl80211 = { workspace = true }
 
 [dev-dependencies]
-serde_yaml = "0.9"
+serde_yaml = { workspace = true }
 pretty_assertions = "1.2.1"

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -1,19 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
+mod conf;
 mod error;
+mod filter;
 #[cfg(test)]
 mod integ_tests;
 mod mac;
-// Since rust 1.62, the `#[default]` can be used for setting default value of
-// `#[derive(Default)]` for enum. The cargo clippy will complain if we impl the
-// Default by ourselves. But currently nispor minimum rust version is 1.58,
-// hence we suppress the clippy warning here.
-mod conf;
-mod filter;
 mod net_conf;
 mod net_state;
 mod netlink;
-#[allow(clippy::derivable_impls)]
 mod query;
 
 pub use crate::conf::{

--- a/src/lib/query/bond.rs
+++ b/src/lib/query/bond.rs
@@ -683,12 +683,14 @@ impl Default for BondSubordinateState {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
+#[derive(Default)]
 pub enum BondMiiStatus {
     LinkUp,
     LinkFail,
     LinkDown,
     LinkBack,
     Other(u8),
+    #[default]
     Unknown,
 }
 
@@ -706,12 +708,6 @@ impl From<u8> for BondMiiStatus {
             BOND_LINK_BACK => Self::LinkBack,
             _ => Self::Other(d),
         }
-    }
-}
-
-impl Default for BondMiiStatus {
-    fn default() -> Self {
-        BondMiiStatus::Unknown
     }
 }
 

--- a/src/lib/query/ethtool.rs
+++ b/src/lib/query/ethtool.rs
@@ -103,9 +103,11 @@ pub struct EthtoolRingInfo {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
+#[derive(Default)]
 pub enum EthtoolLinkModeDuplex {
     Half,
     Full,
+    #[default]
     Unknown,
     Other(u8),
 }
@@ -118,12 +120,6 @@ impl From<&ethtool::EthtoolLinkModeDuplex> for EthtoolLinkModeDuplex {
             ethtool::EthtoolLinkModeDuplex::Unknown => Self::Unknown,
             ethtool::EthtoolLinkModeDuplex::Other(d) => Self::Other(*d),
         }
-    }
-}
-
-impl Default for EthtoolLinkModeDuplex {
-    fn default() -> Self {
-        EthtoolLinkModeDuplex::Unknown
     }
 }
 

--- a/src/lib/query/hsr.rs
+++ b/src/lib/query/hsr.rs
@@ -13,17 +13,13 @@ const HSR_PROTOCOL_PRP: u8 = 1;
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
+#[derive(Default)]
 pub enum HsrProtocol {
     Hsr,
     Prp,
     Other(u8),
+    #[default]
     Unknown,
-}
-
-impl Default for HsrProtocol {
-    fn default() -> Self {
-        HsrProtocol::Unknown
-    }
 }
 
 impl From<u8> for HsrProtocol {

--- a/src/lib/query/iface.rs
+++ b/src/lib/query/iface.rs
@@ -38,6 +38,7 @@ use crate::{
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
+#[derive(Default)]
 pub enum IfaceType {
     Bond,
     Veth,
@@ -57,16 +58,11 @@ pub enum IfaceType {
     IpVlan,
     MacSec,
     Hsr,
+    #[default]
     Unknown,
     Xfrm,
     Wifi,
     Other(String),
-}
-
-impl Default for IfaceType {
-    fn default() -> Self {
-        IfaceType::Unknown
-    }
 }
 
 impl std::fmt::Display for IfaceType {

--- a/src/lib/query/ipoib.rs
+++ b/src/lib/query/ipoib.rs
@@ -13,19 +13,15 @@ const IPOIB_MODE_CONNECTED: u16 = 1;
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
+#[derive(Default)]
 pub enum IpoibMode {
     /* using unreliable datagram QPs */
     Datagram,
     /* using connected QPs */
     Connected,
     Other(u16),
+    #[default]
     Unknown,
-}
-
-impl Default for IpoibMode {
-    fn default() -> Self {
-        IpoibMode::Unknown
-    }
 }
 
 impl From<u16> for IpoibMode {

--- a/src/lib/query/ipvlan.rs
+++ b/src/lib/query/ipvlan.rs
@@ -10,17 +10,13 @@ use crate::{Iface, IfaceType};
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
+#[derive(Default)]
 pub enum IpVlanMode {
     L2,
+    #[default]
     L3,
     L3S,
     Other(u16),
-}
-
-impl Default for IpVlanMode {
-    fn default() -> Self {
-        IpVlanMode::L3
-    }
 }
 
 impl From<rtnetlink::packet_route::link::IpVlanMode> for IpVlanMode {

--- a/src/lib/query/mac_vlan.rs
+++ b/src/lib/query/mac_vlan.rs
@@ -13,6 +13,7 @@ use crate::{
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
+#[derive(Default)]
 pub enum MacVlanMode {
     /* don't talk to other macvlans */
     Private,
@@ -26,13 +27,8 @@ pub enum MacVlanMode {
     /* use source MAC address list to assign */
     Source,
     Other(u32),
+    #[default]
     Unknown,
-}
-
-impl Default for MacVlanMode {
-    fn default() -> Self {
-        MacVlanMode::Unknown
-    }
 }
 
 impl From<rtnetlink::packet_route::link::MacVlanMode> for MacVlanMode {

--- a/src/lib/query/mac_vtap.rs
+++ b/src/lib/query/mac_vtap.rs
@@ -9,6 +9,7 @@ use crate::{MacVlanInfo, MacVlanMode, NisporError};
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
+#[derive(Default)]
 pub enum MacVtapMode {
     /* don't talk to other macvlans */
     Private,
@@ -22,13 +23,8 @@ pub enum MacVtapMode {
     /* use source MAC address list to assign */
     Source,
     Other(u32),
+    #[default]
     Unknown,
-}
-
-impl Default for MacVtapMode {
-    fn default() -> Self {
-        MacVtapMode::Unknown
-    }
 }
 
 impl From<MacVlanMode> for MacVtapMode {

--- a/src/lib/query/macsec.rs
+++ b/src/lib/query/macsec.rs
@@ -23,18 +23,14 @@ const MACSEC_DEFAULT_CIPHER_ID: u64 = 0x0080020001000001;
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
+#[derive(Default)]
 pub enum MacSecValidate {
     Disabled,
     Check,
     Strict,
     Other(u8),
+    #[default]
     Unknown,
-}
-
-impl Default for MacSecValidate {
-    fn default() -> Self {
-        MacSecValidate::Unknown
-    }
 }
 
 impl From<u8> for MacSecValidate {
@@ -51,18 +47,14 @@ impl From<u8> for MacSecValidate {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
+#[derive(Default)]
 pub enum MacSecOffload {
     Off,
     Phy,
     Mac,
     Other(u8),
+    #[default]
     Unknown,
-}
-
-impl Default for MacSecOffload {
-    fn default() -> Self {
-        MacSecOffload::Unknown
-    }
 }
 
 impl From<u8> for MacSecOffload {
@@ -79,18 +71,14 @@ impl From<u8> for MacSecOffload {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
+#[derive(Default)]
 pub enum MacSecCipherId {
+    #[default]
     GcmAes128,
     GcmAes256,
     GcmAesXpn128,
     GcmAesXpn256,
     Other(u64),
-}
-
-impl Default for MacSecCipherId {
-    fn default() -> Self {
-        MacSecCipherId::GcmAes128
-    }
 }
 
 impl From<u64> for MacSecCipherId {

--- a/src/lib/query/tun.rs
+++ b/src/lib/query/tun.rs
@@ -43,16 +43,12 @@ pub struct TunInfo {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
+#[derive(Default)]
 pub enum TunMode {
     Tun,
     Tap,
+    #[default]
     Unknown,
-}
-
-impl Default for TunMode {
-    fn default() -> Self {
-        TunMode::Unknown
-    }
 }
 
 impl From<u8> for TunMode {

--- a/src/python/nispor/__init__.py
+++ b/src/python/nispor/__init__.py
@@ -20,4 +20,13 @@ from .veth import NisporVeth
 from .vlan import NisporVlan
 from .vxlan import NisporVxlan
 
+
+import warnings
+
+warnings.warn(
+    "the nispor module is deprecated, please use nmstate instead",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 __all__ = []


### PR DESCRIPTION
The C and python binding is not used by nmstate anymore and not maintained for
recent year. Hence deprecate both.