### PR TITLE
ipv4: Fix forwarding querying without IP address

### DIFF
--- a/src/lib/integ_tests/ip.rs
+++ b/src/lib/integ_tests/ip.rs
@@ -149,7 +149,10 @@ fn test_add_and_remove_ip() {
         let iface = &state.ifaces[IFACE_NAME];
         let iface_type = &iface.iface_type;
         assert_eq!(iface_type, &crate::IfaceType::Veth);
-        assert_eq!(iface.ipv4, None);
+        assert_eq!(
+            iface.ipv4.as_ref().map(|i| i.addresses.is_empty()),
+            Some(true)
+        );
         assert_value_match(EXPECTED_EMPTY_IPV6_INFO, &iface.ipv6);
     });
 }
@@ -172,7 +175,10 @@ fn test_add_and_remove_dynamic_ip() {
         let iface = &state.ifaces[IFACE_NAME];
         let iface_type = &iface.iface_type;
         assert_eq!(iface_type, &crate::IfaceType::Veth);
-        assert_eq!(iface.ipv4, None);
+        assert_eq!(
+            iface.ipv4.as_ref().map(|i| i.addresses.is_empty()),
+            Some(true)
+        );
         assert_value_match(EXPECTED_EMPTY_IPV6_INFO, &iface.ipv6);
     });
 }

--- a/src/lib/netlink/ip.rs
+++ b/src/lib/netlink/ip.rs
@@ -5,8 +5,8 @@ use std::{collections::HashMap, net::IpAddr};
 use rtnetlink::packet_route::address::{AddressAttribute, AddressMessage};
 
 use crate::{
-    query::read_ipv4_forwarding, Iface, Ipv4AddrInfo, Ipv4Info, Ipv6AddrFlag,
-    Ipv6AddrInfo, Ipv6Info, NisporError,
+    Iface, Ipv4AddrInfo, Ipv4Info, Ipv6AddrFlag, Ipv6AddrInfo, Ipv6Info,
+    NisporError,
 };
 
 pub(crate) fn fill_ip_addr(
@@ -21,11 +21,7 @@ pub(crate) fn fill_ip_addr(
                 let iface_name = i.to_string();
                 if let Some(iface) = iface_states.get_mut(iface_name.as_str()) {
                     if iface.ipv4.is_none() {
-                        let forwarding = read_ipv4_forwarding(&iface.name);
-                        iface.ipv4 = Some(Ipv4Info {
-                            forwarding,
-                            ..Default::default()
-                        });
+                        iface.ipv4 = Some(Ipv4Info::default());
                     }
                     if let Some(ipv4_info) = iface.ipv4.as_mut() {
                         ipv4_info.addresses.push(addr);

--- a/src/lib/query/inter_ifaces.rs
+++ b/src/lib/query/inter_ifaces.rs
@@ -18,6 +18,7 @@ use super::{
         fill_bridge_vlan_info, parse_nl_msg_to_iface,
         parse_nl_msg_to_name_and_index,
     },
+    ip::fill_ip_forwarding,
     ipoib::ipoib_iface_tidy_up,
     ipvlan::ip_vlan_iface_tidy_up,
     mac_vlan::mac_vlan_iface_tidy_up,
@@ -84,6 +85,8 @@ pub(crate) async fn get_ifaces_with_handle(
         while let Some(nl_msg) = addrs.try_next().await? {
             fill_ip_addr(&mut iface_states, &nl_msg)?;
         }
+
+        fill_ip_forwarding(&mut iface_states);
     }
 
     if filter.include_bridge_vlan {

--- a/src/lib/query/ip.rs
+++ b/src/lib/query/ip.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
+    collections::HashMap,
     fs::File,
     io::{BufRead, BufReader},
     net::{IpAddr, Ipv6Addr},
@@ -121,7 +122,7 @@ pub(crate) fn fill_af_spec_inet_info(iface: &mut Iface, nlas: &[AfSpecUnspec]) {
     }
 }
 
-pub(crate) fn read_ipv4_forwarding(iface_name: &str) -> Option<bool> {
+fn read_ipv4_forwarding(iface_name: &str) -> Option<bool> {
     let path = format!("/proc/sys/net/ipv4/conf/{iface_name}/forwarding");
 
     let file = match File::open(&path) {
@@ -217,5 +218,14 @@ impl From<address::AddressFlags> for Ipv6AddrFlag {
             address::AddressFlags::StablePrivacy => Self::StablePrivacy,
             _ => Self::Other(d.bits()),
         }
+    }
+}
+
+pub(crate) fn fill_ip_forwarding(iface_states: &mut HashMap<String, Iface>) {
+    for (iface_name, iface_state) in iface_states.iter_mut() {
+        iface_state
+            .ipv4
+            .get_or_insert(Default::default())
+            .forwarding = read_ipv4_forwarding(iface_name);
     }
 }

--- a/src/lib/query/mod.rs
+++ b/src/lib/query/mod.rs
@@ -74,10 +74,7 @@ pub use self::{
 pub(crate) use self::{
     iface::resolve_iface_index,
     inter_ifaces::{get_iface_name2index, get_ifaces, get_ifaces_with_handle},
-    ip::{
-        is_ipv6_addr, parse_ip_addr_str, parse_ip_net_addr_str,
-        read_ipv4_forwarding,
-    },
+    ip::{is_ipv6_addr, parse_ip_addr_str, parse_ip_net_addr_str},
     mptcp::{get_mptcp, merge_mptcp_info},
     route::get_routes,
     route_rule::get_route_rules,


### PR DESCRIPTION
When interface does not have IP address, nispor will not setup Ipv4
forwarding status, this patch fix it by setting ipv4 forwarding
regardless holding IPv4 address or not.