### PR TITLE
cargo, vlan: update rtnetlink to 0.19.0 and use new VlanFlags API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ futures = "0.3.21"
 libc = "0.2.155"
 log = "0.4.17"
 mptcp-pm = "0.1.4"
-rtnetlink = "0.18.1"
+rtnetlink = "0.19.0"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 serde_yaml = "0.9"

--- a/src/lib/query/vlan.rs
+++ b/src/lib/query/vlan.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use rtnetlink::packet_route::link::{self, InfoData, InfoVlan};
+use rtnetlink::packet_route::link::{self, InfoData, InfoVlan, VlanFlags};
 use serde::{Deserialize, Serialize};
 
 use crate::{Iface, IfaceType};
@@ -30,12 +30,6 @@ impl From<link::VlanProtocol> for VlanProtocol {
         }
     }
 }
-
-const VLAN_FLAG_REORDER_HDR: u32 = 0x1;
-const VLAN_FLAG_GVRP: u32 = 0x2;
-const VLAN_FLAG_LOOSE_BINDING: u32 = 0x4;
-const VLAN_FLAG_MVRP: u32 = 0x8;
-const VLAN_FLAG_BRIDGE_BINDING: u32 = 0x10;
 
 #[derive(
     Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy, Default,
@@ -88,21 +82,14 @@ pub(crate) fn get_vlan_info(data: &InfoData) -> Option<VlanInfo> {
                 vlan_info.protocol = (*d).into();
             } else if let InfoVlan::Flags((flags, _)) = info {
                 // The kernel always set the mask as u32::MAX
-                if *flags & VLAN_FLAG_REORDER_HDR > 0 {
-                    vlan_info.is_reorder_hdr = true
-                }
-                if *flags & VLAN_FLAG_GVRP > 0 {
-                    vlan_info.is_gvrp = true
-                }
-                if *flags & VLAN_FLAG_LOOSE_BINDING > 0 {
-                    vlan_info.is_loose_binding = true
-                }
-                if *flags & VLAN_FLAG_MVRP > 0 {
-                    vlan_info.is_mvrp = true
-                }
-                if *flags & VLAN_FLAG_BRIDGE_BINDING > 0 {
-                    vlan_info.is_bridge_binding = true
-                }
+                vlan_info.is_reorder_hdr =
+                    flags.contains(VlanFlags::ReorderHdr);
+                vlan_info.is_gvrp = flags.contains(VlanFlags::Gvrp);
+                vlan_info.is_loose_binding =
+                    flags.contains(VlanFlags::LooseBinding);
+                vlan_info.is_mvrp = flags.contains(VlanFlags::Mvrp);
+                vlan_info.is_bridge_binding =
+                    flags.contains(VlanFlags::BridgeBinding);
             } else if let InfoVlan::EgressQos(maps) = info {
                 vlan_info.egress_qos_map = maps
                     .as_slice()


### PR DESCRIPTION
Fixes compilation errors after rtnetlink update.