### PR TITLE
bridge vlan: merge `bridge-vlan` section into `bridge` section.

### DIFF
--- a/src/lib/integ_tests/bridge_vlan_filter.rs
+++ b/src/lib/integ_tests/bridge_vlan_filter.rs
@@ -47,7 +47,14 @@ fn test_get_br_vlan_filter_iface_yaml() {
         if let Some(bridge_info) = &iface.bridge {
             assert_eq!(bridge_info.vlan_filtering, Some(true))
         }
-        assert_value_match(BR_SELF_VLAN, iface.bridge_vlan.as_ref().unwrap());
+        assert_value_match(
+            BR_SELF_VLAN,
+            iface
+                .bridge
+                .as_ref()
+                .and_then(|b| b.vlans.as_ref())
+                .unwrap(),
+        );
 
         let port1 = &state.ifaces[PORT1_NAME];
         let port2 = &state.ifaces[PORT2_NAME];
@@ -221,7 +228,11 @@ fn test_modify_bridge_vlan() {
         let iface = &state.ifaces[IFACE_NAME];
         assert_value_match(
             NEW_BR_SELF_VLAN,
-            iface.bridge_vlan.as_ref().unwrap(),
+            iface
+                .bridge
+                .as_ref()
+                .and_then(|b| b.vlans.as_ref())
+                .unwrap(),
         );
 
         let port1 = &state.ifaces[PORT1_NAME];

--- a/src/lib/query/bridge.rs
+++ b/src/lib/query/bridge.rs
@@ -135,6 +135,8 @@ pub struct BridgeInfo {
     pub multicast_igmp_version: Option<u8>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub multicast_mld_version: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vlans: Option<Vec<BridgeVlanEntry>>,
 }
 
 #[derive(

--- a/src/lib/query/bridge_vlan.rs
+++ b/src/lib/query/bridge_vlan.rs
@@ -36,10 +36,12 @@ pub(crate) fn parse_bridge_vlan_info(
             };
         }
     } else if iface_state.iface_type == IfaceType::Bridge {
-        let br_vlan = iface_state.bridge_vlan.get_or_insert(Vec::new());
-        // It's the VLAN of the bridge itself
-        if let Some(cur_vlans) = parse_af_spec_bridge_info(nlas)? {
-            br_vlan.extend(cur_vlans);
+        if let Some(br_conf) = iface_state.bridge.as_mut() {
+            let br_vlan = br_conf.vlans.get_or_insert(Vec::new());
+            // It's the VLAN of the bridge itself
+            if let Some(cur_vlans) = parse_af_spec_bridge_info(nlas)? {
+                br_vlan.extend(cur_vlans);
+            }
         }
     }
     Ok(())

--- a/src/lib/query/iface.rs
+++ b/src/lib/query/iface.rs
@@ -30,11 +30,11 @@ use super::{
     xfrm::get_xfrm_info,
 };
 use crate::{
-    BondInfo, BondPortInfo, BridgeInfo, BridgePortInfo, BridgeVlanEntry,
-    ErrorKind, EthtoolInfo, HsrInfo, IpTunnelInfo, IpVlanInfo, IpoibInfo,
-    Ipv4Info, Ipv6Info, MacSecInfo, MacVlanInfo, MacVtapInfo, MptcpAddress,
-    NisporError, PciAddress, SriovInfo, TunInfo, VethInfo, VfInfo, VlanInfo,
-    VrfInfo, VrfPortInfo, VxlanInfo, WifiInfo, XfrmInfo,
+    BondInfo, BondPortInfo, BridgeInfo, BridgePortInfo, ErrorKind, EthtoolInfo,
+    HsrInfo, IpTunnelInfo, IpVlanInfo, IpoibInfo, Ipv4Info, Ipv6Info,
+    MacSecInfo, MacVlanInfo, MacVtapInfo, MptcpAddress, NisporError,
+    PciAddress, SriovInfo, TunInfo, VethInfo, VfInfo, VlanInfo, VrfInfo,
+    VrfPortInfo, VxlanInfo, WifiInfo, XfrmInfo,
 };
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
@@ -269,8 +269,6 @@ pub struct Iface {
     pub bond_port: Option<BondPortInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bridge: Option<BridgeInfo>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub bridge_vlan: Option<Vec<BridgeVlanEntry>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bridge_port: Option<BridgePortInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
To align with apply schema, this patch changed `bridge-vlan` section in
query output to `bridge.vlans`.

Example query output(many lines omitted):

```yml
- name: br0
  type: linux-bridge
  state: up
  mtu: 1500
  bridge:
    ports:
    - dummy1
    vlans:
    - vid: 1
      is-pvid: false
      is-egress-untagged: true
    - vid: 11
      is-pvid: true
      is-egress-untagged: true
```

Integration test case updated.