### PR TITLE
Support more bond options

### DIFF
--- a/src/lib/conf/bond.rs
+++ b/src/lib/conf/bond.rs
@@ -1,24 +1,199 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::net::{Ipv4Addr, Ipv6Addr};
+
 use rtnetlink::{LinkBond, LinkMessageBuilder};
 use serde::{Deserialize, Serialize};
 
-use crate::{BondMode, IfaceConf};
+use crate::{
+    mac::{mac_str_to_raw, ETH_ALEN},
+    query::resolve_iface_index,
+    BondAdSelect, BondAllSubordinatesActive, BondArpValidate, BondFailOverMac,
+    BondLacpRate, BondMode, BondModeArpAllTargets, BondPrimaryReselect,
+    BondXmitHashPolicy, ErrorKind, IfaceConf, NisporError,
+};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
 pub struct BondConf {
     pub mode: Option<BondMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub miimon: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updelay: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub downdelay: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub use_carrier: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arp_interval: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arp_ip_target: Option<Vec<Ipv4Addr>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arp_all_targets: Option<BondModeArpAllTargets>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arp_validate: Option<BondArpValidate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub primary: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub primary_reselect: Option<BondPrimaryReselect>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fail_over_mac: Option<BondFailOverMac>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub xmit_hash_policy: Option<BondXmitHashPolicy>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resend_igmp: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none", alias = "num_grat_arp")]
+    pub num_unsol_na: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub all_subordinates_active: Option<BondAllSubordinatesActive>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_links: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lp_interval: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub packets_per_subordinate: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lacp_rate: Option<BondLacpRate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ad_select: Option<BondAdSelect>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ad_actor_sys_prio: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ad_user_port_key: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ad_actor_system: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tlb_dynamic_lb: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peer_notif_delay: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lacp_active: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arp_missed_max: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ns_ip6_target: Option<Vec<Ipv6Addr>>,
 }
 
 impl BondConf {
-    pub(crate) fn gen_link_msg_builder(
+    pub(crate) async fn gen_link_msg_builder(
+        handle: &rtnetlink::Handle,
         iface: &IfaceConf,
-    ) -> LinkMessageBuilder<LinkBond> {
+    ) -> Result<LinkMessageBuilder<LinkBond>, NisporError> {
         let mut builder = LinkBond::new(iface.name.as_str());
-        if let Some(bond_mode) = iface.bond.as_ref().and_then(|b| b.mode) {
-            builder = builder.mode(bond_mode.into());
+        if let Some(bond_conf) = iface.bond.as_ref() {
+            if let Some(bond_mode) = bond_conf.mode {
+                builder = builder.mode(bond_mode.into());
+            }
+            if let Some(v) = bond_conf.miimon {
+                builder = builder.miimon(v);
+            }
+            if let Some(v) = bond_conf.updelay {
+                builder = builder.updelay(v);
+            }
+            if let Some(v) = bond_conf.downdelay {
+                builder = builder.downdelay(v);
+            }
+            if let Some(v) = bond_conf.use_carrier {
+                builder = builder.use_carrier(v.into());
+            }
+            if let Some(v) = bond_conf.arp_interval {
+                builder = builder.arp_interval(v);
+            }
+            if let Some(v) = bond_conf.arp_ip_target.as_ref() {
+                builder = builder.arp_ip_target(v.to_vec());
+            }
+            if let Some(v) = bond_conf.arp_all_targets {
+                builder = builder.arp_all_targets(v.into());
+            }
+            if let Some(v) = bond_conf.arp_validate {
+                builder = builder.arp_validate(v.into());
+            }
+            if let Some(v) = bond_conf.primary.as_deref() {
+                builder =
+                    builder.primary(resolve_iface_index(handle, v).await?);
+            }
+            if let Some(v) = bond_conf.primary_reselect {
+                builder = builder.primary_reselect(v.into());
+            }
+            if let Some(v) = bond_conf.fail_over_mac {
+                builder = builder.fail_over_mac(v.into());
+            }
+            if let Some(v) = bond_conf.xmit_hash_policy {
+                builder = builder.xmit_hash_policy(v.into());
+            }
+            if let Some(v) = bond_conf.resend_igmp {
+                builder = builder.resend_igmp(v);
+            }
+            if let Some(v) = bond_conf.num_unsol_na {
+                builder = builder.num_peer_notif(v);
+            }
+            if let Some(v) = bond_conf.all_subordinates_active {
+                builder = builder.all_ports_active(u8::from(v));
+            }
+            if let Some(v) = bond_conf.min_links {
+                builder = builder.min_links(v);
+            }
+            if let Some(v) = bond_conf.lp_interval {
+                builder = builder.lp_interval(v);
+            }
+            if let Some(v) = bond_conf.packets_per_subordinate {
+                builder = builder.packets_per_port(v);
+            }
+            if let Some(v) = bond_conf.lacp_rate {
+                builder = builder.ad_lacp_rate(v.into());
+            }
+            if let Some(v) = bond_conf.ad_select {
+                builder = builder.ad_select(v.into());
+            }
+            if let Some(v) = bond_conf.ad_actor_sys_prio {
+                builder = builder.ad_actor_sys_prio(v);
+            }
+            if let Some(v) = bond_conf.ad_user_port_key {
+                builder = builder.ad_user_port_key(v);
+            }
+            if let Some(v) = bond_conf.ad_actor_system.as_deref() {
+                let mac = mac_str_to_raw(v)?;
+                if mac.len() == ETH_ALEN {
+                    builder = builder.ad_actor_system(mac.try_into().map_err(
+                        |e| {
+                            NisporError::new(
+                                ErrorKind::InvalidArgument,
+                                format!(
+                                    "Invalid bond ad_actor_system: {:?}",
+                                    e
+                                ),
+                            )
+                        },
+                    )?);
+                } else {
+                    return Err(NisporError::new(
+                        ErrorKind::InvalidArgument,
+                        format!(
+                            "Invalid mac address length for bond \
+                             ad_actor_system {v}, should be like \
+                             01:23:45:67:89:ab"
+                        ),
+                    ));
+                }
+            }
+            if let Some(v) = bond_conf.tlb_dynamic_lb {
+                builder = builder.tlb_dynamic_lb(v.into());
+            }
+            if let Some(v) = bond_conf.peer_notif_delay {
+                builder = builder.peer_notif_delay(v);
+            }
+            if let Some(v) = bond_conf.lacp_active {
+                builder = builder.ad_lacp_active(v.into());
+            }
+            if let Some(v) = bond_conf.arp_missed_max {
+                builder = builder.missed_max(v);
+            }
+            if let Some(v) = bond_conf.ns_ip6_target.as_ref() {
+                builder = builder.ns_ip6_target(v.to_vec());
+            }
         }
-        builder
+
+        Ok(builder)
     }
 }

--- a/src/lib/conf/iface.rs
+++ b/src/lib/conf/iface.rs
@@ -122,7 +122,7 @@ async fn gen_link_msg(
         Some(IfaceType::Bond) => {
             apply_base_link_changes(
                 handle,
-                BondConf::gen_link_msg_builder(des_iface),
+                BondConf::gen_link_msg_builder(handle, des_iface).await?,
                 des_iface,
                 cur_iface,
             )

--- a/src/lib/integ_tests/bond.rs
+++ b/src/lib/integ_tests/bond.rs
@@ -5,23 +5,23 @@ use std::panic;
 use pretty_assertions::assert_eq;
 
 use super::utils::assert_value_match;
-use crate::{BondMode, NetConf, NetState};
+use crate::{NetConf, NetState};
 
 const IFACE_NAME: &str = "bond99";
-const PORT1_NAME: &str = "eth1";
-const PORT2_NAME: &str = "eth2";
+const PORT1_NAME: &str = "dummy1";
+const PORT2_NAME: &str = "dummy2";
 
 const EXPECTED_BOND_IFACE: &str = r#"---
 name: bond99
 iface_type: bond
 bond:
   subordinates:
-  - eth1
-  - eth2
-  mode: balance-rr
-  miimon: 0
-  updelay: 0
-  downdelay: 0
+  - dummy1
+  - dummy2
+  mode: active-backup
+  miimon: 30
+  updelay: 60
+  downdelay: 90
   use_carrier: true
   arp_interval: 0
   arp_all_targets: any
@@ -31,7 +31,6 @@ bond:
   all_subordinates_active: dropped
   min_links: 0
   lp_interval: 1
-  packets_per_subordinate: 1
   peer_notif_delay: 0
   "#;
 
@@ -43,20 +42,96 @@ perm_hwaddr: "00:23:45:67:89:1a"
 queue_id: 0"#;
 
 const EXPECTED_PORT2_INFO: &str = r#"---
-subordinate_state: active
+subordinate_state: backup
 mii_status: link_up
 link_failure_count: 0
 perm_hwaddr: "00:23:45:67:89:1b"
 queue_id: 0"#;
 
+const BOND_CREATE_YML: &str = r#"---
+interfaces:
+  - name: bond99
+    type: bond
+    bond:
+      mode: active-backup
+      miimon: 30
+      updelay: 60
+      downdelay: 90
+      use_carrier: true
+      arp_interval: 0
+      arp_all_targets: any
+      arp_validate: none
+      primary_reselect: always
+      resend_igmp: 1
+      all_subordinates_active: dropped
+      min_links: 0
+      lp_interval: 1
+      peer_notif_delay: 0
+  - name: dummy1
+    type: dummy
+    controller: bond99
+    mac-address: 00:23:45:67:89:1a
+  - name: dummy2
+    type: dummy
+    state: up
+    controller: bond99
+    mac-address: 00:23:45:67:89:1b"#;
+
+const BOND_PORT_REMOVE_YML: &str = r#"---
+interfaces:
+  - name: dummy1
+    type: dummy
+    controller: ""
+  - name: dummy2
+    type: dummy
+    controller: """#;
+
+const BOND_DELETE_YML: &str = r#"---
+interfaces:
+  - name: bond99
+    state: absent
+  - name: dummy1
+    state: absent
+  - name: dummy2
+    state: absent"#;
+
+const BOND_CHANGE_YML: &str = r#"---
+interfaces:
+  - name: bond99
+    type: bond
+    bond:
+      miimon: 0
+      arp_interval: 30
+"#;
+
+fn with_bond_iface<T>(test: T)
+where
+    T: FnOnce() + panic::UnwindSafe,
+{
+    let net_conf: NetConf = serde_yaml::from_str(BOND_CREATE_YML).unwrap();
+    net_conf.apply().unwrap();
+
+    // Wait miimon finish
+    std::thread::sleep(std::time::Duration::from_secs(1));
+
+    let result = panic::catch_unwind(|| {
+        test();
+    });
+
+    let net_conf: NetConf = serde_yaml::from_str(BOND_DELETE_YML).unwrap();
+    net_conf.apply().unwrap();
+    let state = NetState::retrieve().unwrap();
+    assert_eq!(None, state.ifaces.get(IFACE_NAME));
+    assert!(result.is_ok())
+}
+
 #[test]
-fn test_get_iface_bond_yaml() {
+fn test_create_delete_bond() {
     with_bond_iface(|| {
         let state = NetState::retrieve().unwrap();
         let iface = &state.ifaces[IFACE_NAME];
         let port1 = &state.ifaces[PORT1_NAME];
         let port2 = &state.ifaces[PORT2_NAME];
-
         assert_value_match(EXPECTED_BOND_IFACE, &iface);
 
         assert_value_match(EXPECTED_PORT1_INFO, &port1.bond_subordinate);
@@ -65,74 +140,29 @@ fn test_get_iface_bond_yaml() {
         assert_eq!(port2.controller, Some("bond99".to_string()));
         assert_eq!(port1.controller_type, Some(crate::ControllerType::Bond));
         assert_eq!(port2.controller_type, Some(crate::ControllerType::Bond));
+
+        let net_conf: NetConf =
+            serde_yaml::from_str(BOND_PORT_REMOVE_YML).unwrap();
+        net_conf.apply().unwrap();
+        let state = NetState::retrieve().unwrap();
+        let iface = &state.ifaces[IFACE_NAME];
+        assert_eq!(&iface.iface_type, &crate::IfaceType::Bond);
+        let empty_vec: Vec<String> = Vec::new();
+        assert_eq!(&iface.bond.as_ref().unwrap().subordinates, &empty_vec);
     });
 }
-
-fn with_bond_iface<T>(test: T)
-where
-    T: FnOnce() + panic::UnwindSafe,
-{
-    super::utils::set_network_environment("bond");
-
-    let result = panic::catch_unwind(|| {
-        test();
-    });
-
-    super::utils::clear_network_environment();
-    assert!(result.is_ok())
-}
-
-const BOND_CREATE_YML: &str = r#"---
-ifaces:
-  - name: bond99
-    type: bond
-    bond:
-      mode: active-backup
-  - name: veth1
-    type: veth
-    controller: bond99
-    veth:
-      peer: veth1.ep
-  - name: veth1.ep
-    type: veth
-    state: up"#;
-
-const BOND_PORT_REMOVE_YML: &str = r#"---
-ifaces:
-  - name: veth1
-    type: veth
-    controller: """#;
-
-const BOND_DELETE_YML: &str = r#"---
-ifaces:
-  - name: bond99
-    state: absent
-  - name: veth1
-    state: absent"#;
 
 #[test]
-fn test_create_delete_bond() {
-    let net_conf: NetConf = serde_yaml::from_str(BOND_CREATE_YML).unwrap();
-    net_conf.apply().unwrap();
-    let state = NetState::retrieve().unwrap();
-    let iface = &state.ifaces[IFACE_NAME];
-    assert_eq!(&iface.iface_type, &crate::IfaceType::Bond);
-    assert_eq!(
-        &iface.bond.as_ref().unwrap().subordinates,
-        &vec!["veth1".to_string()]
-    );
-    assert_eq!(&iface.bond.as_ref().unwrap().mode, &BondMode::ActiveBackup);
-
-    let net_conf: NetConf = serde_yaml::from_str(BOND_PORT_REMOVE_YML).unwrap();
-    net_conf.apply().unwrap();
-    let state = NetState::retrieve().unwrap();
-    let iface = &state.ifaces[IFACE_NAME];
-    assert_eq!(&iface.iface_type, &crate::IfaceType::Bond);
-    let empty_vec: Vec<String> = Vec::new();
-    assert_eq!(&iface.bond.as_ref().unwrap().subordinates, &empty_vec);
-
-    let net_conf: NetConf = serde_yaml::from_str(BOND_DELETE_YML).unwrap();
-    net_conf.apply().unwrap();
-    let state = NetState::retrieve().unwrap();
-    assert_eq!(None, state.ifaces.get(IFACE_NAME));
+fn test_change_bond_disable_miimon_enable_arp_interval() {
+    with_bond_iface(|| {
+        let net_conf: NetConf = serde_yaml::from_str(BOND_CHANGE_YML).unwrap();
+        net_conf.apply().unwrap();
+        let state = NetState::retrieve().unwrap();
+        let iface = &state.ifaces[IFACE_NAME];
+        assert_eq!(&iface.iface_type, &crate::IfaceType::Bond);
+        assert_eq!(iface.bond.as_ref().unwrap().miimon, Some(0));
+        assert_eq!(iface.bond.as_ref().unwrap().updelay, Some(0));
+        assert_eq!(iface.bond.as_ref().unwrap().downdelay, Some(0));
+        assert_eq!(iface.bond.as_ref().unwrap().arp_interval, Some(30));
+    })
 }

--- a/src/lib/query/bond.rs
+++ b/src/lib/query/bond.rs
@@ -7,7 +7,7 @@ use std::{
 
 use rtnetlink::packet_route::link::{
     self, BondArpAllTargets as RtBondArpAllTargets,
-    BondFailOverMac as RtBondFailOverMac,
+    BondArpValidate as RtBondArpValidate, BondFailOverMac as RtBondFailOverMac,
     BondPrimaryReselect as RtBondPrimaryReselect,
     BondXmitHashPolicy as RtBondXmitHashPolicy, InfoBond, InfoBondPort,
     InfoData,
@@ -123,7 +123,7 @@ impl std::fmt::Display for BondMode {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum BondModeArpAllTargets {
@@ -155,7 +155,17 @@ impl From<RtBondArpAllTargets> for BondModeArpAllTargets {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+impl From<BondModeArpAllTargets> for RtBondArpAllTargets {
+    fn from(v: BondModeArpAllTargets) -> Self {
+        match v {
+            BondModeArpAllTargets::Any => Self::Any,
+            BondModeArpAllTargets::All => Self::All,
+            BondModeArpAllTargets::Other(d) => Self::Other(d),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum BondArpValidate {
@@ -171,27 +181,32 @@ pub enum BondArpValidate {
     Other(u32),
 }
 
-impl From<rtnetlink::packet_route::link::BondArpValidate> for BondArpValidate {
-    fn from(d: rtnetlink::packet_route::link::BondArpValidate) -> Self {
+impl From<RtBondArpValidate> for BondArpValidate {
+    fn from(d: RtBondArpValidate) -> Self {
         match d {
-            rtnetlink::packet_route::link::BondArpValidate::None => Self::None,
-            rtnetlink::packet_route::link::BondArpValidate::Active => {
-                Self::Active
-            }
-            rtnetlink::packet_route::link::BondArpValidate::Backup => {
-                Self::Backup
-            }
-            rtnetlink::packet_route::link::BondArpValidate::All => Self::All,
-            rtnetlink::packet_route::link::BondArpValidate::Filter => {
-                Self::Filter
-            }
-            rtnetlink::packet_route::link::BondArpValidate::FilterActive => {
-                Self::FilterActive
-            }
-            rtnetlink::packet_route::link::BondArpValidate::FilterBackup => {
-                Self::FilterBackup
-            }
+            RtBondArpValidate::None => Self::None,
+            RtBondArpValidate::Active => Self::Active,
+            RtBondArpValidate::Backup => Self::Backup,
+            RtBondArpValidate::All => Self::All,
+            RtBondArpValidate::Filter => Self::Filter,
+            RtBondArpValidate::FilterActive => Self::FilterActive,
+            RtBondArpValidate::FilterBackup => Self::FilterBackup,
             _ => Self::Other(d.into()),
+        }
+    }
+}
+
+impl From<BondArpValidate> for RtBondArpValidate {
+    fn from(v: BondArpValidate) -> Self {
+        match v {
+            BondArpValidate::None => Self::None,
+            BondArpValidate::Active => Self::Active,
+            BondArpValidate::Backup => Self::Backup,
+            BondArpValidate::All => Self::All,
+            BondArpValidate::Filter => Self::Filter,
+            BondArpValidate::FilterActive => Self::FilterActive,
+            BondArpValidate::FilterBackup => Self::FilterBackup,
+            BondArpValidate::Other(d) => Self::Other(d),
         }
     }
 }
@@ -200,7 +215,7 @@ const BOND_PRI_RESELECT_ALWAYS: u8 = 0;
 const BOND_PRI_RESELECT_BETTER: u8 = 1;
 const BOND_PRI_RESELECT_FAILURE: u8 = 2;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum BondPrimaryReselect {
@@ -232,11 +247,22 @@ impl From<RtBondPrimaryReselect> for BondPrimaryReselect {
     }
 }
 
+impl From<BondPrimaryReselect> for RtBondPrimaryReselect {
+    fn from(v: BondPrimaryReselect) -> Self {
+        match v {
+            BondPrimaryReselect::Always => Self::Always,
+            BondPrimaryReselect::Better => Self::Better,
+            BondPrimaryReselect::Failure => Self::Failure,
+            BondPrimaryReselect::Other(d) => Self::Other(d),
+        }
+    }
+}
+
 const BOND_FOM_NONE: u8 = 0;
 const BOND_FOM_ACTIVE: u8 = 1;
 const BOND_FOM_FOLLOW: u8 = 2;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum BondFailOverMac {
@@ -268,6 +294,17 @@ impl From<RtBondFailOverMac> for BondFailOverMac {
     }
 }
 
+impl From<BondFailOverMac> for RtBondFailOverMac {
+    fn from(v: BondFailOverMac) -> Self {
+        match v {
+            BondFailOverMac::None => Self::None,
+            BondFailOverMac::Active => Self::Active,
+            BondFailOverMac::Follow => Self::Follow,
+            BondFailOverMac::Other(d) => Self::Other(d),
+        }
+    }
+}
+
 const BOND_XMIT_POLICY_LAYER2: u8 = 0;
 const BOND_XMIT_POLICY_LAYER34: u8 = 1;
 const BOND_XMIT_POLICY_LAYER23: u8 = 2;
@@ -275,7 +312,7 @@ const BOND_XMIT_POLICY_ENCAP23: u8 = 3;
 const BOND_XMIT_POLICY_ENCAP34: u8 = 4;
 const BOND_XMIT_POLICY_VLAN_SRCMAC: u8 = 5;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum BondXmitHashPolicy {
@@ -322,10 +359,24 @@ impl From<RtBondXmitHashPolicy> for BondXmitHashPolicy {
     }
 }
 
+impl From<BondXmitHashPolicy> for RtBondXmitHashPolicy {
+    fn from(v: BondXmitHashPolicy) -> Self {
+        match v {
+            BondXmitHashPolicy::Layer2 => Self::Layer2,
+            BondXmitHashPolicy::Layer34 => Self::Layer34,
+            BondXmitHashPolicy::Layer23 => Self::Layer23,
+            BondXmitHashPolicy::Encap23 => Self::Encap23,
+            BondXmitHashPolicy::Encap34 => Self::Encap34,
+            BondXmitHashPolicy::VlanSrcMac => Self::VlanSrcMac,
+            BondXmitHashPolicy::Other(d) => Self::Other(d),
+        }
+    }
+}
+
 const BOND_ALL_SUBORDINATES_ACTIVE_DROPPED: u8 = 0;
 const BOND_ALL_SUBORDINATES_ACTIVE_DELIEVERD: u8 = 1;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum BondAllSubordinatesActive {
@@ -344,10 +395,24 @@ impl From<u8> for BondAllSubordinatesActive {
     }
 }
 
+impl From<BondAllSubordinatesActive> for u8 {
+    fn from(v: BondAllSubordinatesActive) -> u8 {
+        match v {
+            BondAllSubordinatesActive::Dropped => {
+                BOND_ALL_SUBORDINATES_ACTIVE_DROPPED
+            }
+            BondAllSubordinatesActive::Delivered => {
+                BOND_ALL_SUBORDINATES_ACTIVE_DELIEVERD
+            }
+            BondAllSubordinatesActive::Other(d) => d,
+        }
+    }
+}
+
 const AD_LACP_SLOW: u8 = 0;
 const AD_LACP_FAST: u8 = 1;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum BondLacpRate {
@@ -366,11 +431,21 @@ impl From<u8> for BondLacpRate {
     }
 }
 
+impl From<BondLacpRate> for u8 {
+    fn from(v: BondLacpRate) -> u8 {
+        match v {
+            BondLacpRate::Slow => AD_LACP_SLOW,
+            BondLacpRate::Fast => AD_LACP_FAST,
+            BondLacpRate::Other(d) => d,
+        }
+    }
+}
+
 const BOND_AD_STABLE: u8 = 0;
 const BOND_AD_BANDWIDTH: u8 = 1;
 const BOND_AD_COUNT: u8 = 2;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum BondAdSelect {
@@ -387,6 +462,17 @@ impl From<u8> for BondAdSelect {
             BOND_AD_BANDWIDTH => Self::Bandwidth,
             BOND_AD_COUNT => Self::Count,
             _ => Self::Other(d),
+        }
+    }
+}
+
+impl From<BondAdSelect> for u8 {
+    fn from(v: BondAdSelect) -> u8 {
+        match v {
+            BondAdSelect::Stable => BOND_AD_STABLE,
+            BondAdSelect::Bandwidth => BOND_AD_BANDWIDTH,
+            BondAdSelect::Count => BOND_AD_COUNT,
+            BondAdSelect::Other(d) => d,
         }
     }
 }


### PR DESCRIPTION
Example YAML:

```yml
---
interfaces:
  - name: bond99
    type: bond
    bond:
      mode: active-backup
      miimon: 30
      updelay: 60
      downdelay: 90
      use_carrier: true
      arp_interval: 0
      arp_all_targets: any
      arp_validate: none
      primary_reselect: always
      resend_igmp: 1
      all_subordinates_active: dropped
      min_links: 0
      lp_interval: 1
      peer_notif_delay: 0
  - name: dummy1
    type: dummy
    controller: bond99
    mac-address: 00:23:45:67:89:1a
  - name: dummy2
    type: dummy
    state: up
    mac-address: 00:23:45:67:89:1b
```

Integration test cases included.