### PR TITLE
Support changing bridge port properties

### DIFF
--- a/src/lib/conf/bridge_port.rs
+++ b/src/lib/conf/bridge_port.rs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use rtnetlink::{packet_route::link::LinkMessage, LinkBridgePort};
+use serde::{Deserialize, Serialize};
+
+use crate::{BridgeMulticastRouterType, BridgePortStpState, Iface};
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
+#[non_exhaustive]
+#[serde(deny_unknown_fields)]
+pub struct BridgePortConf {
+    /// Flush the FDB if set to `true`.
+    #[serde(default)]
+    pub flush: bool,
+    pub stp_state: Option<BridgePortStpState>,
+    pub stp_priority: Option<u16>,
+    pub stp_path_cost: Option<u32>,
+    pub hairpin_mode: Option<bool>,
+    pub bpdu_guard: Option<bool>,
+    pub root_block: Option<bool>,
+    pub multicast_fast_leave: Option<bool>,
+    pub learning: Option<bool>,
+    pub unicast_flood: Option<bool>,
+    pub proxy_arp: Option<bool>,
+    pub proxy_arp_wifi: Option<bool>,
+    pub multicast_router: Option<BridgeMulticastRouterType>,
+    pub multicast_flood: Option<bool>,
+    pub multicast_to_unicast: Option<bool>,
+    pub vlan_tunnel: Option<bool>,
+    pub broadcast_flood: Option<bool>,
+    pub group_fwd_mask: Option<u16>,
+    pub neigh_suppress: Option<bool>,
+    pub isolated: Option<bool>,
+    pub mac_authentication_bypass: Option<bool>,
+    pub backup_port: Option<u32>,
+    pub locked: Option<bool>,
+    pub neigh_vlan_suppress: Option<bool>,
+    pub backup_nexthop_id: Option<u32>,
+}
+
+impl BridgePortConf {
+    pub(crate) fn gen_link_msg(&self, cur_iface: &Iface) -> LinkMessage {
+        let mut builder = LinkBridgePort::new(cur_iface.index);
+
+        if self.flush {
+            builder = builder.fdb_flush();
+        }
+
+        if let Some(v) = self.stp_state {
+            builder = builder.state(v.into());
+        }
+
+        if let Some(v) = self.stp_priority {
+            builder = builder.priority(v);
+        }
+
+        if let Some(v) = self.stp_path_cost {
+            builder = builder.cost(v);
+        }
+
+        if let Some(v) = self.hairpin_mode {
+            builder = builder.hairpin(v);
+        }
+
+        if let Some(v) = self.bpdu_guard {
+            builder = builder.guard(v);
+        }
+
+        if let Some(v) = self.root_block {
+            builder = builder.root_block(v);
+        }
+
+        if let Some(v) = self.multicast_fast_leave {
+            builder = builder.mcast_fast_leave(v);
+        }
+
+        if let Some(v) = self.learning {
+            builder = builder.learning(v);
+        }
+
+        if let Some(v) = self.unicast_flood {
+            builder = builder.flood(v);
+        }
+
+        if let Some(v) = self.proxy_arp {
+            builder = builder.proxy_arp(v);
+        }
+
+        if let Some(v) = self.proxy_arp_wifi {
+            builder = builder.proxy_arp_wifi(v);
+        }
+
+        if let Some(v) = self.multicast_router {
+            builder = builder.mcast_router(v.into());
+        }
+
+        if let Some(v) = self.multicast_flood {
+            builder = builder.mcast_flood(v);
+        }
+
+        if let Some(v) = self.multicast_to_unicast {
+            builder = builder.mcast_to_unicast(v);
+        }
+
+        if let Some(v) = self.vlan_tunnel {
+            builder = builder.vlan_tunnel(v);
+        }
+
+        if let Some(v) = self.broadcast_flood {
+            builder = builder.bcast_flood(v);
+        }
+
+        if let Some(v) = self.group_fwd_mask {
+            builder = builder.group_fwd_mask(v);
+        }
+
+        if let Some(v) = self.neigh_suppress {
+            builder = builder.neigh_suppress(v);
+        }
+
+        if let Some(v) = self.isolated {
+            builder = builder.isolated(v);
+        }
+
+        if let Some(v) = self.mac_authentication_bypass {
+            builder = builder.mab(v);
+        }
+
+        if let Some(v) = self.backup_port {
+            builder = builder.backup_port(v);
+        }
+
+        if let Some(v) = self.locked {
+            builder = builder.locked(v);
+        }
+
+        if let Some(v) = self.neigh_vlan_suppress {
+            builder = builder.neigh_vlan_suppress(v);
+        }
+
+        if let Some(v) = self.backup_nexthop_id {
+            builder = builder.backup_nhid(v);
+        }
+
+        builder.build()
+    }
+}

