### PR TITLE
bridge: Add support of changing bridge VLAN filtering

### DIFF
--- a/src/lib/conf/bridge.rs
+++ b/src/lib/conf/bridge.rs
@@ -4,11 +4,13 @@ use rtnetlink::{LinkBridge, LinkMessageBuilder};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    BridgeMulticastRouterType, BridgeStpState, IfaceConf, VlanProtocol,
+    BridgeMulticastRouterType, BridgeStpState, BridgeVlanEntry, IfaceConf,
+    VlanProtocol,
 };
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
+#[serde(deny_unknown_fields)]
 pub struct BridgeConf {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ageing_time: Option<u32>,
@@ -86,6 +88,9 @@ pub struct BridgeConf {
     pub nf_call_arptables: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mdb_offload_fail_notification: Option<bool>,
+    /// VLANs of the bridge itself
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vlans: Option<Vec<BridgeVlanEntry>>,
 }
 
 impl BridgeConf {

--- a/src/lib/conf/bridge_port.rs
+++ b/src/lib/conf/bridge_port.rs
@@ -3,7 +3,9 @@
 use rtnetlink::{packet_route::link::LinkMessage, LinkBridgePort};
 use serde::{Deserialize, Serialize};
 
-use crate::{BridgeMulticastRouterType, BridgePortStpState, Iface};
+use crate::{
+    BridgeMulticastRouterType, BridgePortStpState, BridgeVlanEntry, Iface,
+};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
 #[non_exhaustive]
@@ -36,10 +38,14 @@ pub struct BridgePortConf {
     pub locked: Option<bool>,
     pub neigh_vlan_suppress: Option<bool>,
     pub backup_nexthop_id: Option<u32>,
+    pub vlans: Option<Vec<BridgeVlanEntry>>,
 }
 
 impl BridgePortConf {
-    pub(crate) fn gen_link_msg(&self, cur_iface: &Iface) -> LinkMessage {
+    pub(crate) fn gen_port_conf_link_msg(
+        &self,
+        cur_iface: &Iface,
+    ) -> LinkMessage {
         let mut builder = LinkBridgePort::new(cur_iface.index);
 
         if self.flush {

--- a/src/lib/conf/bridge_vlan.rs
+++ b/src/lib/conf/bridge_vlan.rs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use rtnetlink::{
+    packet_route::link::{BridgeVlanInfoFlags, LinkMessage},
+    LinkBridgeVlan, LinkMessageBuilder,
+};
+
+use crate::{BridgeConf, BridgePortConf, BridgeVlanEntry, Iface};
+
+fn add_bridge_vlan_to_builder<'a, T>(
+    mut builder: LinkMessageBuilder<LinkBridgeVlan>,
+    vlans: T,
+) -> LinkMessageBuilder<LinkBridgeVlan>
+where
+    T: Iterator<Item = &'a BridgeVlanEntry>,
+{
+    for vlan in vlans {
+        let mut flag = BridgeVlanInfoFlags::empty();
+        if vlan.is_pvid {
+            flag |= BridgeVlanInfoFlags::Pvid;
+        }
+        if vlan.is_egress_untagged {
+            flag |= BridgeVlanInfoFlags::Untagged;
+        }
+        if let Some(vid) = vlan.vid {
+            builder = builder.vlan(vid, flag);
+        } else if let Some((vid_start, vid_end)) = vlan.vid_range.as_ref() {
+            builder = builder
+                .vlan_range_start(*vid_start, flag)
+                .vlan_range_end(*vid_end, flag);
+        }
+    }
+    builder
+}
+
+impl BridgePortConf {
+    pub(crate) fn gen_add_port_vlan_conf_link_msg(
+        &self,
+        cur_iface: &Iface,
+    ) -> Option<LinkMessage> {
+        let vlans = self.vlans.as_ref()?;
+        let mut vlans_to_add = vlans.iter().filter(|v| !v.remove).peekable();
+        vlans_to_add.peek()?;
+        let builder = add_bridge_vlan_to_builder(
+            LinkBridgeVlan::new(cur_iface.index),
+            vlans_to_add,
+        );
+        Some(builder.build())
+    }
+
+    pub(crate) fn gen_del_port_vlan_conf_link_msg(
+        &self,
+        cur_iface: &Iface,
+    ) -> Option<LinkMessage> {
+        let vlans = self.vlans.as_ref()?;
+        let mut vlans_to_del = vlans.iter().filter(|v| v.remove).peekable();
+        vlans_to_del.peek()?;
+        let builder = add_bridge_vlan_to_builder(
+            LinkBridgeVlan::new(cur_iface.index),
+            vlans_to_del,
+        );
+        Some(builder.build())
+    }
+}
+
+impl BridgeConf {
+    pub(crate) fn gen_add_vlan_conf_link_msg(
+        &self,
+        cur_iface: &Iface,
+    ) -> Option<LinkMessage> {
+        let vlans = self.vlans.as_ref()?;
+        let mut vlans_to_add = vlans.iter().filter(|v| !v.remove).peekable();
+        vlans_to_add.peek()?;
+        let builder = add_bridge_vlan_to_builder(
+            LinkBridgeVlan::new(cur_iface.index).bridge_self(),
+            vlans_to_add,
+        );
+        Some(builder.build())
+    }
+
+    pub(crate) fn gen_del_vlan_conf_link_msg(
+        &self,
+        cur_iface: &Iface,
+    ) -> Option<LinkMessage> {
+        let vlans = self.vlans.as_ref()?;
+        let mut vlans_to_del = vlans.iter().filter(|v| v.remove).peekable();
+        vlans_to_del.peek()?;
+        let builder = add_bridge_vlan_to_builder(
+            LinkBridgeVlan::new(cur_iface.index).bridge_self(),
+            vlans_to_del,
+        );
+        Some(builder.build())
+    }
+}

--- a/src/lib/conf/iface.rs
+++ b/src/lib/conf/iface.rs
@@ -270,10 +270,74 @@ async fn change_port_config(
     if let Some(bridge_port_conf) = des_iface.bridge_port.as_ref() {
         send_change_netlink(
             handle,
-            bridge_port_conf.gen_link_msg(cur_iface),
+            bridge_port_conf.gen_port_conf_link_msg(cur_iface),
             des_iface.name.as_str(),
         )
         .await?;
+
+        apply_bridge_vlan_conf(
+            handle,
+            des_iface.name.as_str(),
+            bridge_port_conf.gen_del_port_vlan_conf_link_msg(cur_iface),
+            bridge_port_conf.gen_add_port_vlan_conf_link_msg(cur_iface),
+            "port",
+        )
+        .await?;
+    }
+    if let Some(br_conf) = des_iface.bridge.as_ref() {
+        apply_bridge_vlan_conf(
+            handle,
+            des_iface.name.as_str(),
+            br_conf.gen_del_vlan_conf_link_msg(cur_iface),
+            br_conf.gen_add_vlan_conf_link_msg(cur_iface),
+            "self",
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+async fn apply_bridge_vlan_conf(
+    handle: &rtnetlink::Handle,
+    iface_name: &str,
+    del_msg: Option<LinkMessage>,
+    add_msg: Option<LinkMessage>,
+    vlan_entity: &str,
+) -> Result<(), NisporError> {
+    if let Some(msg) = del_msg {
+        log::trace!(
+            "Remove bridge {} VLAN via netlink message {msg:?}",
+            vlan_entity
+        );
+        handle
+            .link()
+            .del_with_message(msg)
+            .execute()
+            .await
+            .map_err(|e| {
+                NisporError::new(
+                    ErrorKind::NisporBug,
+                    format!(
+                        "Failed to remove bridge {} vlan of interface {}: {e}",
+                        vlan_entity, iface_name
+                    ),
+                )
+            })?;
+    }
+    if let Some(msg) = add_msg {
+        log::trace!(
+            "Set bridge {} VLAN via netlink message {msg:?}",
+            vlan_entity
+        );
+        handle.link().set(msg).execute().await.map_err(|e| {
+            NisporError::new(
+                ErrorKind::NisporBug,
+                format!(
+                    "Failed to set bridge {} vlan of interface {}: {e}",
+                    vlan_entity, iface_name
+                ),
+            )
+        })?;
     }
     Ok(())
 }

--- a/src/lib/conf/mod.rs
+++ b/src/lib/conf/mod.rs
@@ -6,6 +6,7 @@ mod bond;
 mod bond_port;
 mod bridge;
 mod bridge_port;
+mod bridge_vlan;
 mod dummy;
 mod iface;
 mod inter_ifaces;

--- a/src/lib/integ_tests/bridge.rs
+++ b/src/lib/integ_tests/bridge.rs
@@ -146,7 +146,7 @@ interfaces:
     type: bridge
     mac-address: 00:23:45:67:89:1c
     bridge:
-      stp-state: disabled
+      stp_state: disabled
   - name: dummy1
     type: dummy
     state: up

--- a/src/lib/integ_tests/bridge_vlan_filter.rs
+++ b/src/lib/integ_tests/bridge_vlan_filter.rs
@@ -5,46 +5,13 @@ use std::panic;
 use pretty_assertions::assert_eq;
 
 use super::utils::assert_value_match;
-use crate::NetState;
+use crate::{NetConf, NetState};
 
 const IFACE_NAME: &str = "br0";
-const PORT1_NAME: &str = "eth1";
-const PORT2_NAME: &str = "eth2";
+const PORT1_NAME: &str = "dummy1";
+const PORT2_NAME: &str = "dummy2";
 
 const EXPECTED_PORT1_BRIDGE_INFO: &str = r#"---
-stp_state: forwarding
-stp_priority: 32
-stp_path_cost: 2
-hairpin_mode: false
-bpdu_guard: false
-root_block: false
-multicast_fast_leave: false
-learning: true
-unicast_flood: true
-proxy_arp: false
-proxy_arp_wifi: false
-designated_root: 8000.00234567891c
-designated_bridge: 8000.00234567891c
-designated_port: 32769
-designated_cost: 0
-port_id: "0x8001"
-port_no: "0x1"
-change_ack: false
-config_pending: false
-message_age_timer: 0
-forward_delay_timer: 0
-hold_timer: 0
-multicast_router: temp_query
-multicast_flood: true
-multicast_to_unicast: false
-vlan_tunnel: false
-broadcast_flood: true
-group_fwd_mask: 0
-neigh_suppress: false
-isolated: false
-mrp_ring_open: false
-mcast_eht_hosts_limit: 512
-mcast_eht_hosts_cnt: 0
 vlans:
   - vid: 1
     is_pvid: false
@@ -54,39 +21,6 @@ vlans:
     is_egress_untagged: true"#;
 
 const EXPECTED_PORT2_BRIDGE_INFO: &str = r#"---
-stp_state: forwarding
-stp_priority: 32
-stp_path_cost: 2
-hairpin_mode: false
-bpdu_guard: false
-root_block: false
-multicast_fast_leave: false
-learning: true
-unicast_flood: true
-proxy_arp: false
-proxy_arp_wifi: false
-designated_root: 8000.00234567891c
-designated_bridge: 8000.00234567891c
-designated_port: 32770
-designated_cost: 0
-port_id: "0x8002"
-port_no: "0x2"
-change_ack: false
-config_pending: false
-message_age_timer: 0
-forward_delay_timer: 0
-hold_timer: 0
-multicast_router: temp_query
-multicast_flood: true
-multicast_to_unicast: false
-vlan_tunnel: false
-broadcast_flood: true
-group_fwd_mask: 0
-neigh_suppress: false
-isolated: false
-mrp_ring_open: false
-mcast_eht_hosts_limit: 512
-mcast_eht_hosts_cnt: 0
 vlans:
   - vid: 1
     is_pvid: true
@@ -108,19 +42,7 @@ static BR_SELF_VLAN: &str = r#"
 #[test]
 fn test_get_br_vlan_filter_iface_yaml() {
     with_br_with_vlan_filter_iface(|| {
-        let mut state = NetState::retrieve().unwrap();
-        let port1 = state.ifaces.get_mut(PORT1_NAME).unwrap();
-        if let Some(ref mut port_info) = port1.bridge_port {
-            port_info.forward_delay_timer = 0;
-            // Below values are not supported by Github CI Ubuntu 20.04
-            port_info.mrp_in_open = None;
-        }
-        let port2 = state.ifaces.get_mut(PORT2_NAME).unwrap();
-        if let Some(ref mut port_info) = port2.bridge_port {
-            port_info.forward_delay_timer = 0;
-            // Below values are not supported by Github CI Ubuntu 20.04
-            port_info.mrp_in_open = None;
-        }
+        let state = NetState::retrieve().unwrap();
         let iface = state.ifaces.get(IFACE_NAME).unwrap();
         if let Some(bridge_info) = &iface.bridge {
             assert_eq!(bridge_info.vlan_filtering, Some(true))
@@ -134,16 +56,177 @@ fn test_get_br_vlan_filter_iface_yaml() {
     });
 }
 
+const BRIDGE_CREATE_YML: &str = r#"---
+interfaces:
+  - name: br0
+    type: bridge
+    mac-address: 00:23:45:67:89:1c
+    bridge:
+      stp_state: disabled
+      vlan_filtering: true
+      vlans:
+      - vid: 1
+        is_pvid: false
+        is_egress_untagged: true
+      - vid: 11
+        is_pvid: true
+        is_egress_untagged: true
+  - name: dummy1
+    type: dummy
+    state: up
+    controller: br0
+    bridge-port:
+      vlans:
+      - vid: 1
+        is_pvid: false
+        is_egress_untagged: true
+      - vid: 10
+        is_pvid: true
+        is_egress_untagged: true
+  - name: dummy2
+    type: dummy
+    state: up
+    controller: br0
+    bridge-port:
+      vlans:
+        - vid: 1
+          is_pvid: true
+          is_egress_untagged: true
+        - vid_range:
+          - 2
+          - 4094
+          is_pvid: false
+          is_egress_untagged: false"#;
+
+const BRIDGE_DELETE_YML: &str = r#"---
+interfaces:
+  - name: br0
+    type: bridge
+    state: absent
+  - name: dummy1
+    type: dummy
+    state: absent
+  - name: dummy2
+    type: dummy
+    state: absent"#;
+
 fn with_br_with_vlan_filter_iface<T>(test: T)
 where
     T: FnOnce() + panic::UnwindSafe,
 {
-    super::utils::set_network_environment("brv");
+    let net_conf: NetConf = serde_yaml::from_str(BRIDGE_CREATE_YML).unwrap();
+    net_conf.apply().unwrap();
 
     let result = panic::catch_unwind(|| {
         test();
     });
 
-    super::utils::clear_network_environment();
+    let net_conf: NetConf = serde_yaml::from_str(BRIDGE_DELETE_YML).unwrap();
+    net_conf.apply().unwrap();
     assert!(result.is_ok())
+}
+
+const BRIDGE_VLAN_MODIFY_YML: &str = r#"---
+interfaces:
+  - name: br0
+    type: bridge
+    bridge:
+      stp_state: disabled
+      vlan_filtering: true
+      vlans:
+      - vid: 1
+        is_pvid: false
+        is_egress_untagged: true
+      - vid: 11
+        is_pvid: true
+        is_egress_untagged: true
+        remove: true
+      - vid: 21
+        is_pvid: true
+        is_egress_untagged: true
+  - name: dummy1
+    type: dummy
+    state: up
+    controller: br0
+    bridge-port:
+      vlans:
+      - vid: 1
+        is_pvid: false
+        is_egress_untagged: true
+      - vid: 10
+        is_pvid: true
+        is_egress_untagged: true
+        remove: true
+      - vid: 20
+        is_pvid: true
+        is_egress_untagged: true
+  - name: dummy2
+    type: dummy
+    state: up
+    controller: br0
+    bridge-port:
+      vlans:
+        - vid: 1
+          is_pvid: true
+          is_egress_untagged: true
+        - vid_range:
+          - 2
+          - 4094
+          is_pvid: false
+          is_egress_untagged: false
+          remove: true
+        - vid_range:
+          - 4
+          - 4094
+          is_pvid: false
+          is_egress_untagged: false"#;
+
+const NEW_PORT1_BRIDGE_INFO: &str = r#"---
+vlans:
+  - vid: 1
+    is_pvid: false
+    is_egress_untagged: true
+  - vid: 20
+    is_pvid: true
+    is_egress_untagged: true"#;
+
+const NEW_PORT2_BRIDGE_INFO: &str = r#"---
+vlans:
+  - vid: 1
+    is_pvid: true
+    is_egress_untagged: true
+  - vid_range:
+      - 4
+      - 4094
+    is_pvid: false
+    is_egress_untagged: false"#;
+
+static NEW_BR_SELF_VLAN: &str = r#"
+  - vid: 1
+    is_pvid: false
+    is_egress_untagged: true
+  - vid: 21
+    is_pvid: true
+    is_egress_untagged: true"#;
+
+#[test]
+fn test_modify_bridge_vlan() {
+    with_br_with_vlan_filter_iface(|| {
+        let net_conf: NetConf =
+            serde_yaml::from_str(BRIDGE_VLAN_MODIFY_YML).unwrap();
+        net_conf.apply().unwrap();
+
+        let state = NetState::retrieve().unwrap();
+
+        let iface = &state.ifaces[IFACE_NAME];
+        assert_value_match(
+            NEW_BR_SELF_VLAN,
+            iface.bridge_vlan.as_ref().unwrap(),
+        );
+
+        let port1 = &state.ifaces[PORT1_NAME];
+        let port2 = &state.ifaces[PORT2_NAME];
+        assert_value_match(NEW_PORT1_BRIDGE_INFO, &port1.bridge_port);
+        assert_value_match(NEW_PORT2_BRIDGE_INFO, &port2.bridge_port);
+    })
 }


### PR DESCRIPTION
Example YAML:

```yml
interfaces:
  - name: br0
    type: bridge
    mac-address: 00:23:45:67:89:1c
    bridge:
      stp_state: disabled
      vlan_filtering: true
      vlans:
      - vid: 1
        is_pvid: false
        is_egress_untagged: true
      - vid: 11
        is_pvid: true
        is_egress_untagged: true
        remove: true
      - vid: 21
        is_pvid: true
        is_egress_untagged: true
        remove: true
  - name: dummy1
    type: dummy
    state: up
    controller: br0
    bridge-port:
      vlans:
      - vid: 1
        is_pvid: false
        is_egress_untagged: true
      - vid: 10
        is_pvid: true
        is_egress_untagged: true
        remove: true
      - vid: 20
        is_pvid: true
        is_egress_untagged: true
```

Integration test case updated.