### PR TITLE
bond: Support changing bond mode

### DIFF
--- a/src/lib/conf/base_iface.rs
+++ b/src/lib/conf/base_iface.rs
@@ -5,7 +5,7 @@ use rtnetlink::{
 };
 
 use super::super::{mac::mac_str_to_raw, query::resolve_iface_index};
-use crate::{ErrorKind, Iface, IfaceConf, IfaceState, NisporError};
+use crate::{Iface, IfaceConf, IfaceFlag, IfaceState, NisporError};
 
 pub(crate) async fn apply_base_link_changes<T>(
     handle: &rtnetlink::Handle,
@@ -15,17 +15,15 @@ pub(crate) async fn apply_base_link_changes<T>(
 ) -> Result<Vec<LinkMessage>, NisporError> {
     let mut ret: Vec<LinkMessage> = Vec::new();
 
-    // We cannot bring interface up when changing controller, hence
-    // we need to bring interface up after controller changed.
-    let mut is_changing_ctrller = false;
-    let mut post_apply_msg: Option<LinkMessage> = None;
-
-    // Interface is created with DOWN state, so even current interface not
-    // exist yet, its current state should be DOWN.
-    let mut cur_iface_state = cur_iface
-        .as_ref()
-        .map(|c| c.state.clone())
-        .unwrap_or(IfaceState::Down);
+    if let Some(cur_iface) = cur_iface {
+        if des_iface.need_state_down_before_apply(cur_iface)
+            && cur_iface.flags.contains(&IfaceFlag::Up)
+        {
+            ret.push(
+                LinkUnspec::new_with_index(cur_iface.index).down().build(),
+            );
+        }
+    }
 
     if let Some(mtu) = des_iface.mtu {
         builder = builder.mtu(mtu);
@@ -33,21 +31,14 @@ pub(crate) async fn apply_base_link_changes<T>(
 
     if let Some(des_mac) = des_iface.mac_address.as_ref() {
         if !des_mac.is_empty() {
-            if let Some(cur_iface) = cur_iface.as_ref() {
-                if des_mac.to_uppercase()
-                    != cur_iface.mac_address.as_str().to_uppercase()
-                    && cur_iface_state != IfaceState::Down
-                {
-                    // Need to bring interface down to change the MAC
-                    ret.push(
-                        LinkUnspec::new_with_index(cur_iface.index)
-                            .down()
-                            .build(),
-                    );
-                    cur_iface_state = IfaceState::Down;
-                }
+            let should_set = cur_iface
+                .as_ref()
+                .map(|c| c.mac_address.to_uppercase() != des_mac.to_uppercase())
+                .unwrap_or(true);
+
+            if should_set {
+                builder = builder.address(mac_str_to_raw(des_mac)?);
             }
-            builder = builder.address(mac_str_to_raw(des_mac)?);
         }
     }
 
@@ -56,20 +47,15 @@ pub(crate) async fn apply_base_link_changes<T>(
             cur_iface.as_ref().and_then(|c| c.controller.as_ref())
         {
             if des_ctrl != cur_ctrl {
-                // Need to bring down interface for changing controller
-                if cur_iface_state != IfaceState::Down {
-                    ret.push(
-                        LinkUnspec::new_with_name(des_iface.name.as_str())
-                            .down()
-                            .build(),
-                    );
-                    cur_iface_state = IfaceState::Down;
+                if des_ctrl.is_empty() {
+                    builder = builder.nocontroller();
+                } else {
+                    let ctrl_index =
+                        resolve_iface_index(handle, des_ctrl).await?;
+                    builder = builder.controller(ctrl_index);
                 }
             }
-        }
-
-        is_changing_ctrller = true;
-        if des_ctrl.is_empty() {
+        } else if des_ctrl.is_empty() {
             builder = builder.nocontroller();
         } else {
             let ctrl_index = resolve_iface_index(handle, des_ctrl).await?;
@@ -77,39 +63,27 @@ pub(crate) async fn apply_base_link_changes<T>(
         }
     }
 
-    // When changing controller, we cannot make the interface as up yet.
-    if cur_iface_state != des_iface.state {
-        match &des_iface.state {
-            IfaceState::Up => {
-                if is_changing_ctrller {
-                    builder = builder.down();
-                    post_apply_msg = Some(
-                        LinkUnspec::new_with_name(des_iface.name.as_str())
-                            .up()
-                            .build(),
-                    );
-                } else {
-                    builder = builder.up();
-                }
-            }
-            IfaceState::Down => {
-                builder = builder.down();
-            }
-            state => {
-                return Err(NisporError::new(
-                    ErrorKind::Bug,
-                    format!(
-                        "apply_base_link_changes(): Invalid interface state \
-                         {state}"
-                    ),
-                ));
-            }
-        }
-    }
-
     ret.push(builder.build());
-    if let Some(msg) = post_apply_msg {
-        ret.push(msg)
+
+    // Many changes cannot done along with link up/down flag set(e.g.
+    // change controller, change bond mode), so we change interface state
+    // in a separate link message
+    match &des_iface.state {
+        IfaceState::Up => {
+            ret.push(
+                LinkUnspec::new_with_name(des_iface.name.as_str())
+                    .up()
+                    .build(),
+            );
+        }
+        IfaceState::Down => {
+            ret.push(
+                LinkUnspec::new_with_name(des_iface.name.as_str())
+                    .down()
+                    .build(),
+            );
+        }
+        _ => (),
     }
 
     Ok(ret)

--- a/src/lib/conf/bond.rs
+++ b/src/lib/conf/bond.rs
@@ -10,7 +10,7 @@ use crate::{
     query::resolve_iface_index,
     BondAdSelect, BondAllSubordinatesActive, BondArpValidate, BondFailOverMac,
     BondLacpRate, BondMode, BondModeArpAllTargets, BondPrimaryReselect,
-    BondXmitHashPolicy, ErrorKind, IfaceConf, NisporError,
+    BondXmitHashPolicy, ErrorKind, Iface, IfaceConf, NisporError,
 };
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
@@ -79,11 +79,19 @@ impl BondConf {
     pub(crate) async fn gen_link_msg_builder(
         handle: &rtnetlink::Handle,
         iface: &IfaceConf,
+        cur_iface: Option<&Iface>,
     ) -> Result<LinkMessageBuilder<LinkBond>, NisporError> {
         let mut builder = LinkBond::new(iface.name.as_str());
         if let Some(bond_conf) = iface.bond.as_ref() {
             if let Some(bond_mode) = bond_conf.mode {
-                builder = builder.mode(bond_mode.into());
+                let cur_bond_mode =
+                    cur_iface.and_then(|i| i.bond.as_ref()).map(|b| b.mode);
+
+                // Only include bond mode request when changing, otherwise
+                // kernel will reject us.
+                if Some(bond_mode) != cur_bond_mode {
+                    builder = builder.mode(bond_mode.into());
+                }
             }
             if let Some(v) = bond_conf.miimon {
                 builder = builder.miimon(v);

--- a/src/lib/conf/iface.rs
+++ b/src/lib/conf/iface.rs
@@ -40,6 +40,34 @@ pub struct IfaceConf {
     pub bond: Option<BondConf>,
 }
 
+impl IfaceConf {
+    /// Need interfaces to be down state for these changes:
+    ///  * Change MAC address
+    ///  * Change controller
+    ///  * Change bond mode
+    pub(crate) fn need_state_down_before_apply(&self, current: &Iface) -> bool {
+        if let Some(des_mac) = self.mac_address.as_ref() {
+            if des_mac.to_uppercase() != current.mac_address.to_uppercase() {
+                return true;
+            }
+        }
+
+        if self.controller.is_some() && self.controller != current.controller {
+            return true;
+        }
+
+        if let Some(des_bond_mode) = self.bond.as_ref().and_then(|b| b.mode) {
+            if let Some(cur_bond_mode) = current.bond.as_ref().map(|b| b.mode) {
+                if des_bond_mode != cur_bond_mode {
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+}
+
 fn default_iface_state_in_conf() -> IfaceState {
     IfaceState::Up
 }
@@ -122,7 +150,8 @@ async fn gen_link_msg(
         Some(IfaceType::Bond) => {
             apply_base_link_changes(
                 handle,
-                BondConf::gen_link_msg_builder(handle, des_iface).await?,
+                BondConf::gen_link_msg_builder(handle, des_iface, cur_iface)
+                    .await?,
                 des_iface,
                 cur_iface,
             )

--- a/src/lib/integ_tests/bond.rs
+++ b/src/lib/integ_tests/bond.rs
@@ -5,7 +5,7 @@ use std::panic;
 use pretty_assertions::assert_eq;
 
 use super::utils::assert_value_match;
-use crate::{NetConf, NetState};
+use crate::{BondMode, NetConf, NetState};
 
 const IFACE_NAME: &str = "bond99";
 const PORT1_NAME: &str = "dummy1";
@@ -164,5 +164,36 @@ fn test_change_bond_disable_miimon_enable_arp_interval() {
         assert_eq!(iface.bond.as_ref().unwrap().updelay, Some(0));
         assert_eq!(iface.bond.as_ref().unwrap().downdelay, Some(0));
         assert_eq!(iface.bond.as_ref().unwrap().arp_interval, Some(30));
+    })
+}
+
+const CHANGE_BOND_MODE_YAML: &str = r#"---
+interfaces:
+  - name: dummy1
+    state: up
+    controller: ""
+  - name: dummy2
+    state: up
+    controller: ""
+  - name: bond99
+    type: bond
+    state: up
+    bond:
+      mode: balance-rr"#;
+
+#[test]
+fn test_change_bond_mode() {
+    with_bond_iface(|| {
+        let net_conf: NetConf =
+            serde_yaml::from_str(CHANGE_BOND_MODE_YAML).unwrap();
+        net_conf.apply().unwrap();
+        let state = NetState::retrieve().unwrap();
+        let iface = &state.ifaces[IFACE_NAME];
+        assert_eq!(&iface.iface_type, &crate::IfaceType::Bond);
+        assert!(&iface.flags.contains(&crate::IfaceFlag::Up));
+        assert_eq!(
+            iface.bond.as_ref().unwrap().mode,
+            BondMode::BalanceRoundRobin
+        );
     })
 }


### PR DESCRIPTION
It is required to bring interface down before changing bond mode.

To achieve state, we move interface state change to dedicate netlink
message as the final netlink message.
With `IfaceConf::need_state_down_before_apply()` return true, we
bring interface down before making link layer changes.

Integration test case included.