### PR TITLE
Support changing bridge options

### DIFF
--- a/src/lib/conf/bridge.rs
+++ b/src/lib/conf/bridge.rs
@@ -3,16 +3,214 @@
 use rtnetlink::{LinkBridge, LinkMessageBuilder};
 use serde::{Deserialize, Serialize};
 
-use crate::IfaceConf;
+use crate::{
+    BridgeMulticastRouterType, BridgeStpState, IfaceConf, VlanProtocol,
+};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
-pub struct BridgeConf {}
+pub struct BridgeConf {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ageing_time: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group_fwd_mask: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group_address: Option<[u8; 6]>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub forward_delay: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hello_time: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_age: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stp_state: Option<BridgeStpState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mst_enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub no_linklocal_learn: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fdb_local_vlan_0: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fdb_max_learned: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vlan_filtering: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vlan_protocol: Option<VlanProtocol>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vlan_default_pvid: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vlan_stats_enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vlan_stats_per_port: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mcast_snooping: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mcast_vlan_snooping: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mcast_router: Option<BridgeMulticastRouterType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mcast_query_use_ifaddr: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mcast_querier: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mcast_hash_max: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mcast_last_member_count: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mcast_startup_query_count: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mcast_last_member_interval: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mcast_membership_interval: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mcast_querier_interval: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mcast_query_interval: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mcast_query_response_interval: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mcast_startup_query_interval: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mcast_stats_enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mcast_igmp_version: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mcast_mld_version: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nf_call_iptables: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nf_call_ip6tables: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nf_call_arptables: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mdb_offload_fail_notification: Option<bool>,
+}
 
 impl BridgeConf {
     pub(crate) fn gen_link_msg_builder(
         iface: &IfaceConf,
     ) -> LinkMessageBuilder<LinkBridge> {
-        LinkBridge::new(iface.name.as_str())
+        let mut builder = LinkBridge::new(iface.name.as_str());
+
+        if let Some(br_conf) = iface.bridge.as_ref() {
+            if let Some(v) = br_conf.ageing_time {
+                builder = builder.ageing_time(v);
+            }
+            if let Some(v) = br_conf.group_fwd_mask {
+                builder = builder.group_fwd_mask(v);
+            }
+            if let Some(v) = br_conf.group_address {
+                builder = builder.group_address(v);
+            }
+            if let Some(v) = br_conf.forward_delay {
+                builder = builder.forward_delay(v);
+            }
+            if let Some(v) = br_conf.hello_time {
+                builder = builder.hello_time(v);
+            }
+            if let Some(v) = br_conf.max_age {
+                builder = builder.max_age(v);
+            }
+            if let Some(v) = br_conf.stp_state.as_ref() {
+                builder = builder.stp_state(v.clone().into());
+            }
+            if let Some(v) = br_conf.mst_enabled {
+                builder = builder.mst_enabled(v);
+            }
+            if let Some(v) = br_conf.priority {
+                builder = builder.priority(v);
+            }
+            if let Some(v) = br_conf.no_linklocal_learn {
+                builder = builder.no_linklocal_learn(v);
+            }
+            if let Some(v) = br_conf.fdb_local_vlan_0 {
+                builder = builder.fdb_local_vlan_0(v);
+            }
+            if let Some(v) = br_conf.fdb_max_learned {
+                builder = builder.fdb_max_learned(v);
+            }
+            if let Some(v) = br_conf.vlan_filtering {
+                builder = builder.vlan_filtering(v);
+            }
+            if let Some(v) = br_conf.vlan_protocol {
+                builder = builder.vlan_protocol(v.into());
+            }
+            if let Some(v) = br_conf.vlan_default_pvid {
+                builder = builder.vlan_default_pvid(v);
+            }
+            if let Some(v) = br_conf.vlan_stats_enabled {
+                builder = builder.vlan_stats_enabled(v);
+            }
+            if let Some(v) = br_conf.vlan_stats_per_port {
+                builder = builder.vlan_stats_per_port(v);
+            }
+            if let Some(v) = br_conf.mcast_snooping {
+                builder = builder.mcast_snooping(v);
+            }
+            if let Some(v) = br_conf.mcast_vlan_snooping {
+                builder = builder.mcast_vlan_snooping(v);
+            }
+            if let Some(v) = br_conf.mcast_router.as_ref() {
+                builder = builder.mcast_router((*v).into());
+            }
+            if let Some(v) = br_conf.mcast_query_use_ifaddr {
+                builder = builder.mcast_query_use_ifaddr(v);
+            }
+            if let Some(v) = br_conf.mcast_querier {
+                builder = builder.mcast_querier(v);
+            }
+            if let Some(v) = br_conf.mcast_hash_max {
+                builder = builder.mcast_hash_max(v);
+            }
+            if let Some(v) = br_conf.mcast_last_member_count {
+                builder = builder.mcast_last_member_count(v);
+            }
+            if let Some(v) = br_conf.mcast_startup_query_count {
+                builder = builder.mcast_startup_query_count(v);
+            }
+            if let Some(v) = br_conf.mcast_last_member_interval {
+                builder = builder.mcast_last_member_interval(v);
+            }
+            if let Some(v) = br_conf.mcast_membership_interval {
+                builder = builder.mcast_membership_interval(v);
+            }
+            if let Some(v) = br_conf.mcast_querier_interval {
+                builder = builder.mcast_querier_interval(v);
+            }
+            if let Some(v) = br_conf.mcast_query_interval {
+                builder = builder.mcast_query_interval(v);
+            }
+            if let Some(v) = br_conf.mcast_query_response_interval {
+                builder = builder.mcast_query_response_interval(v);
+            }
+            if let Some(v) = br_conf.mcast_startup_query_interval {
+                builder = builder.mcast_startup_query_interval(v);
+            }
+            if let Some(v) = br_conf.mcast_stats_enabled {
+                builder = builder.mcast_stats_enabled(v);
+            }
+            if let Some(v) = br_conf.mcast_igmp_version {
+                builder = builder.mcast_igmp_version(v);
+            }
+            if let Some(v) = br_conf.mcast_mld_version {
+                builder = builder.mcast_mld_version(v);
+            }
+            if let Some(v) = br_conf.nf_call_iptables {
+                builder = builder.nf_call_iptables(v);
+            }
+            if let Some(v) = br_conf.nf_call_ip6tables {
+                builder = builder.nf_call_ip6tables(v);
+            }
+            if let Some(v) = br_conf.nf_call_arptables {
+                builder = builder.nf_call_arptables(v);
+            }
+            if let Some(v) = br_conf.mdb_offload_fail_notification {
+                builder = builder.mdb_offload_fail_notification(v);
+            }
+        }
+
+        builder
     }
 }

