### PR TITLE
release script: `cargo pkgid` require Cargo.lock file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=$(shell cargo pkgid nispor|cut -d@ -f2)
+VERSION=$(shell cargo update; cargo pkgid nispor|cut -d@ -f2)
 ROOT_DIR?=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 RUST_DEBUG_BIN_DIR=./target/debug
 RUST_RELEASE_BIN_DIR=./target/release

--- a/tools/upstream_release.sh
+++ b/tools/upstream_release.sh
@@ -25,6 +25,8 @@ CODE_BASE_DIR=$(readlink -f "$(dirname -- "$0")/..");
 
 cd $CODE_BASE_DIR;
 
+cargo update
+
 CUR_VERSION=$(cargo pkgid nispor|cut -d@ -f2)
 CUR_MAJOR_VERSION=$(echo $CUR_VERSION|cut -f1 -d.)
 CUR_MINOR_VERSION=$(echo $CUR_VERSION|cut -f2 -d.)


### PR DESCRIPTION
The `cargo pkgid` require existence of `Cargo.lock` file, hence run
`cargo update` before checking package version.