--- a/src/lib/conf/iface.rs
+++ b/src/lib/conf/iface.rs
@@ -8,9 +8,9 @@ use super::{
     base_iface::apply_base_link_changes, ip::change_ip_layer,
 };
 use crate::{
-    AltNameConf, BondConf, BondPortConf, BridgeConf, DummyConf, ErrorKind,
-    Iface, IfaceState, IfaceType, IpConf, NetStateIfaceFilter, NisporError,
-    VethConf, VlanConf,
+    AltNameConf, BondConf, BondPortConf, BridgeConf, BridgePortConf, DummyConf,
+    ErrorKind, Iface, IfaceState, IfaceType, IpConf, NetStateIfaceFilter,
+    NisporError, VethConf, VlanConf,
 };
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
@@ -35,7 +35,10 @@ pub struct IfaceConf {
     pub vlan: Option<VlanConf>,
     #[serde(alias = "link-aggregation")]
     pub bond: Option<BondConf>,
+    #[serde(alias = "bond_port")]
     pub bond_port: Option<BondPortConf>,
+    #[serde(alias = "bridge_port")]
+    pub bridge_port: Option<BridgePortConf>,
 }
 
 impl IfaceConf {
@@ -260,6 +263,14 @@ async fn change_port_config(
         send_change_netlink(
             handle,
             bond_port_conf.gen_link_msg(cur_iface),
+            des_iface.name.as_str(),
+        )
+        .await?;
+    }
+    if let Some(bridge_port_conf) = des_iface.bridge_port.as_ref() {
+        send_change_netlink(
+            handle,
+            bridge_port_conf.gen_link_msg(cur_iface),
             des_iface.name.as_str(),
         )
         .await?;

--- a/src/lib/conf/mod.rs
+++ b/src/lib/conf/mod.rs
@@ -5,6 +5,7 @@ mod base_iface;
 mod bond;
 mod bond_port;
 mod bridge;
+mod bridge_port;
 mod dummy;
 mod iface;
 mod inter_ifaces;
@@ -18,6 +19,7 @@ pub use self::{
     bond::BondConf,
     bond_port::BondPortConf,
     bridge::BridgeConf,
+    bridge_port::BridgePortConf,
     dummy::DummyConf,
     iface::IfaceConf,
     ip::{IpAddrConf, IpConf},

--- a/src/lib/integ_tests/bridge.rs
+++ b/src/lib/integ_tests/bridge.rs
@@ -66,34 +66,34 @@ bridge:
 
 const EXPECTED_PORT1_BRIDGE_INFO: &str = r#"---
 stp_state: forwarding
-stp_priority: 32
-stp_path_cost: 100
-hairpin_mode: false
-bpdu_guard: false
-root_block: false
-multicast_fast_leave: false
+stp_priority: 60
+stp_path_cost: 1000
+hairpin_mode: true
+bpdu_guard: true
+root_block: true
+multicast_fast_leave: true
 learning: true
 unicast_flood: true
-proxy_arp: false
-proxy_arp_wifi: false
+proxy_arp: true
+proxy_arp_wifi: true
 designated_root: 8000.00234567891c
 designated_bridge: 8000.00234567891c
-designated_port: 32769
+designated_port: 61441
 designated_cost: 0
-port_id: "0x8001"
+port_id: "0xf001"
 port_no: "0x1"
 change_ack: false
 config_pending: false
 message_age_timer: 0
 hold_timer: 0
-multicast_router: temp_query
+multicast_router: perm
 multicast_flood: true
-multicast_to_unicast: false
+multicast_to_unicast: true
 vlan_tunnel: false
 broadcast_flood: true
-group_fwd_mask: 0
-neigh_suppress: false
-isolated: false
+group_fwd_mask: 1
+neigh_suppress: true
+isolated: true
 mrp_ring_open: false
 mcast_eht_hosts_limit: 512
 mcast_eht_hosts_cnt: 0
@@ -104,34 +104,34 @@ vlans:
 
 const EXPECTED_PORT2_BRIDGE_INFO: &str = r#"---
 stp_state: forwarding
-stp_priority: 32
-stp_path_cost: 100
-hairpin_mode: false
-bpdu_guard: false
-root_block: false
-multicast_fast_leave: false
+stp_priority: 50
+stp_path_cost: 1001
+hairpin_mode: true
+bpdu_guard: true
+root_block: true
+multicast_fast_leave: true
 learning: true
 unicast_flood: true
-proxy_arp: false
-proxy_arp_wifi: false
+proxy_arp: true
+proxy_arp_wifi: true
 designated_root: 8000.00234567891c
 designated_bridge: 8000.00234567891c
-designated_port: 32770
+designated_port: 51202
 designated_cost: 0
-port_id: "0x8002"
+port_id: "0xc802"
 port_no: "0x2"
 change_ack: false
 config_pending: false
 message_age_timer: 0
 hold_timer: 0
-multicast_router: temp_query
+multicast_router: perm
 multicast_flood: true
-multicast_to_unicast: false
+multicast_to_unicast: true
 vlan_tunnel: false
 broadcast_flood: true
-group_fwd_mask: 0
-neigh_suppress: false
-isolated: false
+group_fwd_mask: 1
+neigh_suppress: true
+isolated: true
 mrp_ring_open: false
 mcast_eht_hosts_limit: 512
 mcast_eht_hosts_cnt: 0
@@ -151,10 +151,60 @@ interfaces:
     type: dummy
     state: up
     controller: br0
+    bridge-port:
+      flush: false
+      stp_priority: 60
+      stp_path_cost: 1000
+      hairpin_mode: true
+      bpdu_guard: true
+      root_block: true
+      multicast_fast_leave: true
+      learning: true
+      unicast_flood: true
+      proxy_arp: true
+      proxy_arp_wifi: true
+      multicast_router: perm
+      multicast_flood: true
+      multicast_to_unicast: true
+      vlan_tunnel: false
+      broadcast_flood: true
+      group_fwd_mask: 1
+      neigh_suppress: true
+      isolated: true
+      mac_authentication_bypass: true
+      backup_port: 0
+      locked: true
+      neigh_vlan_suppress: false
+      backup_nexthop_id: 0
   - name: dummy2
     type: dummy
     state: up
     controller: br0
+    bridge-port:
+      flush: false
+      stp_priority: 50
+      stp_path_cost: 1001
+      hairpin_mode: true
+      bpdu_guard: true
+      root_block: true
+      multicast_fast_leave: true
+      learning: true
+      unicast_flood: true
+      proxy_arp: true
+      proxy_arp_wifi: true
+      multicast_router: perm
+      multicast_flood: true
+      multicast_to_unicast: true
+      vlan_tunnel: false
+      broadcast_flood: true
+      group_fwd_mask: 1
+      neigh_suppress: true
+      isolated: true
+      mac_authentication_bypass: true
+      backup_port: 0
+      locked: true
+      neigh_vlan_suppress: false
+      backup_nexthop_id: 0
     "#;
 
 const BRIDGE_DELETE_YML: &str = r#"---

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -13,8 +13,9 @@ mod query;
 
 pub use crate::{
     conf::{
-        AltNameConf, BondConf, BondPortConf, BridgeConf, DummyConf, IfaceConf,
-        IpAddrConf, IpConf, RouteConf, VethConf, VlanConf,
+        AltNameConf, BondConf, BondPortConf, BridgeConf, BridgePortConf,
+        DummyConf, IfaceConf, IpAddrConf, IpConf, RouteConf, VethConf,
+        VlanConf,
     },
     error::{ErrorKind, NisporError},
     filter::{

--- a/src/lib/query/bridge.rs
+++ b/src/lib/query/bridge.rs
@@ -267,7 +267,7 @@ pub struct BridgePortInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub multicast_max_groups: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub neigh_vlan_supress: Option<bool>,
+    pub neigh_vlan_suppress: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub backup_nexthop_id: Option<u32>,
 }
@@ -350,7 +350,7 @@ pub(crate) fn get_bridge_port_info(
                 ret.multicast_max_groups = Some(*d)
             }
             InfoBridgePort::NeighVlanSupress(d) => {
-                ret.neigh_vlan_supress = Some(*d)
+                ret.neigh_vlan_suppress = Some(*d)
             }
             InfoBridgePort::BackupNextHopId(d) => {
                 ret.backup_nexthop_id = Some(*d)


### PR DESCRIPTION
Example YAML:

```yml
interfaces:
  - name: br0
    type: bridge
    mac-address: 00:23:45:67:89:1c
    bridge:
      stp-state: disabled
  - name: dummy1
    type: dummy
    state: up
    controller: br0
    bridge-port:
      flush: false
      stp_priority: 60
      stp_path_cost: 1000
      hairpin_mode: true
      bpdu_guard: true
      root_block: true
      multicast_fast_leave: true
      learning: true
      unicast_flood: true
      proxy_arp: true
      proxy_arp_wifi: true
      multicast_router: perm
      multicast_flood: true
      multicast_to_unicast: true
      vlan_tunnel: false
      broadcast_flood: true
      group_fwd_mask: 1
      neigh_suppress: true
      isolated: true
      mac_authentication_bypass: true
      backup_port: 0
      locked: true
      neigh_vlan_supress: false
      backup_nexthop_id: 0
```

Integration test case updated.