--- a/src/lib/integ_tests/bridge.rs
+++ b/src/lib/integ_tests/bridge.rs
@@ -5,11 +5,11 @@ use std::panic;
 use pretty_assertions::assert_eq;
 
 use super::utils::assert_value_match;
-use crate::{NetConf, NetState};
+use crate::{BridgeStpState, NetConf, NetState};
 
 const IFACE_NAME: &str = "br0";
-const PORT1_NAME: &str = "eth1";
-const PORT2_NAME: &str = "eth2";
+const PORT1_NAME: &str = "dummy1";
+const PORT2_NAME: &str = "dummy2";
 
 // On Archlinux where HZ == 300, these properties will be rounded up by
 // `jiffies_to_clock_t()` of kernel:
@@ -30,8 +30,8 @@ name: br0
 iface_type: bridge
 bridge:
   ports:
-    - eth1
-    - eth2
+    - dummy1
+    - dummy2
   bridge_id: 8000.00234567891c
   group_fwd_mask: 0
   root_id: 8000.00234567891c
@@ -51,7 +51,6 @@ bridge:
   vlan_stats_enabled: false
   vlan_stats_per_port: false
   stp_state: disabled
-  hello_timer: 0
   priority: 32768
   multicast_router: temp_query
   multicast_snooping: true
