### PR TITLE
pci: Use `IFLA_PARENT_DEV_NAME` for PCI address

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ futures = "0.3.21"
 libc = "0.2.155"
 log = "0.4.17"
 mptcp-pm = "0.1.4"
-rtnetlink = "0.20.0"
+rtnetlink = "0.21.0"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 serde_yaml = "0.9"

--- a/src/lib/query/bond.rs
+++ b/src/lib/query/bond.rs
@@ -6,7 +6,8 @@ use std::{
 };
 
 use rtnetlink::packet_route::link::{
-    self, BondArpAllTargets as RtBondArpAllTargets,
+    self, BondAdSelect as RtBondAdSelect,
+    BondArpAllTargets as RtBondArpAllTargets,
     BondArpValidate as RtBondArpValidate, BondFailOverMac as RtBondFailOverMac,
     BondPrimaryReselect as RtBondPrimaryReselect,
     BondXmitHashPolicy as RtBondXmitHashPolicy, InfoBond, InfoBondPort,
@@ -392,10 +393,6 @@ impl From<BondLacpRate> for link::BondLacpRate {
     }
 }
 
-const BOND_AD_STABLE: u8 = 0;
-const BOND_AD_BANDWIDTH: u8 = 1;
-const BOND_AD_COUNT: u8 = 2;
-
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
@@ -406,24 +403,24 @@ pub enum BondAdSelect {
     Other(u8),
 }
 
-impl From<u8> for BondAdSelect {
-    fn from(d: u8) -> Self {
-        match d {
-            BOND_AD_STABLE => Self::Stable,
-            BOND_AD_BANDWIDTH => Self::Bandwidth,
-            BOND_AD_COUNT => Self::Count,
-            _ => Self::Other(d),
+impl From<RtBondAdSelect> for BondAdSelect {
+    fn from(v: RtBondAdSelect) -> Self {
+        match v {
+            RtBondAdSelect::Stable => Self::Stable,
+            RtBondAdSelect::Bandwidth => Self::Bandwidth,
+            RtBondAdSelect::Count => Self::Count,
+            _ => Self::Other(u8::from(v)),
         }
     }
 }
 
-impl From<BondAdSelect> for u8 {
-    fn from(v: BondAdSelect) -> u8 {
+impl From<BondAdSelect> for RtBondAdSelect {
+    fn from(v: BondAdSelect) -> RtBondAdSelect {
         match v {
-            BondAdSelect::Stable => BOND_AD_STABLE,
-            BondAdSelect::Bandwidth => BOND_AD_BANDWIDTH,
-            BondAdSelect::Count => BOND_AD_COUNT,
-            BondAdSelect::Other(d) => d,
+            BondAdSelect::Stable => RtBondAdSelect::Stable,
+            BondAdSelect::Bandwidth => RtBondAdSelect::Bandwidth,
+            BondAdSelect::Count => RtBondAdSelect::Count,
+            BondAdSelect::Other(d) => RtBondAdSelect::Other(d),
         }
     }
 }

--- a/src/lib/query/bridge.rs
+++ b/src/lib/query/bridge.rs
@@ -355,7 +355,7 @@ pub(crate) fn get_bridge_port_info(
             InfoBridgePort::MulticastMaxGroups(d) => {
                 ret.multicast_max_groups = Some(*d)
             }
-            InfoBridgePort::NeighVlanSupress(d) => {
+            InfoBridgePort::NeighVlanSuppress(d) => {
                 ret.neigh_vlan_suppress = Some(*d)
             }
             InfoBridgePort::BackupNextHopId(d) => {

--- a/src/lib/query/iface.rs
+++ b/src/lib/query/iface.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashMap, path::Path};
+use std::{collections::HashMap, path::Path, str::FromStr};
 
 use futures::stream::TryStreamExt;
 use rtnetlink::packet_route::link::{
@@ -370,6 +370,16 @@ pub(crate) fn parse_nl_msg_to_iface(
             iface_state.controller = Some(format!("{controller}"));
         } else if let LinkAttribute::Link(l) = nla {
             link = Some(*l);
+        } else if let LinkAttribute::ParentDevName(addr) = nla {
+            if nl_msg.attributes.as_slice().iter().any(|n| {
+                matches!(
+                    n,
+                    LinkAttribute::ParentDevBusName(bus_name)
+                    if bus_name == "pci"
+                )
+            }) {
+                iface_state.pci_address = PciAddress::from_str(addr).ok();
+            }
         } else if let LinkAttribute::PropList(prop_list) = nla {
             iface_state.alt_names = prop_list
                 .iter()

--- a/src/lib/query/inter_ifaces.rs
+++ b/src/lib/query/inter_ifaces.rs
@@ -126,7 +126,9 @@ pub(crate) async fn get_ifaces_with_handle(
     }
 
     for iface in iface_states.values_mut() {
-        iface.fill_pci_address();
+        if iface.pci_address.is_none() {
+            iface.fill_pci_address_by_sysfs();
+        }
     }
 
     // The cfg80211 module might not exists or loaded in environments,

--- a/src/lib/query/pci.rs
+++ b/src/lib/query/pci.rs
@@ -96,11 +96,9 @@ impl FromStr for PciAddress {
 }
 
 impl Iface {
-    // The PCI address only available via ethtool IOCTL `ETHTOOL_GDRVINFO`,
-    // there is no netlink API for this yet. Hence using sysfs required.
     // The systemd `src/udev/udev-builtin-path_id.c` is also using this
-    // information for ID_PATH.
-    pub(crate) fn fill_pci_address(&mut self) {
+    // sysfs information for ID_PATH.
+    pub(crate) fn fill_pci_address_by_sysfs(&mut self) {
         if let Some(dev_path) =
             PathBuf::from(format!("/sys/class/net/{}/device", self.name))
                 .read_link()


### PR DESCRIPTION
Since linux 5.14, kernel expose NIC bus address via `IFLA_PARENT_DEV_NAME`
and `IFLA_PARENT_DEV_BUS_NAME`. The rtnetlink crate 0.21.0 added support of
this.

This patch use those information along to set `Iface.pci_address` saving us
from accessing sysfs. When this information is missing, we still fallback
to use sysfs for checking PCI address of a NIC.