### PR TITLE
Support wireguard query and apply

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,4 @@ serde_json = "1.0.81"
 serde_yaml = "0.9"
 tokio = { version = "1.19.2", features = ["macros", "rt"] }
 wl-nl80211 = "0.4.0"
+nl-wireguard = { version = "0.1.0"}

--- a/src/cli/npc.rs
+++ b/src/cli/npc.rs
@@ -251,7 +251,7 @@ impl CliIfaceBrief {
                 alt_names: iface.alt_names.clone(),
             })
         }
-        ret.sort_by(|a, b| a.index.cmp(&b.index));
+        ret.sort_by_key(|a| a.index);
         ret
     }
 }

--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -26,6 +26,7 @@ futures = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
 wl-nl80211 = { workspace = true }
+nl-wireguard = { workspace = true }
 
 [dev-dependencies]
 serde_yaml = { workspace = true }

--- a/src/lib/conf/iface.rs
+++ b/src/lib/conf/iface.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use rtnetlink::{LinkUnspec, packet_route::link::LinkMessage};
+use rtnetlink::{
+    LinkMessageBuilder, LinkUnspec,
+    packet_route::link::{InfoKind, LinkMessage},
+};
 use serde::{Deserialize, Serialize};
 
 use super::{
@@ -10,7 +13,7 @@ use super::{
 use crate::{
     AltNameConf, BondConf, BondPortConf, BridgeConf, BridgePortConf, DummyConf,
     ErrorKind, Iface, IfaceState, IfaceType, IpConf, NetStateIfaceFilter,
-    NisporError, VethConf, VlanConf,
+    NisporError, VethConf, VlanConf, WireguardConf,
 };
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
@@ -37,6 +40,7 @@ pub struct IfaceConf {
     pub bond: Option<BondConf>,
     pub bond_port: Option<BondPortConf>,
     pub bridge_port: Option<BridgePortConf>,
+    pub wireguard: Option<WireguardConf>,
 }
 
 impl IfaceConf {
@@ -180,6 +184,28 @@ async fn gen_link_msg(
                 apply_base_link_changes(
                     handle,
                     DummyConf::gen_link_msg_builder(des_iface),
+                    des_iface,
+                    cur_iface,
+                )
+                .await?
+            } else {
+                apply_base_link_changes(
+                    handle,
+                    LinkUnspec::new_with_name(des_iface.name.as_str()),
+                    des_iface,
+                    cur_iface,
+                )
+                .await?
+            }
+        }
+        Some(IfaceType::Wireguard) => {
+            if cur_iface.is_none() {
+                apply_base_link_changes(
+                    handle,
+                    LinkMessageBuilder::<LinkUnspec>::new_with_info_kind(
+                        InfoKind::Wireguard,
+                    )
+                    .name(des_iface.name.clone()),
                     des_iface,
                     cur_iface,
                 )

--- a/src/lib/conf/inter_ifaces.rs
+++ b/src/lib/conf/inter_ifaces.rs
@@ -2,8 +2,8 @@
 
 use rtnetlink::new_connection;
 
-use super::iface::apply_iface_conf;
-use crate::{IfaceConf, NisporError};
+use super::{iface::apply_iface_conf, wireguard::apply_wg_conf};
+use crate::{IfaceConf, IfaceType, NisporError};
 
 pub(crate) async fn apply_ifaces_conf(
     des_ifaces: &[IfaceConf],
@@ -13,5 +13,20 @@ pub(crate) async fn apply_ifaces_conf(
     for des_iface in des_ifaces {
         apply_iface_conf(&handle, des_iface).await?;
     }
+
+    let wg_ifaces: Vec<_> = des_ifaces
+        .iter()
+        .filter(|i| i.iface_type == Some(IfaceType::Wireguard))
+        .collect();
+
+    if !wg_ifaces.is_empty() {
+        let (wg_connection, mut wg_handle, _) = nl_wireguard::new_connection()?;
+        tokio::spawn(wg_connection);
+
+        for des_iface in wg_ifaces {
+            apply_wg_conf(&mut wg_handle, des_iface).await?;
+        }
+    }
+
     Ok(())
 }

--- a/src/lib/conf/mod.rs
+++ b/src/lib/conf/mod.rs
@@ -14,6 +14,7 @@ mod ip;
 mod route;
 mod veth;
 mod vlan;
+mod wireguard;
 
 pub use self::{
     alt_name::AltNameConf,
@@ -27,6 +28,7 @@ pub use self::{
     route::RouteConf,
     veth::VethConf,
     vlan::VlanConf,
+    wireguard::{WireguardConf, WireguardPeerConf},
 };
 pub(crate) use self::{
     inter_ifaces::apply_ifaces_conf, route::apply_routes_conf,

--- a/src/lib/conf/wireguard.rs
+++ b/src/lib/conf/wireguard.rs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::net::SocketAddr;
+
+use nl_wireguard::{WireguardHandle, WireguardParsed, WireguardPeerParsed};
+use serde::{Deserialize, Serialize};
+
+use crate::{IfaceConf, NisporError, WireguardIpAddress};
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+#[non_exhaustive]
+pub struct WireguardConf {
+    /// Base64 encoded private key
+    pub private_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub listen_port: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fwmark: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peers: Option<Vec<WireguardPeerConf>>,
+}
+
+impl From<&WireguardConf> for WireguardParsed {
+    fn from(conf: &WireguardConf) -> WireguardParsed {
+        let mut wg_conf = WireguardParsed::default();
+        wg_conf.private_key = conf.private_key.clone();
+        wg_conf.listen_port = conf.listen_port;
+        wg_conf.fwmark = conf.fwmark;
+        wg_conf.peers = conf
+            .peers
+            .as_ref()
+            .map(|peers| peers.iter().map(WireguardPeerParsed::from).collect());
+        wg_conf
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+#[non_exhaustive]
+pub struct WireguardPeerConf {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<SocketAddr>,
+    /// Base64 encoded public key
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub public_key: Option<String>,
+    /// Base64 encoded preshared key
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preshared_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub persistent_keepalive: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_ips: Option<Vec<WireguardIpAddress>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub protocol_version: Option<u32>,
+}
+
+impl From<&WireguardPeerConf> for WireguardPeerParsed {
+    fn from(peer_conf: &WireguardPeerConf) -> Self {
+        let mut wg_peer_conf = Self::default();
+        wg_peer_conf.endpoint = peer_conf.endpoint;
+        wg_peer_conf.public_key = peer_conf.public_key.clone();
+        wg_peer_conf.preshared_key = peer_conf.preshared_key.clone();
+        wg_peer_conf.persistent_keepalive = peer_conf.persistent_keepalive;
+        wg_peer_conf.protocol_version = peer_conf.protocol_version;
+        wg_peer_conf.allowed_ips = peer_conf.allowed_ips.as_ref().map(|ips| {
+            ips.iter()
+                .map(|ip| nl_wireguard::WireguardIpAddress::from(*ip))
+                .collect()
+        });
+        wg_peer_conf
+    }
+}
+
+pub(crate) async fn apply_wg_conf(
+    handle: &mut WireguardHandle,
+    iface: &IfaceConf,
+) -> Result<(), NisporError> {
+    if let Some(wg_conf) = iface.wireguard.as_ref() {
+        let mut conf = WireguardParsed::from(wg_conf);
+        conf.iface_name = Some(iface.name.to_string());
+        handle.set(conf).await?;
+    }
+
+    Ok(())
+}

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -159,3 +159,12 @@ impl From<wl_nl80211::Nl80211Error> for NisporError {
         }
     }
 }
+
+impl From<nl_wireguard::WireguardError> for NisporError {
+    fn from(e: nl_wireguard::WireguardError) -> Self {
+        NisporError {
+            kind: ErrorKind::NetlinkError,
+            msg: e.to_string(),
+        }
+    }
+}

--- a/src/lib/integ_tests/mod.rs
+++ b/src/lib/integ_tests/mod.rs
@@ -2,49 +2,27 @@
 
 mod utils;
 
-#[cfg(test)]
 mod alt_name;
-#[cfg(test)]
 mod base_info;
-#[cfg(test)]
 mod bond;
-#[cfg(test)]
 mod bridge;
-#[cfg(test)]
 mod bridge_vlan_filter;
-#[cfg(test)]
 mod dummy;
-#[cfg(test)]
 mod ethtool;
-#[cfg(test)]
 mod hsr;
-#[cfg(test)]
 mod ip;
-#[cfg(test)]
 mod ip_vlan;
-#[cfg(test)]
 mod iptunnel;
-#[cfg(test)]
 mod mac_vlan;
-#[cfg(test)]
 mod mac_vtap;
-#[cfg(test)]
 mod macsec;
-#[cfg(test)]
 mod route;
-#[cfg(test)]
 mod route_rule;
-#[cfg(test)]
 mod tap;
-#[cfg(test)]
 mod tun;
-#[cfg(test)]
 mod veth;
-#[cfg(test)]
 mod vlan;
-#[cfg(test)]
 mod vrf;
-#[cfg(test)]
 mod vxlan;
-#[cfg(test)]
+mod wireguard;
 mod xfrm;

--- a/src/lib/integ_tests/wireguard.rs
+++ b/src/lib/integ_tests/wireguard.rs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::panic;
+
+use pretty_assertions::assert_eq;
+
+use super::utils::assert_value_match;
+use crate::{NetConf, NetState};
+
+const IFACE_NAME: &str = "wg_nispor_test";
+
+const WIREGUARD_CREATE_YAML: &str = r#"
+interfaces:
+  - name: wg_nispor_test
+    type: wireguard
+    wireguard:
+      private-key: "6LTHiAM4vgKEgi5vm30f/EBIEWFDmySkTc9EWCcIqEs="
+      peers:
+        - endpoint: 192.0.2.254:9999
+          public-key: "8bdQrVLqiw3ZoHCucNh1YfH0iCWuyStniRr8t7H24Fk="
+          preshared-key: "iDMSzj8ZMpdbVWuVjOm/f/Zzl7s1WOdhlJtdV0YXHEU="
+          persistent-keepalive: 360
+          allowed-ips:
+            - address: 0.0.0.0
+              prefix-length: 0
+            - address: "::"
+              prefix-length: 0
+"#;
+
+const WIREGUARD_CHANGE_YAML: &str = r#"
+interfaces:
+  - name: wg_nispor_test
+    type: wireguard
+    wireguard:
+      private-key: "6LTHiAM4vgKEgi5vm30f/EBIEWFDmySkTc9EWCcIqEs="
+      peers:
+        - endpoint: 192.0.2.253:9999
+          public-key: "8bdQrVLqiw3ZoHCucNh1YfH0iCWuyStniRr8t7H24Fk="
+          preshared-key: "iDMSzj8ZMpdbVWuVjOm/f/Zzl7s1WOdhlJtdV0YXHEU="
+          persistent-keepalive: 0
+          allowed-ips:
+            - address: 0.0.0.0
+              prefix-length: 0
+            - address: "::"
+              prefix-length: 0
+"#;
+
+const WIREGUARD_DELETE_YML: &str = r#"---
+interfaces:
+  - name: wg_nispor_test
+    type: wireguard
+    state: absent
+"#;
+
+const EXPECTED_WIREGUARD_INFO: &str = r#"---
+public-key: "JKossUAjywXuJ2YVcaeD6PaHs+afPmIthDuqEVlspwA="
+peers:
+- endpoint: 192.0.2.254:9999
+  public-key: "8bdQrVLqiw3ZoHCucNh1YfH0iCWuyStniRr8t7H24Fk="
+  has-preshared-key: true
+  persistent-keepalive: 360
+  allowed-ips:
+    - address: 0.0.0.0
+      prefix-length: 0
+    - address: "::"
+      prefix-length: 0
+"#;
+
+const EXPECTED_CHANGED_WIREGUARD_INFO: &str = r#"---
+public-key: "JKossUAjywXuJ2YVcaeD6PaHs+afPmIthDuqEVlspwA="
+peers:
+- endpoint: 192.0.2.253:9999
+  public-key: "8bdQrVLqiw3ZoHCucNh1YfH0iCWuyStniRr8t7H24Fk="
+  has-preshared-key: true
+  persistent-keepalive: 0
+  allowed-ips:
+    - address: 0.0.0.0
+      prefix-length: 0
+    - address: "::"
+      prefix-length: 0
+"#;
+
+#[test]
+fn test_create_change_and_delete_wireguard() {
+    with_wireguard_iface(|| {
+        let state = NetState::retrieve().unwrap();
+        let iface = &state.ifaces[IFACE_NAME];
+        assert_eq!(iface.iface_type, crate::IfaceType::Wireguard);
+        assert_value_match(EXPECTED_WIREGUARD_INFO, &iface.wireguard);
+
+        let net_conf: NetConf =
+            serde_yaml::from_str(WIREGUARD_CHANGE_YAML).unwrap();
+        net_conf.apply().unwrap();
+
+        let state = NetState::retrieve().unwrap();
+        let iface = &state.ifaces[IFACE_NAME];
+        assert_eq!(iface.iface_type, crate::IfaceType::Wireguard);
+        assert_value_match(EXPECTED_CHANGED_WIREGUARD_INFO, &iface.wireguard);
+    });
+}
+
+fn with_wireguard_iface<T>(test: T)
+where
+    T: FnOnce() + panic::UnwindSafe,
+{
+    let net_conf: NetConf =
+        serde_yaml::from_str(WIREGUARD_CREATE_YAML).unwrap();
+    net_conf.apply().unwrap();
+
+    let result = panic::catch_unwind(|| {
+        test();
+    });
+
+    let net_conf: NetConf = serde_yaml::from_str(WIREGUARD_DELETE_YML).unwrap();
+    net_conf.apply().unwrap();
+
+    assert!(result.is_ok())
+}

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -15,7 +15,7 @@ pub use crate::{
     conf::{
         AltNameConf, BondConf, BondPortConf, BridgeConf, BridgePortConf,
         DummyConf, IfaceConf, IpAddrConf, IpConf, RouteConf, VethConf,
-        VlanConf,
+        VlanConf, WireguardConf, WireguardPeerConf,
     },
     error::{ErrorKind, NisporError},
     filter::{
@@ -44,6 +44,7 @@ pub use crate::{
         RouteType, RuleAction, SriovInfo, TunInfo, TunMode, TunnelEncapFlag,
         TunnelEncapType, VethInfo, VfInfo, VfLinkState, VfState, VlanInfo,
         VlanProtocol, VlanQosMapping, VrfInfo, VrfPortInfo, VxlanInfo,
-        WifiInfo, XfrmInfo,
+        WifiInfo, WireguardInfo, WireguardIpAddress, WireguardPeerInfo,
+        XfrmInfo,
     },
 };

--- a/src/lib/query/iface.rs
+++ b/src/lib/query/iface.rs
@@ -34,7 +34,7 @@ use crate::{
     HsrInfo, IpTunnelInfo, IpVlanInfo, IpoibInfo, Ipv4Info, Ipv6Info,
     MacSecInfo, MacVlanInfo, MacVtapInfo, MptcpAddress, NisporError,
     PciAddress, SriovInfo, TunInfo, VethInfo, VfInfo, VlanInfo, VrfInfo,
-    VrfPortInfo, VxlanInfo, WifiInfo, XfrmInfo,
+    VrfPortInfo, VxlanInfo, WifiInfo, WireguardInfo, XfrmInfo,
 };
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
@@ -67,6 +67,7 @@ pub enum IfaceType {
     Hsr,
     Xfrm,
     Wifi,
+    Wireguard,
     Other(String),
 }
 
@@ -98,6 +99,7 @@ impl std::fmt::Display for IfaceType {
                 Self::Hsr => "hsr",
                 Self::Xfrm => "xfrm",
                 Self::Wifi => "wifi",
+                Self::Wireguard => "wireguard",
                 Self::Other(s) => s,
             }
         )
@@ -309,6 +311,8 @@ pub struct Iface {
     pub ip_vlan: Option<IpVlanInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wifi: Option<WifiInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wireguard: Option<WireguardInfo>,
 }
 
 // TODO: impl From Iface to IfaceConf
@@ -399,6 +403,7 @@ pub(crate) fn parse_nl_msg_to_iface(
                         InfoKind::MacSec => IfaceType::MacSec,
                         InfoKind::Hsr => IfaceType::Hsr,
                         InfoKind::Xfrm => IfaceType::Xfrm,
+                        InfoKind::Wireguard => IfaceType::Wireguard,
                         InfoKind::Other(s) => match s.as_ref() {
                             "openvswitch" => IfaceType::OpenvSwitch,
                             _ => IfaceType::Other(s.to_lowercase()),

--- a/src/lib/query/inter_ifaces.rs
+++ b/src/lib/query/inter_ifaces.rs
@@ -29,6 +29,7 @@ use super::{
     vrf::vrf_iface_tidy_up,
     vxlan::vxlan_iface_tidy_up,
     wifi::fill_wifi_info,
+    wireguard::fill_wireguard,
     xfrm::xfrm_iface_tidy_up,
 };
 use crate::{EthtoolInfo, Iface, NetStateIfaceFilter, NisporError};
@@ -134,6 +135,8 @@ pub(crate) async fn get_ifaces_with_handle(
     if let Err(e) = fill_wifi_info(&mut iface_states).await {
         log::warn!("Failed to query WIFI information {e}");
     }
+
+    fill_wireguard(&mut iface_states).await?;
 
     tidy_up(&mut iface_states);
     Ok(iface_states)

--- a/src/lib/query/mod.rs
+++ b/src/lib/query/mod.rs
@@ -9,6 +9,7 @@ mod iptunnel;
 mod mptcp;
 mod pci;
 mod wifi;
+mod wireguard;
 mod xfrm;
 // Disable `needless_pass_by_ref_mut` check due to upstream issue:
 // https://github.com/rust-netlink/ethtool/issues/12
@@ -75,6 +76,7 @@ pub use self::{
     vrf::{VrfInfo, VrfPortInfo},
     vxlan::VxlanInfo,
     wifi::WifiInfo,
+    wireguard::{WireguardInfo, WireguardIpAddress, WireguardPeerInfo},
     xfrm::XfrmInfo,
 };
 pub(crate) use self::{

--- a/src/lib/query/wireguard.rs
+++ b/src/lib/query/wireguard.rs
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::HashMap,
+    net::IpAddr,
+    time::{Duration, SystemTime},
+};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{Iface, IfaceType, NisporError};
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+#[non_exhaustive]
+pub struct WireguardInfo {
+    /// Base64 encoded public key
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub public_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub listen_port: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fwmark: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peers: Option<Vec<WireguardPeerInfo>>,
+}
+
+impl From<nl_wireguard::WireguardParsed> for WireguardInfo {
+    fn from(nl_wg: nl_wireguard::WireguardParsed) -> Self {
+        Self {
+            public_key: nl_wg.public_key,
+            listen_port: nl_wg.listen_port,
+            fwmark: nl_wg.fwmark,
+            peers: nl_wg.peers.map(|nl_peers| {
+                nl_peers.into_iter().map(WireguardPeerInfo::from).collect()
+            }),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+#[non_exhaustive]
+pub struct WireguardPeerInfo {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    /// Base64 encoded public key
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub public_key: Option<String>,
+    /// Whether has pershared key configure or not
+    pub has_preshared_key: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub persistent_keepalive: Option<u16>,
+    /// Last handshake in a format of `32 seconds ago`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_handshake: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rx_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tx_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_ips: Option<Vec<WireguardIpAddress>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub protocol_version: Option<u32>,
+}
+
+impl From<nl_wireguard::WireguardPeerParsed> for WireguardPeerInfo {
+    fn from(nl_peer: nl_wireguard::WireguardPeerParsed) -> Self {
+        Self {
+            endpoint: nl_peer.endpoint.map(|e| e.to_string()),
+            public_key: nl_peer.public_key,
+            has_preshared_key: nl_peer.preshared_key.is_some(),
+            persistent_keepalive: nl_peer.persistent_keepalive,
+            last_handshake: nl_peer
+                .last_handshake
+                .and_then(last_handshake_to_human_str),
+            rx_bytes: nl_peer.rx_bytes,
+            tx_bytes: nl_peer.tx_bytes,
+            allowed_ips: nl_peer.allowed_ips.map(|nl_ips| {
+                nl_ips.into_iter().map(WireguardIpAddress::from).collect()
+            }),
+            protocol_version: nl_peer.protocol_version,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Copy)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct WireguardIpAddress {
+    pub address: IpAddr,
+    pub prefix_length: u8,
+}
+
+impl From<nl_wireguard::WireguardIpAddress> for WireguardIpAddress {
+    fn from(nl_ip: nl_wireguard::WireguardIpAddress) -> Self {
+        Self {
+            address: nl_ip.ip_addr,
+            prefix_length: nl_ip.prefix_length,
+        }
+    }
+}
+
+impl From<WireguardIpAddress> for nl_wireguard::WireguardIpAddress {
+    fn from(ip: WireguardIpAddress) -> Self {
+        Self {
+            ip_addr: ip.address,
+            prefix_length: ip.prefix_length,
+        }
+    }
+}
+
+pub(crate) async fn fill_wireguard(
+    ifaces: &mut HashMap<String, Iface>,
+) -> Result<(), NisporError> {
+    if !ifaces
+        .values()
+        .any(|i| i.iface_type == IfaceType::Wireguard)
+    {
+        return Ok(());
+    }
+
+    let (connection, mut handle, _) = nl_wireguard::new_connection()?;
+    tokio::spawn(connection);
+
+    for iface in ifaces
+        .values_mut()
+        .filter(|i| i.iface_type == IfaceType::Wireguard)
+    {
+        match handle.get_by_name(iface.name.as_str()).await {
+            Ok(nl_wg) => iface.wireguard = Some(nl_wg.into()),
+            Err(e) => {
+                // Mostly permission error because querying wireguard info need
+                // root access.
+                log::debug!("Failed to fill wireguard information: {e}");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn last_handshake_to_human_str(last_handshake: Duration) -> Option<String> {
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .ok()?;
+
+    if last_handshake > now {
+        None
+    } else {
+        Some(format!("{} seconds ago", (now - last_handshake).as_secs()))
+    }
+}


### PR DESCRIPTION
Example YAML of query:

```rust
interfaces:
- name: wg_nispor_test
  type: wireguard
  wireguard:
    public-key: "JKossUAjywXuJ2YVcaeD6PaHs+afPmIthDuqEVlspwA="
    peers:
    - endpoint: 192.0.2.254:9999
      public-key: "8bdQrVLqiw3ZoHCucNh1YfH0iCWuyStniRr8t7H24Fk="
      has-preshared-key: true
      persistent-keepalive: 360
      allowed-ips:
        - address: 0.0.0.0
          prefix-length: 0
        - address: "::"
          prefix-length: 0
```

Example YAML of apply:

```rust
interfaces:
- name: wg_nispor_test
  type: wireguard
  wireguard:
    private-key: "6LTHiAM4vgKEgi5vm30f/EBIEWFDmySkTc9EWCcIqEs="
    peers:
      - endpoint: 192.0.2.253:9999
        public-key: "8bdQrVLqiw3ZoHCucNh1YfH0iCWuyStniRr8t7H24Fk="
        preshared-key: "iDMSzj8ZMpdbVWuVjOm/f/Zzl7s1WOdhlJtdV0YXHEU="
        persistent-keepalive: 0
        allowed-ips:
          - address: 0.0.0.0
            prefix-length: 0
          - address: "::"
            prefix-length: 0
```

Integration test case included.