@@ -68,7 +67,7 @@ bridge:
 const EXPECTED_PORT1_BRIDGE_INFO: &str = r#"---
 stp_state: forwarding
 stp_priority: 32
-stp_path_cost: 2
+stp_path_cost: 100
 hairpin_mode: false
 bpdu_guard: false
 root_block: false
@@ -86,7 +85,6 @@ port_no: "0x1"
 change_ack: false
 config_pending: false
 message_age_timer: 0
-forward_delay_timer: 0
 hold_timer: 0
 multicast_router: temp_query
 multicast_flood: true
@@ -107,7 +105,7 @@ vlans:
 const EXPECTED_PORT2_BRIDGE_INFO: &str = r#"---
 stp_state: forwarding
 stp_priority: 32
-stp_path_cost: 2
+stp_path_cost: 100
 hairpin_mode: false
 bpdu_guard: false
 root_block: false
@@ -125,7 +123,6 @@ port_no: "0x2"
 change_ack: false
 config_pending: false
 message_age_timer: 0
-forward_delay_timer: 0
 hold_timer: 0
 multicast_router: temp_query
 multicast_flood: true
@@ -143,29 +140,55 @@ vlans:
     is_pvid: true
     is_egress_untagged: true"#;
 
-#[test]
-fn test_get_br_iface_yaml() {
-    with_br_iface(|| {
-        let mut state = NetState::retrieve().unwrap();
-        let iface = state.ifaces.get_mut(IFACE_NAME).unwrap();
-        if let Some(ref mut bridge_info) = iface.bridge {
-            bridge_info.gc_timer = None;
-            // Below value is different between CI and RHEL/CentOS 8
-            // https://blog.grisge.info/posts/br_on_250hz_kernel/
-            bridge_info.multicast_startup_query_interval = None;
-        }
-        let port1 = state.ifaces.get_mut(PORT1_NAME).unwrap();
-        if let Some(ref mut port_info) = port1.bridge_port {
-            port_info.forward_delay_timer = 0;
-            // Below values are not supported by Github CI Ubuntu 20.04
-            port_info.mrp_in_open = None;
-        }
-        let port2 = state.ifaces.get_mut(PORT2_NAME).unwrap();
-        if let Some(ref mut port_info) = port2.bridge_port {
-            port_info.forward_delay_timer = 0;
-            port_info.mrp_in_open = None;
-        }
+const BRIDGE_CREATE_YML: &str = r#"---
+interfaces:
+  - name: br0
+    type: bridge
+    mac-address: 00:23:45:67:89:1c
+    bridge:
+      stp-state: disabled
+  - name: dummy1
+    type: dummy
+    state: up
+    controller: br0
+  - name: dummy2
+    type: dummy
+    state: up
+    controller: br0
+    "#;
 
+const BRIDGE_DELETE_YML: &str = r#"---
+interfaces:
+  - name: br0
+    type: bridge
+    state: absent
+  - name: dummy1
+    type: dummy
+    state: absent
+  - name: dummy2
+    type: dummy
+    state: absent"#;
+
+fn with_br_iface<T>(test: T)
+where
+    T: FnOnce() + panic::UnwindSafe,
+{
+    let net_conf: NetConf = serde_yaml::from_str(BRIDGE_CREATE_YML).unwrap();
+    net_conf.apply().unwrap();
+
+    let result = panic::catch_unwind(|| {
+        test();
+    });
+
+    let net_conf: NetConf = serde_yaml::from_str(BRIDGE_DELETE_YML).unwrap();
+    net_conf.apply().unwrap();
+    assert!(result.is_ok())
+}
+
+#[test]
+fn test_create_delete_bridge() {
+    with_br_iface(|| {
+        let state = NetState::retrieve().unwrap();
         let iface = &state.ifaces[IFACE_NAME];
         let port1 = &state.ifaces[PORT1_NAME];
         let port2 = &state.ifaces[PORT2_NAME];
@@ -175,43 +198,31 @@ fn test_get_br_iface_yaml() {
         assert_value_match(EXPECTED_PORT1_BRIDGE_INFO, &port1.bridge_port);
         assert_value_match(EXPECTED_PORT2_BRIDGE_INFO, &port2.bridge_port);
     });
-}
-
-fn with_br_iface<T>(test: T)
-where
-    T: FnOnce() + panic::UnwindSafe,
-{
-    super::utils::set_network_environment("br");
-
-    let result = panic::catch_unwind(|| {
-        test();
-    });
-
-    super::utils::clear_network_environment();
-    assert!(result.is_ok())
-}
-
-const BRIDGE_CREATE_YML: &str = r#"---
-ifaces:
-  - name: br0
-    type: bridge"#;
-
-const BRIDGE_DELETE_YML: &str = r#"---
-ifaces:
-  - name: br0
-    type: bridge
-    state: absent"#;
-
-#[test]
-fn test_create_delete_bridge() {
-    let net_conf: NetConf = serde_yaml::from_str(BRIDGE_CREATE_YML).unwrap();
-    net_conf.apply().unwrap();
-    let state = NetState::retrieve().unwrap();
-    let iface = &state.ifaces[IFACE_NAME];
-    assert_eq!(&iface.iface_type, &crate::IfaceType::Bridge);
-
-    let net_conf: NetConf = serde_yaml::from_str(BRIDGE_DELETE_YML).unwrap();
-    net_conf.apply().unwrap();
     let state = NetState::retrieve().unwrap();
     assert_eq!(None, state.ifaces.get(IFACE_NAME));
+}
+
+#[test]
+fn test_bridge_change_stp_state() {
+    with_br_iface(|| {
+        let net_conf: NetConf = serde_yaml::from_str(
+            r#"---
+                interfaces:
+                - name: br0
+                  type: linux-bridge
+                  bridge:
+                    stp_state: kernel_stp
+                "#,
+        )
+        .unwrap();
+        net_conf.apply().unwrap();
+        let state = NetState::retrieve().unwrap();
+        let iface = &state.ifaces[IFACE_NAME];
+        assert_eq!(iface.iface_type, crate::IfaceType::Bridge);
+
+        assert_eq!(
+            iface.bridge.as_ref().and_then(|b| b.stp_state.as_ref()),
+            Some(&BridgeStpState::KernelStp)
+        );
+    });
 }

--- a/src/lib/query/iface.rs
+++ b/src/lib/query/iface.rs
@@ -44,6 +44,7 @@ use crate::{
 pub enum IfaceType {
     Bond,
     Veth,
+    #[serde(alias = "linux-bridge")]
     Bridge,
     Vlan,
     Dummy,


### PR DESCRIPTION
Support changing these bridge options:

 * `ageing_time`
 * `group_fwd_mask`
 * `group_address`
 * `forward_delay`
 * `hello_time`
 * `max_age`
 * `stp_state`
 * `mst_enabled`
 * `priority`
 * `no_linklocal_learn`
 * `fdb_local_vlan_0`
 * `fdb_max_learned`
 * `vlan_filtering`
 * `vlan_protocol`
 * `vlan_default_pvid`
 * `vlan_stats_enabled`
 * `vlan_stats_per_port`
 * `mcast_snooping`
 * `mcast_vlan_snooping`
 * `mcast_router`
 * `mcast_query_use_ifaddr`
 * `mcast_querier`
 * `mcast_hash_elasticity`
 * `mcast_hash_max`
 * `mcast_last_member_count`
 * `mcast_startup_query_count`
 * `mcast_last_member_interval`
 * `mcast_membership_interval`
 * `mcast_querier_interval`
 * `mcast_query_interval`
 * `mcast_query_response_interval`
 * `mcast_startup_query_interval`
 * `mcast_stats_enabled`
 * `mcast_igmp_version`
 * `mcast_mld_version`
 * `nf_call_iptables`
 * `nf_call_ip6tables`
 * `nf_call_arptables`
 * `mdb_offload_fail_notification`

Integration test case included.