### PR TITLE
Bump minimum supported rust version to 1.88

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ tier = "2"
 all-features = true
 
 [workspace.package]
-rust-version = "1.85"
+rust-version = "1.88"
 version = "2.0.0"
 authors = ["Gris Ge <fge@redhat.com>"]
 description = "Unified interface for Linux network state querying"

--- a/src/cli/npc.rs
+++ b/src/cli/npc.rs
@@ -362,10 +362,10 @@ fn parse_arg_output_format(matches: &clap::ArgMatches) -> CliOutputType {
 }
 
 fn _is_route_to_specified_dev(route: &Route, iface_name: &str) -> bool {
-    if let Some(oif) = &route.oif {
-        if oif == iface_name {
-            return true;
-        }
+    if let Some(oif) = &route.oif
+        && oif == iface_name
+    {
+        return true;
     }
     if let Some(mp_routes) = &route.multipath {
         for mp_route in mp_routes {
@@ -681,10 +681,11 @@ fn get_ifaces(matches: &clap::ArgMatches) -> Result<CliReply, CliError> {
 fn get_routes(matches: &clap::ArgMatches) -> Result<CliReply, CliError> {
     let mut route_filter = NetStateRouteFilter::default();
 
-    if let Some(scope) = matches.get_one::<String>("scope") {
-        if scope != "a" && scope != "all" {
-            route_filter.scope = Some(RouteScope::try_from(scope.as_str())?);
-        }
+    if let Some(scope) = matches.get_one::<String>("scope")
+        && scope != "a"
+        && scope != "all"
+    {
+        route_filter.scope = Some(RouteScope::try_from(scope.as_str())?);
     }
 
     if let Some(protocol) = matches.get_one::<String>("protocol") {

--- a/src/lib/conf/base_iface.rs
+++ b/src/lib/conf/base_iface.rs
@@ -15,30 +15,27 @@ pub(crate) async fn apply_base_link_changes<T>(
 ) -> Result<Vec<LinkMessage>, NisporError> {
     let mut ret: Vec<LinkMessage> = Vec::new();
 
-    if let Some(cur_iface) = cur_iface {
-        if des_iface.need_state_down_before_apply(cur_iface)
-            && cur_iface.flags.contains(&IfaceFlag::Up)
-        {
-            ret.push(
-                LinkUnspec::new_with_index(cur_iface.index).down().build(),
-            );
-        }
+    if let Some(cur_iface) = cur_iface
+        && des_iface.need_state_down_before_apply(cur_iface)
+        && cur_iface.flags.contains(&IfaceFlag::Up)
+    {
+        ret.push(LinkUnspec::new_with_index(cur_iface.index).down().build());
     }
 
     if let Some(mtu) = des_iface.mtu {
         builder = builder.mtu(mtu);
     }
 
-    if let Some(des_mac) = des_iface.mac_address.as_ref() {
-        if !des_mac.is_empty() {
-            let should_set = cur_iface
-                .as_ref()
-                .map(|c| c.mac_address.to_uppercase() != des_mac.to_uppercase())
-                .unwrap_or(true);
+    if let Some(des_mac) = des_iface.mac_address.as_ref()
+        && !des_mac.is_empty()
+    {
+        let should_set = cur_iface
+            .as_ref()
+            .map(|c| c.mac_address.to_uppercase() != des_mac.to_uppercase())
+            .unwrap_or(true);
 
-            if should_set {
-                builder = builder.address(mac_str_to_raw(des_mac)?);
-            }
+        if should_set {
+            builder = builder.address(mac_str_to_raw(des_mac)?);
         }
     }
 

--- a/src/lib/conf/iface.rs
+++ b/src/lib/conf/iface.rs
@@ -45,22 +45,21 @@ impl IfaceConf {
     ///  * Change controller
     ///  * Change bond mode
     pub(crate) fn need_state_down_before_apply(&self, current: &Iface) -> bool {
-        if let Some(des_mac) = self.mac_address.as_ref() {
-            if des_mac.to_uppercase() != current.mac_address.to_uppercase() {
-                return true;
-            }
+        if let Some(des_mac) = self.mac_address.as_ref()
+            && des_mac.to_uppercase() != current.mac_address.to_uppercase()
+        {
+            return true;
         }
 
         if self.controller.is_some() && self.controller != current.controller {
             return true;
         }
 
-        if let Some(des_bond_mode) = self.bond.as_ref().and_then(|b| b.mode) {
-            if let Some(cur_bond_mode) = current.bond.as_ref().map(|b| b.mode) {
-                if des_bond_mode != cur_bond_mode {
-                    return true;
-                }
-            }
+        if let Some(des_bond_mode) = self.bond.as_ref().and_then(|b| b.mode)
+            && let Some(cur_bond_mode) = current.bond.as_ref().map(|b| b.mode)
+            && des_bond_mode != cur_bond_mode
+        {
+            return true;
         }
 
         false

--- a/src/lib/conf/ip.rs
+++ b/src/lib/conf/ip.rs
@@ -104,10 +104,10 @@ async fn apply_ip_conf(
                 ip_addr_str_to_enum(&addr_conf.address)?,
             ));
             if let Err(e) = handle.address().del(nl_msg).execute().await {
-                if let rtnetlink::Error::NetlinkError(ref e) = e {
-                    if e.raw_code() == -libc::EADDRNOTAVAIL {
-                        return Ok(());
-                    }
+                if let rtnetlink::Error::NetlinkError(ref e) = e
+                    && e.raw_code() == -libc::EADDRNOTAVAIL
+                {
+                    return Ok(());
                 }
                 return Err(e.into());
             }

--- a/src/lib/conf/route.rs
+++ b/src/lib/conf/route.rs
@@ -135,18 +135,18 @@ async fn apply_route_conf(
 
     if route.remove {
         if let Err(e) = handle.route().del(builder.build()).execute().await {
-            if let rtnetlink::Error::NetlinkError(ref e) = e {
-                if e.raw_code() == -libc::ESRCH {
-                    return Ok(());
-                }
+            if let rtnetlink::Error::NetlinkError(ref e) = e
+                && e.raw_code() == -libc::ESRCH
+            {
+                return Ok(());
             }
             return Err(e.into());
         }
     } else if let Err(e) = handle.route().add(builder.build()).execute().await {
-        if let rtnetlink::Error::NetlinkError(ref e) = e {
-            if e.raw_code() == -libc::EEXIST {
-                return Ok(());
-            }
+        if let rtnetlink::Error::NetlinkError(ref e) = e
+            && e.raw_code() == -libc::EEXIST
+        {
+            return Ok(());
         }
         return Err(e.into());
     }

--- a/src/lib/net_conf.rs
+++ b/src/lib/net_conf.rs
@@ -29,11 +29,11 @@ impl NetConf {
             apply_ifaces_conf(ifaces).await?;
         }
 
-        if let Some(routes) = self.routes.as_ref() {
-            if !routes.is_empty() {
-                let cur_iface_name_2_index = get_iface_name2index().await?;
-                apply_routes_conf(routes, &cur_iface_name_2_index).await?;
-            }
+        if let Some(routes) = self.routes.as_ref()
+            && !routes.is_empty()
+        {
+            let cur_iface_name_2_index = get_iface_name2index().await?;
+            apply_routes_conf(routes, &cur_iface_name_2_index).await?;
         }
         Ok(())
     }

--- a/src/lib/query/bond.rs
+++ b/src/lib/query/bond.rs
@@ -806,25 +806,24 @@ pub(crate) fn bond_iface_tidy_up(iface_states: &mut HashMap<String, Iface>) {
 fn gen_port_list_of_controller(iface_states: &mut HashMap<String, Iface>) {
     let mut controller_ports: HashMap<String, Vec<String>> = HashMap::new();
     for iface in iface_states.values() {
-        if iface.controller_type == Some(ControllerType::Bond) {
-            if let Some(controller) = &iface.controller {
-                match controller_ports.get_mut(controller) {
-                    Some(ports) => ports.push(iface.name.clone()),
-                    None => {
-                        let new_ports: Vec<String> = vec![iface.name.clone()];
-                        controller_ports.insert(controller.clone(), new_ports);
-                    }
-                };
-            }
+        if iface.controller_type == Some(ControllerType::Bond)
+            && let Some(controller) = &iface.controller
+        {
+            match controller_ports.get_mut(controller) {
+                Some(ports) => ports.push(iface.name.clone()),
+                None => {
+                    let new_ports: Vec<String> = vec![iface.name.clone()];
+                    controller_ports.insert(controller.clone(), new_ports);
+                }
+            };
         }
     }
     for (controller, ports) in controller_ports.iter_mut() {
         if let Some(ref mut controller_iface) = iface_states.get_mut(controller)
+            && let Some(ref mut bond_info) = controller_iface.bond
         {
-            if let Some(ref mut bond_info) = controller_iface.bond {
-                ports.sort();
-                bond_info.ports.clone_from(ports);
-            }
+            ports.sort();
+            bond_info.ports.clone_from(ports);
         }
     }
 }
@@ -838,12 +837,11 @@ fn primary_index_to_iface_name(iface_states: &mut HashMap<String, Iface>) {
         if iface.iface_type != IfaceType::Bond {
             continue;
         }
-        if let Some(ref mut bond_info) = iface.bond {
-            if let Some(index) = &bond_info.primary {
-                if let Some(iface_name) = index_to_name.get(index) {
-                    bond_info.primary = Some(iface_name.clone());
-                }
-            }
+        if let Some(ref mut bond_info) = iface.bond
+            && let Some(index) = &bond_info.primary
+            && let Some(iface_name) = index_to_name.get(index)
+        {
+            bond_info.primary = Some(iface_name.clone());
         }
     }
 }

--- a/src/lib/query/bridge.rs
+++ b/src/lib/query/bridge.rs
@@ -379,24 +379,24 @@ pub(crate) fn bridge_iface_tidy_up(iface_states: &mut HashMap<String, Iface>) {
 fn gen_port_list_of_controller(iface_states: &mut HashMap<String, Iface>) {
     let mut controller_ports: HashMap<String, Vec<String>> = HashMap::new();
     for iface in iface_states.values() {
-        if iface.controller_type == Some(ControllerType::Bridge) {
-            if let Some(controller) = &iface.controller {
-                match controller_ports.get_mut(controller) {
-                    Some(ports) => ports.push(iface.name.clone()),
-                    None => {
-                        let new_ports: Vec<String> = vec![iface.name.clone()];
-                        controller_ports.insert(controller.clone(), new_ports);
-                    }
-                };
-            }
+        if iface.controller_type == Some(ControllerType::Bridge)
+            && let Some(controller) = &iface.controller
+        {
+            match controller_ports.get_mut(controller) {
+                Some(ports) => ports.push(iface.name.clone()),
+                None => {
+                    let new_ports: Vec<String> = vec![iface.name.clone()];
+                    controller_ports.insert(controller.clone(), new_ports);
+                }
+            };
         }
     }
     for (controller, ports) in controller_ports.iter_mut() {
-        if let Some(controller_iface) = iface_states.get_mut(controller) {
-            if let Some(ref mut bridge_info) = controller_iface.bridge {
-                ports.sort();
-                bridge_info.ports.clone_from(ports);
-            }
+        if let Some(controller_iface) = iface_states.get_mut(controller)
+            && let Some(ref mut bridge_info) = controller_iface.bridge
+        {
+            ports.sort();
+            bridge_info.ports.clone_from(ports);
         }
     }
 }
@@ -412,10 +412,10 @@ fn convert_back_port_index_to_name(iface_states: &mut HashMap<String, Iface>) {
         }
         if let Some(ref mut port_info) = iface.bridge_port {
             let index = &port_info.backup_port;
-            if !index.is_empty() {
-                if let Some(iface_name) = index_to_name.get(index) {
-                    port_info.backup_port = iface_name.into();
-                }
+            if !index.is_empty()
+                && let Some(iface_name) = index_to_name.get(index)
+            {
+                port_info.backup_port = iface_name.into();
             }
         }
     }

--- a/src/lib/query/bridge_vlan.rs
+++ b/src/lib/query/bridge_vlan.rs
@@ -35,13 +35,13 @@ pub(crate) fn parse_bridge_vlan_info(
                 None => port_info.vlans = Some(cur_vlans),
             };
         }
-    } else if iface_state.iface_type == IfaceType::Bridge {
-        if let Some(br_conf) = iface_state.bridge.as_mut() {
-            let br_vlan = br_conf.vlans.get_or_insert(Vec::new());
-            // It's the VLAN of the bridge itself
-            if let Some(cur_vlans) = parse_af_spec_bridge_info(nlas)? {
-                br_vlan.extend(cur_vlans);
-            }
+    } else if iface_state.iface_type == IfaceType::Bridge
+        && let Some(br_conf) = iface_state.bridge.as_mut()
+    {
+        let br_vlan = br_conf.vlans.get_or_insert(Vec::new());
+        // It's the VLAN of the bridge itself
+        if let Some(cur_vlans) = parse_af_spec_bridge_info(nlas)? {
+            br_vlan.extend(cur_vlans);
         }
     }
     Ok(())
@@ -53,10 +53,10 @@ fn parse_af_spec_bridge_info(
     let mut vlans = Vec::new();
 
     for nla in nlas {
-        if let AfSpecBridge::VlanInfo(nla_vlan_info) = nla {
-            if let Some(v) = parse_vlan_info(nla_vlan_info)? {
-                vlans.push(v);
-            }
+        if let AfSpecBridge::VlanInfo(nla_vlan_info) = nla
+            && let Some(v) = parse_vlan_info(nla_vlan_info)?
+        {
+            vlans.push(v);
         }
     }
 

--- a/src/lib/query/iface.rs
+++ b/src/lib/query/iface.rs
@@ -534,10 +534,9 @@ pub(crate) fn parse_nl_msg_to_iface(
         } else if let LinkAttribute::VfInfoList(nlas) = nla {
             if let Ok(info) =
                 get_sriov_info(&iface_state.name, nlas, &link_layer_type)
+                && sriov_is_enabled(&iface_state.name)
             {
-                if sriov_is_enabled(&iface_state.name) {
-                    iface_state.sriov = Some(info);
-                }
+                iface_state.sriov = Some(info);
             }
         } else if let LinkAttribute::LinkNetNsId(id) = nla {
             iface_state.link_netnsid = Some(*id);
@@ -547,20 +546,20 @@ pub(crate) fn parse_nl_msg_to_iface(
             // Place holder for paring more Nla
         }
     }
-    if let Some(ref mut vlan_info) = iface_state.vlan {
-        if let Some(base_iface_index) = link {
-            vlan_info.base_iface = format!("{base_iface_index}");
-        }
+    if let Some(ref mut vlan_info) = iface_state.vlan
+        && let Some(base_iface_index) = link
+    {
+        vlan_info.base_iface = format!("{base_iface_index}");
     }
-    if let Some(ref mut ib_info) = iface_state.ipoib {
-        if let Some(base_iface_index) = link {
-            ib_info.base_iface = Some(format!("{base_iface_index}"));
-        }
+    if let Some(ref mut ib_info) = iface_state.ipoib
+        && let Some(base_iface_index) = link
+    {
+        ib_info.base_iface = Some(format!("{base_iface_index}"));
     }
-    if let Some(ref mut macsec_info) = iface_state.macsec {
-        if let Some(base_iface_index) = link {
-            macsec_info.base_iface = Some(format!("{base_iface_index}"));
-        }
+    if let Some(ref mut macsec_info) = iface_state.macsec
+        && let Some(base_iface_index) = link
+    {
+        macsec_info.base_iface = Some(format!("{base_iface_index}"));
     }
     if let Some(iface_index) = link {
         match iface_state.iface_type {
@@ -667,10 +666,9 @@ pub(crate) async fn resolve_iface_index(
     while let Some(nl_msg) = links.try_next().await? {
         if let Some((cur_iface_name, iface_index)) =
             parse_nl_msg_to_name_and_index(&nl_msg)
+            && cur_iface_name == iface_name
         {
-            if cur_iface_name == iface_name {
-                return Ok(iface_index);
-            }
+            return Ok(iface_index);
         }
     }
     Err(NisporError::new(

--- a/src/lib/query/inter_ifaces.rs
+++ b/src/lib/query/inter_ifaces.rs
@@ -65,13 +65,13 @@ pub(crate) async fn get_ifaces_with_handle(
         .and_then(|name| iface_states.get(name))
         .map(|i| i.index);
 
-    if iface_index.is_none() {
-        if let Some(iface_name) = filter.iface_name.as_ref() {
-            return Err(NisporError::invalid_argument(format!(
-                "Interface {} not found",
-                iface_name,
-            )));
-        }
+    if iface_index.is_none()
+        && let Some(iface_name) = filter.iface_name.as_ref()
+    {
+        return Err(NisporError::invalid_argument(format!(
+            "Interface {} not found",
+            iface_name,
+        )));
     }
 
     if filter.include_ip_address || filter.include_mptcp {
@@ -172,10 +172,10 @@ fn controller_iface_index_to_name(iface_states: &mut HashMap<String, Iface>) {
         index_to_name.insert(format!("{}", iface.index), iface.name.clone());
     }
     for iface in iface_states.values_mut() {
-        if let Some(controller) = &iface.controller {
-            if let Some(name) = index_to_name.get(controller) {
-                iface.controller = Some(name.to_string());
-            }
+        if let Some(controller) = &iface.controller
+            && let Some(name) = index_to_name.get(controller)
+        {
+            iface.controller = Some(name.to_string());
         }
     }
 }

--- a/src/lib/query/ipoib.rs
+++ b/src/lib/query/ipoib.rs
@@ -85,14 +85,13 @@ fn convert_base_iface_index_to_name(iface_states: &mut HashMap<String, Iface>) {
         if iface.iface_type != IfaceType::Ipoib {
             continue;
         }
-        if let Some(ref mut ib_info) = iface.ipoib {
-            if let Some(base_iface_name) = &ib_info
+        if let Some(ref mut ib_info) = iface.ipoib
+            && let Some(base_iface_name) = &ib_info
                 .base_iface
                 .as_ref()
                 .and_then(|i| index_to_name.get(i))
-            {
-                ib_info.base_iface = Some(base_iface_name.to_string());
-            }
+        {
+            ib_info.base_iface = Some(base_iface_name.to_string());
         }
     }
 }

--- a/src/lib/query/iptunnel.rs
+++ b/src/lib/query/iptunnel.rs
@@ -269,12 +269,11 @@ fn fill_port_iface_names(iface_states: &mut HashMap<String, Iface>) {
     }
 
     for iface in iface_states.values_mut() {
-        if let Some(tun) = iface.ip_tunnel.as_mut() {
-            if let Some(parent_iface_name) =
+        if let Some(tun) = iface.ip_tunnel.as_mut()
+            && let Some(parent_iface_name) =
                 index_to_name.get(&tun._parent_ifindex.unwrap_or_default())
-            {
-                tun.parent = Some(parent_iface_name.to_string());
-            }
+        {
+            tun.parent = Some(parent_iface_name.to_string());
         }
     }
 }

--- a/src/lib/query/ipvlan.rs
+++ b/src/lib/query/ipvlan.rs
@@ -89,10 +89,10 @@ fn convert_base_iface_index_to_name(iface_states: &mut HashMap<String, Iface>) {
         if iface.iface_type != IfaceType::IpVlan {
             continue;
         }
-        if let Some(ref mut info) = iface.ip_vlan {
-            if let Some(base_iface_name) = index_to_name.get(&info.base_iface) {
-                info.base_iface.clone_from(base_iface_name);
-            }
+        if let Some(ref mut info) = iface.ip_vlan
+            && let Some(base_iface_name) = index_to_name.get(&info.base_iface)
+        {
+            info.base_iface.clone_from(base_iface_name);
         }
     }
 }

--- a/src/lib/query/mac_vlan.rs
+++ b/src/lib/query/mac_vlan.rs
@@ -121,10 +121,10 @@ fn convert_base_iface_index_to_name(iface_states: &mut HashMap<String, Iface>) {
             if let Some(base_iface_name) = index_to_name.get(&info.base_iface) {
                 info.base_iface.clone_from(base_iface_name);
             }
-        } else if let Some(ref mut info) = iface.mac_vtap {
-            if let Some(base_iface_name) = index_to_name.get(&info.base_iface) {
-                info.base_iface.clone_from(base_iface_name);
-            }
+        } else if let Some(ref mut info) = iface.mac_vtap
+            && let Some(base_iface_name) = index_to_name.get(&info.base_iface)
+        {
+            info.base_iface.clone_from(base_iface_name);
         }
     }
 }

--- a/src/lib/query/macsec.rs
+++ b/src/lib/query/macsec.rs
@@ -188,14 +188,13 @@ fn convert_base_iface_index_to_name(iface_states: &mut HashMap<String, Iface>) {
         if iface.iface_type != IfaceType::MacSec {
             continue;
         }
-        if let Some(ref mut macsec_info) = iface.macsec {
-            if let Some(base_iface_name) = &macsec_info
+        if let Some(ref mut macsec_info) = iface.macsec
+            && let Some(base_iface_name) = &macsec_info
                 .base_iface
                 .as_ref()
                 .and_then(|i| index_to_name.get(i))
-            {
-                macsec_info.base_iface = Some(base_iface_name.to_string());
-            }
+        {
+            macsec_info.base_iface = Some(base_iface_name.to_string());
         }
     }
 }

--- a/src/lib/query/pci.rs
+++ b/src/lib/query/pci.rs
@@ -108,10 +108,9 @@ impl Iface {
                 .as_deref()
                 .and_then(Path::file_name)
                 .and_then(std::ffi::OsStr::to_str)
+            && let Ok(pci_addr) = PciAddress::from_str(dev_path)
         {
-            if let Ok(pci_addr) = PciAddress::from_str(dev_path) {
-                self.pci_address = Some(pci_addr);
-            }
+            self.pci_address = Some(pci_addr);
         }
     }
 }

--- a/src/lib/query/route.rs
+++ b/src/lib/query/route.rs
@@ -476,21 +476,19 @@ pub(crate) async fn get_routes(
         ifindex_to_name.insert(format!("{index}"), name.to_string());
     }
 
-    if let Some(filter) = filter {
-        if !filter.is_empty() {
-            if let Err(e) = connection
-                .socket_mut()
-                .socket_mut()
-                .set_netlink_get_strict_chk(true)
-            {
-                log::warn!(
-                    "Failed to set kernel space route filter: {e}, falling \
-                     back to user space route filtering which would lead to \
-                     performance penalty"
-                );
-                has_kernel_filter = false;
-            }
-        }
+    if let Some(filter) = filter
+        && !filter.is_empty()
+        && let Err(e) = connection
+            .socket_mut()
+            .socket_mut()
+            .set_netlink_get_strict_chk(true)
+    {
+        log::warn!(
+            "Failed to set kernel space route filter: {e}, falling back to \
+             user space route filtering which would lead to performance \
+             penalty"
+        );
+        has_kernel_filter = false;
     }
 
     tokio::spawn(connection);
@@ -501,24 +499,24 @@ pub(crate) async fn get_routes(
             IpVersion::V6 => RouteMessageBuilder::<Ipv6Addr>::new().build(),
         };
         let mut rt_handle = handle.route().get(rt_msg);
-        if let Some(filter) = filter {
-            if has_kernel_filter {
-                apply_kernel_route_filter(
-                    &mut rt_handle,
-                    filter,
-                    iface_name2index,
-                )?;
-            }
+        if let Some(filter) = filter
+            && has_kernel_filter
+        {
+            apply_kernel_route_filter(
+                &mut rt_handle,
+                filter,
+                iface_name2index,
+            )?;
         }
 
         let mut links = rt_handle.execute();
         while let Some(rt_msg) = links.try_next().await? {
             let route = get_route(rt_msg, &ifindex_to_name)?;
             // User space filter is required for RT_SCOPE_UNIVERSE and etc
-            if let Some(filter) = filter {
-                if should_drop_by_filter(&route, filter, has_kernel_filter) {
-                    continue;
-                }
+            if let Some(filter) = filter
+                && should_drop_by_filter(&route, filter, has_kernel_filter)
+            {
+                continue;
             }
             routes.push(route);
         }

--- a/src/lib/query/sriov.rs
+++ b/src/lib/query/sriov.rs
@@ -241,10 +241,10 @@ fn read_folder(folder_path: &str) -> Vec<String> {
             }
         };
         let path = entry.path();
-        if let Ok(content) = path.strip_prefix(folder_path) {
-            if let Some(content_str) = content.to_str() {
-                folder_contents.push(content_str.to_string());
-            }
+        if let Ok(content) = path.strip_prefix(folder_path)
+            && let Some(content_str) = content.to_str()
+        {
+            folder_contents.push(content_str.to_string());
         }
     }
     folder_contents

--- a/src/lib/query/veth.rs
+++ b/src/lib/query/veth.rs
@@ -31,12 +31,12 @@ pub(crate) fn veth_iface_tidy_up(iface_states: &mut HashMap<String, Iface>) {
             continue;
         }
 
-        if let Some(VethInfo { peer }) = &iface.veth {
-            if let Some(peer_iface_name) = index_to_name.get(peer) {
-                iface.veth = Some(VethInfo {
-                    peer: peer_iface_name.clone(),
-                })
-            }
+        if let Some(VethInfo { peer }) = &iface.veth
+            && let Some(peer_iface_name) = index_to_name.get(peer)
+        {
+            iface.veth = Some(VethInfo {
+                peer: peer_iface_name.clone(),
+            })
         }
     }
 }

--- a/src/lib/query/vlan.rs
+++ b/src/lib/query/vlan.rs
@@ -140,12 +140,11 @@ fn convert_base_iface_index_to_name(iface_states: &mut HashMap<String, Iface>) {
         if iface.iface_type != IfaceType::Vlan {
             continue;
         }
-        if let Some(ref mut vlan_info) = iface.vlan {
-            if let Some(base_iface_name) =
+        if let Some(ref mut vlan_info) = iface.vlan
+            && let Some(base_iface_name) =
                 index_to_name.get(&vlan_info.base_iface)
-            {
-                vlan_info.base_iface.clone_from(base_iface_name);
-            }
+        {
+            vlan_info.base_iface.clone_from(base_iface_name);
         }
     }
 }

--- a/src/lib/query/vrf.rs
+++ b/src/lib/query/vrf.rs
@@ -61,24 +61,24 @@ pub(crate) fn vrf_iface_tidy_up(iface_states: &mut HashMap<String, Iface>) {
 fn gen_port_list_of_controller(iface_states: &mut HashMap<String, Iface>) {
     let mut controller_ports: HashMap<String, Vec<String>> = HashMap::new();
     for iface in iface_states.values() {
-        if iface.controller_type == Some(ControllerType::Vrf) {
-            if let Some(controller) = &iface.controller {
-                match controller_ports.get_mut(controller) {
-                    Some(ports) => ports.push(iface.name.clone()),
-                    None => {
-                        let new_ports: Vec<String> = vec![iface.name.clone()];
-                        controller_ports.insert(controller.clone(), new_ports);
-                    }
-                };
-            }
+        if iface.controller_type == Some(ControllerType::Vrf)
+            && let Some(controller) = &iface.controller
+        {
+            match controller_ports.get_mut(controller) {
+                Some(ports) => ports.push(iface.name.clone()),
+                None => {
+                    let new_ports: Vec<String> = vec![iface.name.clone()];
+                    controller_ports.insert(controller.clone(), new_ports);
+                }
+            };
         }
     }
     for (controller, ports) in controller_ports.iter_mut() {
-        if let Some(controller_iface) = iface_states.get_mut(controller) {
-            if let Some(ref mut vrf_info) = controller_iface.vrf {
-                ports.sort();
-                vrf_info.ports.clone_from(ports);
-            }
+        if let Some(controller_iface) = iface_states.get_mut(controller)
+            && let Some(ref mut vrf_info) = controller_iface.vrf
+        {
+            ports.sort();
+            vrf_info.ports.clone_from(ports);
         }
     }
 }

--- a/src/lib/query/vxlan.rs
+++ b/src/lib/query/vxlan.rs
@@ -127,12 +127,11 @@ fn convert_base_iface_index_to_name(iface_states: &mut HashMap<String, Iface>) {
         if iface.iface_type != IfaceType::Vxlan {
             continue;
         }
-        if let Some(ref mut vxlan_info) = iface.vxlan {
-            if let Some(base_iface_name) =
+        if let Some(ref mut vxlan_info) = iface.vxlan
+            && let Some(base_iface_name) =
                 index_to_name.get(&vxlan_info.base_iface)
-            {
-                vxlan_info.base_iface.clone_from(base_iface_name);
-            }
+        {
+            vxlan_info.base_iface.clone_from(base_iface_name);
         }
     }
 }

--- a/src/lib/query/wifi.rs
+++ b/src/lib/query/wifi.rs
@@ -82,12 +82,11 @@ pub(crate) async fn fill_wifi_info(
                 _ => (),
             }
         }
-        if info.mode == WifiMode::Ap {
-            if let Some(Nl80211Attr::Mac(mac)) =
+        if info.mode == WifiMode::Ap
+            && let Some(Nl80211Attr::Mac(mac)) =
                 attrs.iter().find(|a| matches!(a, Nl80211Attr::Mac(_)))
-            {
-                info.bssid = parse_as_mac(mac.len(), mac.as_slice()).ok();
-            }
+        {
+            info.bssid = parse_as_mac(mac.len(), mac.as_slice()).ok();
         }
         iface.wifi = Some(info);
         iface.iface_type = IfaceType::Wifi;

--- a/src/lib/query/xfrm.rs
+++ b/src/lib/query/xfrm.rs
@@ -49,10 +49,10 @@ fn fill_port_iface_names(iface_states: &mut HashMap<String, Iface>) {
         .values_mut()
         .filter(|i| i.iface_type == IfaceType::Xfrm)
     {
-        if let Some(xfrm_info) = iface.xfrm.as_mut() {
-            if let Some(base_iface) = index_to_name.get(&xfrm_info.base_iface) {
-                xfrm_info.base_iface = base_iface.to_string();
-            }
+        if let Some(xfrm_info) = iface.xfrm.as_mut()
+            && let Some(base_iface) = index_to_name.get(&xfrm_info.base_iface)
+        {
+            xfrm_info.base_iface = base_iface.to_string();
         }
     }
 }


### PR DESCRIPTION
With Rust 1.88 and edition 2024, we can use let chain:

    https://doc.rust-lang.org/edition-guide/rust-2024/let-chains.html

which could decrease our indentation chains.