### PR TITLE
log: Change warn message to debug for unknown netlink attribute

### DIFF
--- a/src/lib/query/bond.rs
+++ b/src/lib/query/bond.rs
@@ -682,7 +682,7 @@ impl From<&[InfoBond]> for BondInfo {
                 }
                 InfoBond::NsIp6Target(v) => ret.ns_ip6_target = Some(v.clone()),
                 _ => {
-                    log::warn!("Unsupported InfoBond: {nla:?}");
+                    log::debug!("Unsupported InfoBond: {nla:?}");
                 }
             }
         }

--- a/src/lib/query/ethtool.rs
+++ b/src/lib/query/ethtool.rs
@@ -488,9 +488,7 @@ async fn dump_coalesce_infos(
                     EthtoolCoalesceAttr::RateSampleInterval(d) => {
                         coalesce_info.rate_sample_interval = Some(*d)
                     }
-                    _ => log::warn!(
-                        "WARN: Unsupported EthtoolCoalesceAttr {nla:?}"
-                    ),
+                    _ => log::debug!("Unsupported EthtoolCoalesceAttr {nla:?}"),
                 }
             }
         }
@@ -531,7 +529,7 @@ async fn dump_ring_infos(
                     }
                     EthtoolRingAttr::Tx(d) => ring_info.tx = Some(*d),
                     _ => {
-                        log::warn!("WARN: Unsupported EthtoolRingAttr {nla:?}")
+                        log::debug!("Unsupported EthtoolRingAttr {nla:?}")
                     }
                 }
             }
@@ -592,9 +590,7 @@ async fn dump_link_mode_infos(
                         link_mode_info.lanes = Some(*d)
                     }
 
-                    _ => log::warn!(
-                        "WARN: Unsupported EthtoolLinkModeAttr {nla:?}"
-                    ),
+                    _ => log::debug!("Unsupported EthtoolLinkModeAttr {nla:?}"),
                 }
             }
         }

--- a/src/lib/query/hsr.rs
+++ b/src/lib/query/hsr.rs
@@ -85,7 +85,7 @@ pub(crate) fn get_hsr_info(data: &InfoData) -> Option<HsrInfo> {
                     hsr_info.protocol = u8::from(d).into();
                 }
                 _ => {
-                    log::warn!("Unknown HSR info {info:?}");
+                    log::debug!("Unknown HSR info {info:?}");
                 }
             }
         }

--- a/src/lib/query/iface.rs
+++ b/src/lib/query/iface.rs
@@ -470,7 +470,7 @@ pub(crate) fn parse_nl_msg_to_iface(
                         IfaceType::Xfrm => {
                             iface_state.xfrm = get_xfrm_info(d);
                         }
-                        _ => log::warn!(
+                        _ => log::debug!(
                             "Unhandled IFLA_INFO_DATA for iface type {:?}",
                             iface_state.iface_type
                         ),
@@ -519,7 +519,7 @@ pub(crate) fn parse_nl_msg_to_iface(
                                     Some(get_vrf_port_info(data)?);
                             }
                             InfoPortData::Other(_) => {
-                                log::warn!(
+                                log::info!(
                                     "Unknown controller type \
                                      {controller_type:?}"
                                 );

--- a/src/lib/query/tun.rs
+++ b/src/lib/query/tun.rs
@@ -96,7 +96,7 @@ pub(crate) fn get_tun_info(data: &InfoData) -> Result<TunInfo, NisporError> {
                     tun_info.num_disabled_queues = Some(parse_as_u32(payload)?);
                 }
                 _ => {
-                    log::warn!(
+                    log::debug!(
                         "Unhandled TUN NLA {} {:?}",
                         nla.kind(),
                         payload


### PR DESCRIPTION
We should not scare user about netlink attribute we are not processing.