### PR TITLE
infiniband: restore detection of Ipoib iface type

### DIFF
--- a/src/lib/query/bridge.rs
+++ b/src/lib/query/bridge.rs
@@ -513,7 +513,7 @@ fn parse_bridge_info(infos: &[InfoBridge]) -> Result<BridgeInfo, NisporError> {
         } else if let InfoBridge::VlanStatsPerPort(d) = info {
             bridge_info.vlan_stats_per_port = Some(*d);
         } else {
-            log::debug!("Unknown NLA {:?}", &info);
+            log::debug!("Unknown NLA {:?}", info);
         }
     }
     Ok(bridge_info)

--- a/src/lib/query/iface.rs
+++ b/src/lib/query/iface.rs
@@ -420,14 +420,23 @@ pub(crate) fn parse_nl_msg_to_iface(
                         },
                         _ => IfaceType::Other(format!("{t:?}").to_lowercase()),
                     };
-                    // Always prefer InfoKind unless link type is loopback or
-                    // infiniband.
-                    if !matches!(
-                        iface_state.iface_type,
-                        IfaceType::Loopback | IfaceType::Infiniband
-                    ) {
-                        iface_state.iface_type = iface_type;
+
+                    // We prefer LinkLayerType over InfoKind for loopback, as it
+                    // is more accurate in this case. We also prefer it for
+                    // infiniband, but only if we didn't detect a specific
+                    // InfoKind (we detected Other). For example, Ipoib is more
+                    // specific than Infiniband, but Other is not.
+                    if iface_state.iface_type == IfaceType::Loopback
+                        || (iface_state.iface_type == IfaceType::Infiniband
+                            && matches!(iface_type, IfaceType::Other(_)))
+                    {
+                        continue;
                     }
+
+                    // For any other case, we prefer InfoKind over LinkLayerType
+                    // as it is almost always more accurate. LinkLayerType is
+                    // set as ethernet for most device types.
+                    iface_state.iface_type = iface_type;
                 }
             }
             for info in infos {


### PR DESCRIPTION
Fixes 5e13d3f "Prefer LinkInfo::Kind as interface type". This commit made to always prefer InfoKind over anything for Ethernet, but at the same time it made to prefer LinkLayerType over InfoKind for Infiniband. This causes that the Ipoib iface typeis not detected anymore, causing two problems:
- Interfaces previously detected as Ipoib are now detected as Infiniband, breaking some clients like nmstate.
- The Ipoib data is not parsed, as it is only done for Ipoib iface type.

Fix it by prefering the "Infiniband" generic type only if no InfoKind was detected, or InfoKind::Other was detected.

Signed-off-by: Íñigo Huguet <ihuguet@riseup.net>