### PR TITLE
hsr: add support for interlink attribute

### DIFF
--- a/src/lib/integ_tests/hsr.rs
+++ b/src/lib/integ_tests/hsr.rs
@@ -21,6 +21,18 @@ hsr:
   version: 0
   protocol: prp"#;
 
+const EXPECTED_HSR_INTERLINK_INFO: &str = r#"---
+name: hsr0
+iface_type: hsr
+hsr:
+  port1: eth1
+  port2: eth2
+  interlink: eth3
+  supervision_addr: 01:15:4e:00:01:2d
+  multicast_spec: 0
+  version: 0
+  protocol: hsr"#;
+
 #[test]
 fn test_get_hsr_iface_yaml() {
     with_hsr_iface(|| {
@@ -33,11 +45,38 @@ fn test_get_hsr_iface_yaml() {
     });
 }
 
+#[test]
+#[ignore]
+fn test_get_hsr_interlink_iface_yaml() {
+    with_hsr_interlink_iface(|| {
+        let state = NetState::retrieve().unwrap();
+        let iface = &state.ifaces[IFACE_NAME];
+
+        assert_eq!(iface.iface_type, crate::IfaceType::Hsr);
+
+        assert_value_match(EXPECTED_HSR_INTERLINK_INFO, iface);
+    });
+}
+
 fn with_hsr_iface<T>(test: T)
 where
     T: FnOnce() + panic::UnwindSafe,
 {
     super::utils::set_network_environment("hsr");
+
+    let result = panic::catch_unwind(|| {
+        test();
+    });
+
+    super::utils::clear_network_environment();
+    assert!(result.is_ok())
+}
+
+fn with_hsr_interlink_iface<T>(test: T)
+where
+    T: FnOnce() + panic::UnwindSafe,
+{
+    super::utils::set_network_environment("hsr_interlink");
 
     let result = panic::catch_unwind(|| {
         test();

--- a/src/lib/query/hsr.rs
+++ b/src/lib/query/hsr.rs
@@ -39,6 +39,7 @@ impl From<u8> for HsrProtocol {
 pub struct HsrInfo {
     pub port1: Option<String>,
     pub port2: Option<String>,
+    pub interlink: Option<String>,
     pub supervision_addr: String,
     pub seq_nr: u16,
     pub multicast_spec: u8,
@@ -48,6 +49,8 @@ pub struct HsrInfo {
     _port1_ifindex: u32,
     #[serde(skip_serializing)]
     _port2_ifindex: u32,
+    #[serde(skip_serializing)]
+    _interlink_ifindex: u32,
 }
 
 pub(crate) fn get_hsr_info(data: &InfoData) -> Option<HsrInfo> {
@@ -60,6 +63,9 @@ pub(crate) fn get_hsr_info(data: &InfoData) -> Option<HsrInfo> {
                 }
                 InfoHsr::Port2(d) => {
                     hsr_info._port2_ifindex = d;
+                }
+                InfoHsr::Interlink(d) => {
+                    hsr_info._interlink_ifindex = d;
                 }
                 InfoHsr::SupervisionAddr(d) => {
                     hsr_info.supervision_addr =
@@ -111,6 +117,11 @@ fn fill_port_iface_names(iface_states: &mut HashMap<String, Iface>) {
                 index_to_name.get(&hsr_info._port2_ifindex)
             {
                 hsr_info.port2 = Some(port2_iface_name.to_string());
+            }
+            if let Some(interlink_iface_name) =
+                index_to_name.get(&hsr_info._interlink_ifindex)
+            {
+                hsr_info.interlink = Some(interlink_iface_name.to_string());
             }
         }
     }

--- a/src/python/nispor/hsr.py
+++ b/src/python/nispor/hsr.py
@@ -17,6 +17,10 @@ class NisporHsr(NisporBaseIface):
         return self._hsr_info["port2"]
 
     @property
+    def interlink(self):
+        return self._hsr_info["interlink"]
+
+    @property
     def supervision_addr(self):
         return self._hsr_info["supervision_addr"]
 

--- a/src/python/nispor/hsr.py
+++ b/src/python/nispor/hsr.py
@@ -10,32 +10,32 @@ class NisporHsr(NisporBaseIface):
 
     @property
     def port1(self):
-        return self._hsr_info["port1"]
+        return self._hsr_info.get("port1")
 
     @property
     def port2(self):
-        return self._hsr_info["port2"]
+        return self._hsr_info.get("port2")
 
     @property
     def interlink(self):
-        return self._hsr_info["interlink"]
+        return self._hsr_info.get("interlink")
 
     @property
     def supervision_addr(self):
-        return self._hsr_info["supervision_addr"]
+        return self._hsr_info.get("supervision_addr")
 
     @property
     def seq_nr(self):
-        return self._hsr_info["seq_nr"]
+        return self._hsr_info.get("seq_nr")
 
     @property
     def multicast_spec(self):
-        return self._hsr_info["multicast_spec"]
+        return self._hsr_info.get("multicast_spec")
 
     @property
     def version(self):
-        return self._hsr_info["version"]
+        return self._hsr_info.get("version")
 
     @property
     def protocol(self):
-        return self._hsr_info["protocol"]
+        return self._hsr_info.get("protocol")

--- a/tools/test_env
+++ b/tools/test_env
@@ -32,6 +32,7 @@ function clean_up {
     sudo ip link del vxlan0
     sudo ip link del eth1
     sudo ip link del eth2
+    sudo ip link del eth3
     sudo ip link del vrf0
     sudo ip link del tun1
     sudo ip link del tun2
@@ -258,6 +259,20 @@ elif [ "CHK$1" == "CHKhsr" ];then
         supervision 45 proto 1
     sudo ip link set eth1 up
     sudo ip link set eth2 up
+    sudo ip link set hsr0 up
+    sleep $LINK_WAIT_TIME
+elif [ "CHK$1" == "CHKhsr_interlink" ];then
+    create_nics
+
+    sudo ip link add eth3 type veth peer name eth3.ep
+    sudo ip link set eth3 address $TEST_MAC3
+    sudo ip link set eth3.ep up
+
+    sudo ip link add name hsr0 type hsr slave1 eth1 slave2 eth2 \
+        supervision 45 interlink eth3
+    sudo ip link set eth1 up
+    sudo ip link set eth2 up
+    sudo ip link set eth3 up
     sudo ip link set hsr0 up
     sleep $LINK_WAIT_TIME
 elif [ "CHK$1" == "CHKxfrm" ];then


### PR DESCRIPTION
- not very easily testable, because `interlink` attribute is properly exposed only on  ~~linux-next branch, and is not in any released kernel yet~~ 6.19-rc1 or newer