### PR TITLE
conf: Support changing bond port configurations

### DIFF
--- a/src/lib/conf/alt_name.rs
+++ b/src/lib/conf/alt_name.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{query::resolve_iface_index, Iface, IfaceConf, NisporError};
+use crate::{Iface, IfaceConf, NisporError};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
@@ -21,13 +21,9 @@ impl AltNameConf {
 pub(crate) async fn change_iface_alt_name(
     handle: &rtnetlink::Handle,
     iface: &IfaceConf,
-    cur_iface: Option<&Iface>,
+    cur_iface: &Iface,
 ) -> Result<(), NisporError> {
-    let iface_index = if let Some(i) = cur_iface.as_ref().map(|c| c.index) {
-        i
-    } else {
-        resolve_iface_index(handle, iface.name.as_str()).await?
-    };
+    let iface_index = cur_iface.index;
 
     if is_all_remove(&iface.alt_names) {
         let names: Vec<&str> =

--- a/src/lib/conf/bond_port.rs
+++ b/src/lib/conf/bond_port.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use rtnetlink::{packet_route::link::LinkMessage, LinkBondPort};
+use serde::{Deserialize, Serialize};
+
+use crate::Iface;
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
+#[non_exhaustive]
+#[serde(deny_unknown_fields)]
+pub struct BondPortConf {
+    pub queue_id: Option<u16>,
+    pub prio: Option<i32>,
+}
+
+impl BondPortConf {
+    pub(crate) fn gen_link_msg(&self, cur_iface: &Iface) -> LinkMessage {
+        let mut builder = LinkBondPort::new(cur_iface.index);
+
+        if let Some(v) = self.queue_id {
+            builder = builder.queue_id(v);
+        }
+
+        if let Some(v) = self.prio {
+            builder = builder.prio(v);
+        }
+
+        builder.build()
+    }
+}

--- a/src/lib/conf/iface.rs
+++ b/src/lib/conf/iface.rs
@@ -4,12 +4,13 @@ use rtnetlink::{packet_route::link::LinkMessage, LinkUnspec};
 use serde::{Deserialize, Serialize};
 
 use super::{
-    alt_name::change_iface_alt_name, base_iface::apply_base_link_changes,
-    ip::change_ip_layer,
+    super::query::get_ifaces_with_handle, alt_name::change_iface_alt_name,
+    base_iface::apply_base_link_changes, ip::change_ip_layer,
 };
 use crate::{
-    AltNameConf, BondConf, BridgeConf, DummyConf, ErrorKind, Iface, IfaceState,
-    IfaceType, IpConf, NisporError, VethConf, VlanConf,
+    AltNameConf, BondConf, BondPortConf, BridgeConf, DummyConf, ErrorKind,
+    Iface, IfaceState, IfaceType, IpConf, NetStateIfaceFilter, NisporError,
+    VethConf, VlanConf,
 };
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
@@ -34,6 +35,7 @@ pub struct IfaceConf {
     pub vlan: Option<VlanConf>,
     #[serde(alias = "link-aggregation")]
     pub bond: Option<BondConf>,
+    pub bond_port: Option<BondPortConf>,
 }
 
 impl IfaceConf {
@@ -71,8 +73,12 @@ fn default_iface_state_in_conf() -> IfaceState {
 pub(crate) async fn apply_iface_conf(
     handle: &rtnetlink::Handle,
     des_iface: &IfaceConf,
-    cur_iface: Option<&Iface>,
 ) -> Result<(), NisporError> {
+    // Instead of query full current state, we query desired interface only
+    // one by one, because:
+    // 1. Consistent performance regardless current interface amount.
+    // 2. Allowing removing interface and add it back sequentially.
+    let cur_iface = get_cur_iface(handle, des_iface).await;
     if des_iface.state == IfaceState::Absent {
         if let Some(cur_iface) = cur_iface {
             delete_iface(handle, &des_iface.name, cur_iface.index).await?;
@@ -83,7 +89,8 @@ pub(crate) async fn apply_iface_conf(
             );
         }
     } else {
-        let mut msgs = gen_link_msg(handle, des_iface, cur_iface).await?;
+        let mut msgs =
+            gen_link_msg(handle, des_iface, cur_iface.as_ref()).await?;
         if cur_iface.is_some() {
             for msg in msgs {
                 send_change_netlink(handle, msg, des_iface.name.as_str())
@@ -112,8 +119,13 @@ pub(crate) async fn apply_iface_conf(
             }
         }
 
-        change_iface_alt_name(handle, des_iface, cur_iface).await?;
-        change_ip_layer(handle, des_iface).await?;
+        // Refresh current interface for newly created interface or
+        // controller/port attached
+        if let Some(cur_iface) = get_cur_iface(handle, des_iface).await {
+            change_port_config(handle, des_iface, &cur_iface).await?;
+            change_iface_alt_name(handle, des_iface, &cur_iface).await?;
+            change_ip_layer(handle, des_iface, &cur_iface).await?;
+        }
     }
 
     Ok(())
@@ -164,13 +176,23 @@ async fn gen_link_msg(
             .await?
         }
         Some(IfaceType::Dummy) => {
-            apply_base_link_changes(
-                handle,
-                DummyConf::gen_link_msg_builder(des_iface),
-                des_iface,
-                cur_iface,
-            )
-            .await?
+            if cur_iface.is_none() {
+                apply_base_link_changes(
+                    handle,
+                    DummyConf::gen_link_msg_builder(des_iface),
+                    des_iface,
+                    cur_iface,
+                )
+                .await?
+            } else {
+                apply_base_link_changes(
+                    handle,
+                    LinkUnspec::new_with_name(des_iface.name.as_str()),
+                    des_iface,
+                    cur_iface,
+                )
+                .await?
+            }
         }
         _ => {
             apply_base_link_changes(
@@ -209,4 +231,38 @@ async fn send_change_netlink(
             format!("Failed to change interface {iface_name}: {e}"),
         )
     })
+}
+
+async fn get_cur_iface(
+    handle: &rtnetlink::Handle,
+    des_iface: &IfaceConf,
+) -> Option<Iface> {
+    let mut iface_filter = NetStateIfaceFilter::minimum();
+    iface_filter.iface_name = Some(des_iface.name.to_string());
+    if des_iface.ipv4.is_some() || des_iface.ipv6.is_some() {
+        iface_filter.include_ip_address = true;
+    }
+    if let Ok(mut cur_ifaces) =
+        get_ifaces_with_handle(handle, Some(&iface_filter)).await
+    {
+        cur_ifaces.remove(&des_iface.name)
+    } else {
+        None
+    }
+}
+
+async fn change_port_config(
+    handle: &rtnetlink::Handle,
+    des_iface: &IfaceConf,
+    cur_iface: &Iface,
+) -> Result<(), NisporError> {
+    if let Some(bond_port_conf) = des_iface.bond_port.as_ref() {
+        send_change_netlink(
+            handle,
+            bond_port_conf.gen_link_msg(cur_iface),
+            des_iface.name.as_str(),
+        )
+        .await?;
+    }
+    Ok(())
 }

--- a/src/lib/conf/inter_ifaces.rs
+++ b/src/lib/conf/inter_ifaces.rs
@@ -2,33 +2,16 @@
 
 use rtnetlink::new_connection;
 
-use super::{super::query::get_ifaces_with_handle, iface::apply_iface_conf};
-use crate::{IfaceConf, NetStateIfaceFilter, NisporError};
+use super::iface::apply_iface_conf;
+use crate::{IfaceConf, NisporError};
 
 pub(crate) async fn apply_ifaces_conf(
     des_ifaces: &[IfaceConf],
 ) -> Result<(), NisporError> {
     let (connection, handle, _) = new_connection()?;
     tokio::spawn(connection);
-    // Instead of query full current state, we query desired interface only
-    // one by one, because:
-    // 1. Consistent performance regardless current interface amount.
-    // 2. Allowing removing interface and add it back sequentially.
     for des_iface in des_ifaces {
-        let mut iface_filter = NetStateIfaceFilter::minimum();
-        iface_filter.iface_name = Some(des_iface.name.to_string());
-        if des_iface.ipv4.is_some() || des_iface.ipv6.is_some() {
-            iface_filter.include_ip_address = true;
-        }
-        let cur_iface = if let Ok(mut cur_ifaces) =
-            get_ifaces_with_handle(&handle, Some(&iface_filter)).await
-        {
-            cur_ifaces.remove(&des_iface.name)
-        } else {
-            None
-        };
-
-        apply_iface_conf(&handle, des_iface, cur_iface.as_ref()).await?;
+        apply_iface_conf(&handle, des_iface).await?;
     }
     Ok(())
 }

--- a/src/lib/conf/ip.rs
+++ b/src/lib/conf/ip.rs
@@ -8,11 +8,8 @@ use rtnetlink::packet_route::{
 };
 use serde::{Deserialize, Serialize};
 
-use super::super::query::{get_ifaces_with_handle, is_ipv6_addr};
-use crate::{
-    ErrorKind, IfaceConf, IpFamily, Ipv4Info, Ipv6Info, NetStateIfaceFilter,
-    NisporError,
-};
+use super::super::query::is_ipv6_addr;
+use crate::{Iface, IfaceConf, IpFamily, Ipv4Info, Ipv6Info, NisporError};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
@@ -74,28 +71,13 @@ pub struct IpAddrConf {
 pub(crate) async fn change_ip_layer(
     handle: &rtnetlink::Handle,
     des_iface: &IfaceConf,
+    cur_iface: &Iface,
 ) -> Result<(), NisporError> {
-    if des_iface.ipv4.is_some() || des_iface.ipv6.is_some() {
-        let mut iface_filter = NetStateIfaceFilter::minimum();
-        iface_filter.iface_name = Some(des_iface.name.to_string());
-        iface_filter.include_ip_address = true;
-        let mut cur_ifaces =
-            get_ifaces_with_handle(handle, Some(&iface_filter)).await?;
-        let cur_iface =
-            cur_ifaces.remove(&des_iface.name).ok_or_else(|| {
-                NisporError::new(
-                    ErrorKind::NisporBug,
-                    format!("Failed to find interface {des_iface:?}"),
-                )
-            })?;
-        if let Some(ip_conf) = des_iface.ipv4.as_ref() {
-            apply_ip_conf(handle, cur_iface.index, ip_conf, IpFamily::Ipv4)
-                .await?;
-        }
-        if let Some(ip_conf) = des_iface.ipv6.as_ref() {
-            apply_ip_conf(handle, cur_iface.index, ip_conf, IpFamily::Ipv6)
-                .await?;
-        }
+    if let Some(ip_conf) = des_iface.ipv4.as_ref() {
+        apply_ip_conf(handle, cur_iface.index, ip_conf, IpFamily::Ipv4).await?;
+    }
+    if let Some(ip_conf) = des_iface.ipv6.as_ref() {
+        apply_ip_conf(handle, cur_iface.index, ip_conf, IpFamily::Ipv6).await?;
     }
 
     Ok(())

--- a/src/lib/conf/mod.rs
+++ b/src/lib/conf/mod.rs
@@ -3,6 +3,7 @@
 mod alt_name;
 mod base_iface;
 mod bond;
+mod bond_port;
 mod bridge;
 mod dummy;
 mod iface;
@@ -15,6 +16,7 @@ mod vlan;
 pub use self::{
     alt_name::AltNameConf,
     bond::BondConf,
+    bond_port::BondPortConf,
     bridge::BridgeConf,
     dummy::DummyConf,
     iface::IfaceConf,

--- a/src/lib/integ_tests/bond.rs
+++ b/src/lib/integ_tests/bond.rs
@@ -39,14 +39,16 @@ port_state: active
 mii_status: link_up
 link_failure_count: 0
 perm_hwaddr: "00:23:45:67:89:1a"
-queue_id: 0"#;
+prio: -10
+queue_id: 1"#;
 
 const EXPECTED_PORT2_INFO: &str = r#"---
 port_state: backup
 mii_status: link_up
 link_failure_count: 0
 perm_hwaddr: "00:23:45:67:89:1b"
-queue_id: 0"#;
+prio: -20
+queue_id: 2"#;
 
 const BOND_CREATE_YML: &str = r#"---
 interfaces:
@@ -71,11 +73,17 @@ interfaces:
     type: dummy
     controller: bond99
     mac-address: 00:23:45:67:89:1a
+    bond-port:
+      prio: -10
+      queue_id: 1
   - name: dummy2
     type: dummy
     state: up
     controller: bond99
-    mac-address: 00:23:45:67:89:1b"#;
+    mac-address: 00:23:45:67:89:1b
+    bond-port:
+      prio: -20
+      queue_id: 2"#;
 
 const BOND_PORT_REMOVE_YML: &str = r#"---
 interfaces:

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -13,8 +13,8 @@ mod query;
 
 pub use crate::{
     conf::{
-        AltNameConf, BondConf, BridgeConf, DummyConf, IfaceConf, IpAddrConf,
-        IpConf, RouteConf, VethConf, VlanConf,
+        AltNameConf, BondConf, BondPortConf, BridgeConf, DummyConf, IfaceConf,
+        IpAddrConf, IpConf, RouteConf, VethConf, VlanConf,
     },
     error::{ErrorKind, NisporError},
     filter::{


### PR DESCRIPTION
Example YAML:

```
---
interfaces:
  - name: bond99
    type: bond
    bond:
      mode: active-backup
  - name: dummy1
    type: dummy
    controller: bond99
    bond-port:
      priority: -10
      queue-id: 1
  - name: dummy2
    type: dummy
    state: up
    controller: bond99
    bond-port:
      priority: -20
      queue-id: 2
```

Integration test case updated.