### PR TITLE
vlan: Support applying VLAN options

### DIFF
--- a/src/lib/conf/vlan.rs
+++ b/src/lib/conf/vlan.rs
@@ -1,16 +1,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use rtnetlink::{Handle, LinkMessageBuilder, LinkVlan};
+use rtnetlink::{
+    packet_route::link::VlanFlags, Handle, LinkMessageBuilder, LinkVlan,
+};
 use serde::{Deserialize, Serialize};
 
 use super::super::query::resolve_iface_index;
-use crate::{ErrorKind, IfaceConf, NisporError};
+use crate::{ErrorKind, IfaceConf, NisporError, VlanProtocol, VlanQosMapping};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct VlanConf {
     pub vlan_id: u16,
     pub base_iface: String,
+    pub protocol: Option<VlanProtocol>,
+    pub is_reorder_hdr: Option<bool>,
+    pub is_gvrp: Option<bool>,
+    pub is_loose_binding: Option<bool>,
+    pub is_mvrp: Option<bool>,
+    pub is_bridge_binding: Option<bool>,
+    pub ingress_qos_map: Vec<VlanQosMapping>,
+    pub egress_qos_map: Vec<VlanQosMapping>,
 }
 
 impl VlanConf {
@@ -21,11 +31,41 @@ impl VlanConf {
         if let Some(vlan_conf) = iface.vlan.as_ref() {
             let parent_index =
                 resolve_iface_index(handle, &vlan_conf.base_iface).await?;
-            Ok(LinkVlan::new(
+            let mut builder = LinkVlan::new(
                 iface.name.as_str(),
                 parent_index,
                 vlan_conf.vlan_id,
-            ))
+            );
+            if let Some(protocol) = vlan_conf.protocol {
+                builder = builder.protocol(protocol.into());
+            }
+            let mut flags = VlanFlags::empty();
+            let mut flags_mask = VlanFlags::empty();
+
+            let mut set_flag = |v, flag| {
+                if let Some(val) = v {
+                    flags_mask |= flag;
+                    if val {
+                        flags |= flag;
+                    }
+                }
+            };
+            set_flag(vlan_conf.is_reorder_hdr, VlanFlags::ReorderHdr);
+            set_flag(vlan_conf.is_gvrp, VlanFlags::Gvrp);
+            set_flag(vlan_conf.is_loose_binding, VlanFlags::LooseBinding);
+            set_flag(vlan_conf.is_mvrp, VlanFlags::Mvrp);
+            set_flag(vlan_conf.is_bridge_binding, VlanFlags::BridgeBinding);
+
+            if flags_mask != VlanFlags::empty() {
+                builder = builder.flags(flags, flags_mask);
+            }
+
+            builder = builder.qos(
+                vlan_conf.ingress_qos_map.iter().map(|m| m.into()),
+                vlan_conf.egress_qos_map.iter().map(|m| m.into()),
+            );
+
+            Ok(builder)
         } else {
             Err(NisporError::new(
                 ErrorKind::NisporBug,

--- a/src/lib/integ_tests/vlan.rs
+++ b/src/lib/integ_tests/vlan.rs
@@ -7,17 +7,58 @@ use pretty_assertions::assert_eq;
 use super::utils::assert_value_match;
 use crate::{NetConf, NetState};
 
-const IFACE_NAME: &str = "eth1.101";
+const IFACE_NAME: &str = "dummy1.99";
+
+const VLAN_CREATE_FULL_INFO_YAML: &str = r#"
+ifaces:
+  - name: dummy1
+    type: dummy
+  - name: dummy1.99
+    type: vlan
+    vlan:
+      base_iface: dummy1
+      vlan_id: 99
+      protocol: 802.1q
+      is_reorder_hdr: true
+      is_gvrp: true
+      is_loose_binding: true
+      is_mvrp: true
+      is_bridge_binding: true
+      ingress_qos_map:
+      - from: 2
+        to: 9
+      - from: 3
+        to: 8
+      - from: 4
+        to: 7
+      egress_qos_map:
+      - from: 7
+        to: 4
+      - from: 8
+        to: 3
+      - from: 9
+        to: 2
+"#;
+
+const VLAN_DELETE_YML: &str = r#"---
+ifaces:
+  - name: dummy1.99
+    type: vlan
+    state: absent
+  - name: dummy1
+    type: dummy
+    state: absent
+"#;
 
 const EXPECTED_VLAN_INFO: &str = r#"---
-vlan_id: 101
+vlan_id: 99
 protocol: 802.1q
-base_iface: eth1
+base_iface: dummy1
 is_reorder_hdr: true
-is_gvrp: false
-is_loose_binding: false
-is_mvrp: false
-is_bridge_binding: false
+is_gvrp: true
+is_loose_binding: true
+is_mvrp: true
+is_bridge_binding: true
 ingress_qos_map:
 - from: 2
   to: 9
@@ -35,7 +76,7 @@ egress_qos_map:
 "#;
 
 #[test]
-fn test_get_vlan_iface_yaml() {
+fn test_create_and_delete_vlan() {
     with_vlan_iface(|| {
         let state = NetState::retrieve().unwrap();
         let iface = &state.ifaces[IFACE_NAME];
@@ -48,63 +89,16 @@ fn with_vlan_iface<T>(test: T)
 where
     T: FnOnce() + panic::UnwindSafe,
 {
-    super::utils::set_network_environment("vlan");
+    let net_conf: NetConf =
+        serde_yaml::from_str(VLAN_CREATE_FULL_INFO_YAML).unwrap();
+    net_conf.apply().unwrap();
 
     let result = panic::catch_unwind(|| {
         test();
     });
 
-    super::utils::clear_network_environment();
-    assert!(result.is_ok())
-}
-
-const VETH_CREATE_YML: &str = r#"---
-ifaces:
-  - name: veth1
-    type: veth
-    veth:
-      peer: veth1.ep
-  - name: veth1.ep
-    type: veth"#;
-
-const VETH_DELETE_YML: &str = r#"---
-ifaces:
-  - name: veth1
-    type: veth
-    state: absent"#;
-
-const VLAN_CREATE_YML: &str = r#"---
-ifaces:
-  - name: veth1.99
-    type: vlan
-    vlan:
-      base_iface: veth1
-      vlan_id: 99"#;
-
-const VLAN_DELETE_YML: &str = r#"---
-ifaces:
-  - name: veth1.99
-    type: vlan
-    state: absent"#;
-
-#[test]
-fn test_create_delete_vlan() {
-    let net_conf: NetConf = serde_yaml::from_str(VETH_CREATE_YML).unwrap();
-    net_conf.apply().unwrap();
-
-    let net_conf: NetConf = serde_yaml::from_str(VLAN_CREATE_YML).unwrap();
-    net_conf.apply().unwrap();
-    let state = NetState::retrieve().unwrap();
-    let iface = &state.ifaces["veth1.99"];
-    assert_eq!(&iface.iface_type, &crate::IfaceType::Vlan);
-    assert_eq!(iface.vlan.as_ref().unwrap().vlan_id, 99);
-    assert_eq!(iface.vlan.as_ref().unwrap().base_iface.as_str(), "veth1");
-
     let net_conf: NetConf = serde_yaml::from_str(VLAN_DELETE_YML).unwrap();
     net_conf.apply().unwrap();
-    let state = NetState::retrieve().unwrap();
-    assert_eq!(None, state.ifaces.get("veth1.99"));
 
-    let net_conf: NetConf = serde_yaml::from_str(VETH_DELETE_YML).unwrap();
-    net_conf.apply().unwrap();
+    assert!(result.is_ok())
 }

--- a/src/lib/query/vlan.rs
+++ b/src/lib/query/vlan.rs
@@ -31,6 +31,21 @@ impl From<link::VlanProtocol> for VlanProtocol {
     }
 }
 
+impl From<VlanProtocol> for link::VlanProtocol {
+    fn from(v: VlanProtocol) -> Self {
+        match v {
+            VlanProtocol::Ieee8021Q => link::VlanProtocol::Ieee8021Q,
+            VlanProtocol::Ieee8021AD => link::VlanProtocol::Ieee8021Ad,
+            VlanProtocol::Unknown => {
+                log::warn!(
+                    "Unknown vlan protocol {v:?}, treating it as 802.1q"
+                );
+                link::VlanProtocol::Ieee8021Q
+            }
+        }
+    }
+}
+
 #[derive(
     Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy, Default,
 )]
@@ -40,15 +55,20 @@ pub struct VlanQosMapping {
 }
 
 impl VlanQosMapping {
-    fn from_netlink(
-        map: &rtnetlink::packet_route::link::VlanQosMapping,
-    ) -> Option<Self> {
-        if let rtnetlink::packet_route::link::VlanQosMapping::Mapping(f, t) =
-            map
-        {
+    fn from_netlink(map: &link::VlanQosMapping) -> Option<Self> {
+        if let link::VlanQosMapping::Mapping(f, t) = map {
             Some(Self { from: *f, to: *t })
         } else {
             None
+        }
+    }
+}
+
+impl From<&VlanQosMapping> for rtnetlink::QosMapping {
+    fn from(v: &VlanQosMapping) -> Self {
+        Self {
+            from: v.from,
+            to: v.to,
         }
     }
 }


### PR DESCRIPTION
Support changing all the VLAN options supported by query:
 * `protocol`
 * `is_reorder_hdr`
 * `is_gvrp`
 * `is_loose_binding`
 * `is_mvrp`
 * `is_bridge_binding`
 * `ingress_qos_map`
 * `egress_qos_map`

Integration test case updated.