### PR TITLE
Prefer `LinkInfo::Kind` as interface type

### DIFF
--- a/src/lib/conf/iface.rs
+++ b/src/lib/conf/iface.rs
@@ -179,46 +179,26 @@ async fn gen_link_msg(
             )
             .await?
         }
-        Some(IfaceType::Dummy) => {
-            if cur_iface.is_none() {
-                apply_base_link_changes(
-                    handle,
-                    DummyConf::gen_link_msg_builder(des_iface),
-                    des_iface,
-                    cur_iface,
-                )
-                .await?
-            } else {
-                apply_base_link_changes(
-                    handle,
-                    LinkUnspec::new_with_name(des_iface.name.as_str()),
-                    des_iface,
-                    cur_iface,
-                )
-                .await?
-            }
+        Some(IfaceType::Dummy) if cur_iface.is_none() => {
+            apply_base_link_changes(
+                handle,
+                DummyConf::gen_link_msg_builder(des_iface),
+                des_iface,
+                cur_iface,
+            )
+            .await?
         }
-        Some(IfaceType::Wireguard) => {
-            if cur_iface.is_none() {
-                apply_base_link_changes(
-                    handle,
-                    LinkMessageBuilder::<LinkUnspec>::new_with_info_kind(
-                        InfoKind::Wireguard,
-                    )
-                    .name(des_iface.name.clone()),
-                    des_iface,
-                    cur_iface,
+        Some(IfaceType::Wireguard) if cur_iface.is_none() => {
+            apply_base_link_changes(
+                handle,
+                LinkMessageBuilder::<LinkUnspec>::new_with_info_kind(
+                    InfoKind::Wireguard,
                 )
-                .await?
-            } else {
-                apply_base_link_changes(
-                    handle,
-                    LinkUnspec::new_with_name(des_iface.name.as_str()),
-                    des_iface,
-                    cur_iface,
-                )
-                .await?
-            }
+                .name(des_iface.name.clone()),
+                des_iface,
+                cur_iface,
+            )
+            .await?
         }
         _ => {
             apply_base_link_changes(

--- a/src/lib/integ_tests/gre.rs
+++ b/src/lib/integ_tests/gre.rs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use pretty_assertions::assert_eq;
+
+const IFACE_NAME: &str = "gretap99";
+
+// This test ensures gretap interfaces are correctly identified as
+// Other("gretap") rather than being treated as ethernet.
+#[test]
+fn test_gretap_iface_type() {
+    with_gretap(|| {
+        let state = crate::NetState::retrieve()
+            .expect("Failed to retrieve network state");
+        let iface = &state.ifaces[IFACE_NAME];
+
+        assert_eq!(iface.iface_type, crate::IfaceType::Other("gretap".into()));
+    })
+}
+
+fn with_gretap<T>(test: T)
+where
+    T: FnOnce() + std::panic::UnwindSafe,
+{
+    super::utils::set_network_environment("gretap");
+
+    let result = std::panic::catch_unwind(|| {
+        test();
+    });
+
+    super::utils::clear_network_environment();
+    if let Err(e) = result {
+        std::panic::resume_unwind(e);
+    }
+}

--- a/src/lib/integ_tests/mod.rs
+++ b/src/lib/integ_tests/mod.rs
@@ -9,6 +9,7 @@ mod bridge;
 mod bridge_vlan_filter;
 mod dummy;
 mod ethtool;
+mod gre;
 mod hsr;
 mod ip;
 mod ip_vlan;

--- a/src/lib/query/iface.rs
+++ b/src/lib/query/iface.rs
@@ -408,22 +408,15 @@ pub(crate) fn parse_nl_msg_to_iface(
                             "openvswitch" => IfaceType::OpenvSwitch,
                             _ => IfaceType::Other(s.to_lowercase()),
                         },
-                        _ => IfaceType::Other(
-                            format!("{t:?}").as_str().to_lowercase(),
-                        ),
+                        _ => IfaceType::Other(format!("{t:?}").to_lowercase()),
                     };
-                    if let IfaceType::Other(_) = iface_type {
-                        /* We did not find an explicit link type. Instead
-                         * it's just "Other(_)". If
-                         * we already determined a link type
-                         * above (ethernet or infiniband), keep that one. */
-                        if !matches!(&link_layer_type, &IfaceType::Other(_)) {
-                            iface_state.iface_type = link_layer_type.clone();
-                        }
-                    } else {
-                        /* We found a better link type based on the kind. Use
-                         * it. */
-                        iface_state.iface_type = iface_type
+                    // Always prefer InfoKind unless link type is loopback or
+                    // infiniband.
+                    if !matches!(
+                        iface_state.iface_type,
+                        IfaceType::Loopback | IfaceType::Infiniband
+                    ) {
+                        iface_state.iface_type = iface_type;
                     }
                 }
             }

--- a/src/lib/query/mptcp.rs
+++ b/src/lib/query/mptcp.rs
@@ -199,10 +199,8 @@ fn mptcp_msg_to_nispor(
                     MptcpPathManagerAddressAttr::IfIndex(i) => {
                         ret.iface_index = Some(*i);
                     }
-                    MptcpPathManagerAddressAttr::Port(i) => {
-                        if *i != 0 {
-                            ret.port = Some(*i);
-                        }
+                    MptcpPathManagerAddressAttr::Port(i) if *i != 0 => {
+                        ret.port = Some(*i);
                     }
                     MptcpPathManagerAddressAttr::Id(i) => {
                         ret.id = Some(*i);

--- a/src/lib/query/wifi.rs
+++ b/src/lib/query/wifi.rs
@@ -166,10 +166,10 @@ pub(crate) async fn fill_wifi_info(
                             }
                         }
                     }
-                    Nl80211StationInfo::StationFlags(v) => {
-                        if v.set.contains(Nl80211StationFlags::Authorized) {
-                            authorized = true;
-                        }
+                    Nl80211StationInfo::StationFlags(v)
+                        if v.set.contains(Nl80211StationFlags::Authorized) =>
+                    {
+                        authorized = true;
                     }
                     Nl80211StationInfo::RxBitrate(rates) => {
                         for rate in rates {

--- a/tools/test_env
+++ b/tools/test_env
@@ -16,7 +16,7 @@ sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0 1>/dev/null
 if [ "CHK$1" == "CHK" ];then
     echo 'Need argument: bond, br, brv, vlan, dummy, vxlan, veth, vrf, sriov,'
     echo 'rm, route, rule, sim, mptcp, bgp, macsec, ipv6token, ipv6p2p, hsr,'
-    echo 'xfrm, ipvlan, ipip, sit, ip6ip6, ipip6'
+    echo 'xfrm, ipvlan, ipip, sit, ip6ip6, ipip6, gretap'
     exit 1
 fi
 
@@ -44,6 +44,7 @@ function clean_up {
     sudo ip link del macsec0
     sudo ip link del hsr0
     sudo ip link del xfrm1
+    sudo ip link del gretap99
     sudo ip rule del priority 999
     sudo ip -6 rule del priority 999
     sudo modprobe -r netdevsim
@@ -307,6 +308,9 @@ elif [ "CHK$1" == "CHKip6ip6" ];then
 elif [ "CHK$1" == "CHKipip6" ];then
     create_nics
     sudo ip -6 tunnel add ipip60 mode ipip6 local 2001:db8:f::1 remote 2001:db8:f::ffff ttl 42
+    sleep $LINK_WAIT_TIME
+elif [ "CHK$1" == "CHKgretap" ];then
+    sudo ip link add gretap99 type gretap local 192.0.2.1 remote 192.0.2.2
     sleep $LINK_WAIT_TIME
 elif [ "CHK$1" == "CHKrm" ];then
     clean_up 2>/dev/null


### PR DESCRIPTION
Current code will treat `gretap` interface as ethernet. To reproduce the
issue:

```bash
modprobe ip_gre
npc iface gretap0
```

To fix the issue, unless link layer is `loopback` or `infiniband`, we
should always prefer `LinkInfo::Kind` for interface type because kernel
always set link layer as `Ethernet` for most kind of interfaces.

Integration test case included.