### PR TITLE
Mark wireguard as optional feature

### DIFF
--- a/src/lib/Cargo.toml
+++ b/src/lib/Cargo.toml
@@ -16,6 +16,10 @@ name = "nispor"
 path = "lib.rs"
 crate-type = ["lib"]
 
+[features]
+default = []
+wireguard = ["dep:nl-wireguard"]
+
 [dependencies]
 serde = { workspace = true }
 rtnetlink = { workspace = true }
@@ -26,7 +30,7 @@ futures = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
 wl-nl80211 = { workspace = true }
-nl-wireguard = { workspace = true }
+nl-wireguard = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_yaml = { workspace = true }

--- a/src/lib/conf/iface.rs
+++ b/src/lib/conf/iface.rs
@@ -10,10 +10,12 @@ use super::{
     super::query::get_ifaces_with_handle, alt_name::change_iface_alt_name,
     base_iface::apply_base_link_changes, ip::change_ip_layer,
 };
+#[cfg(feature = "wireguard")]
+use crate::WireguardConf;
 use crate::{
     AltNameConf, BondConf, BondPortConf, BridgeConf, BridgePortConf, DummyConf,
     ErrorKind, Iface, IfaceState, IfaceType, IpConf, NetStateIfaceFilter,
-    NisporError, VethConf, VlanConf, WireguardConf,
+    NisporError, VethConf, VlanConf,
 };
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
@@ -40,6 +42,7 @@ pub struct IfaceConf {
     pub bond: Option<BondConf>,
     pub bond_port: Option<BondPortConf>,
     pub bridge_port: Option<BridgePortConf>,
+    #[cfg(feature = "wireguard")]
     pub wireguard: Option<WireguardConf>,
 }
 

--- a/src/lib/conf/inter_ifaces.rs
+++ b/src/lib/conf/inter_ifaces.rs
@@ -2,8 +2,12 @@
 
 use rtnetlink::new_connection;
 
-use super::{iface::apply_iface_conf, wireguard::apply_wg_conf};
-use crate::{IfaceConf, IfaceType, NisporError};
+use super::iface::apply_iface_conf;
+#[cfg(feature = "wireguard")]
+use super::wireguard::apply_wg_conf;
+#[cfg(feature = "wireguard")]
+use crate::IfaceType;
+use crate::{IfaceConf, NisporError};
 
 pub(crate) async fn apply_ifaces_conf(
     des_ifaces: &[IfaceConf],
@@ -14,18 +18,30 @@ pub(crate) async fn apply_ifaces_conf(
         apply_iface_conf(&handle, des_iface).await?;
     }
 
+    #[cfg(feature = "wireguard")]
+    apply_wireguard_confs(des_ifaces).await?;
+
+    Ok(())
+}
+
+#[cfg(feature = "wireguard")]
+async fn apply_wireguard_confs(
+    des_ifaces: &[IfaceConf],
+) -> Result<(), NisporError> {
     let wg_ifaces: Vec<_> = des_ifaces
         .iter()
         .filter(|i| i.iface_type == Some(IfaceType::Wireguard))
         .collect();
 
-    if !wg_ifaces.is_empty() {
-        let (wg_connection, mut wg_handle, _) = nl_wireguard::new_connection()?;
-        tokio::spawn(wg_connection);
+    if wg_ifaces.is_empty() {
+        return Ok(());
+    }
 
-        for des_iface in wg_ifaces {
-            apply_wg_conf(&mut wg_handle, des_iface).await?;
-        }
+    let (wg_connection, mut wg_handle, _) = nl_wireguard::new_connection()?;
+    tokio::spawn(wg_connection);
+
+    for des_iface in wg_ifaces {
+        apply_wg_conf(&mut wg_handle, des_iface).await?;
     }
 
     Ok(())

--- a/src/lib/conf/mod.rs
+++ b/src/lib/conf/mod.rs
@@ -14,8 +14,11 @@ mod ip;
 mod route;
 mod veth;
 mod vlan;
+#[cfg(feature = "wireguard")]
 mod wireguard;
 
+#[cfg(feature = "wireguard")]
+pub use self::wireguard::{WireguardConf, WireguardPeerConf};
 pub use self::{
     alt_name::AltNameConf,
     bond::BondConf,
@@ -28,7 +31,6 @@ pub use self::{
     route::RouteConf,
     veth::VethConf,
     vlan::VlanConf,
-    wireguard::{WireguardConf, WireguardPeerConf},
 };
 pub(crate) use self::{
     inter_ifaces::apply_ifaces_conf, route::apply_routes_conf,

--- a/src/lib/error.rs
+++ b/src/lib/error.rs
@@ -160,6 +160,7 @@ impl From<wl_nl80211::Nl80211Error> for NisporError {
     }
 }
 
+#[cfg(feature = "wireguard")]
 impl From<nl_wireguard::WireguardError> for NisporError {
     fn from(e: nl_wireguard::WireguardError) -> Self {
         NisporError {

--- a/src/lib/integ_tests/mod.rs
+++ b/src/lib/integ_tests/mod.rs
@@ -25,5 +25,6 @@ mod veth;
 mod vlan;
 mod vrf;
 mod vxlan;
+#[cfg(feature = "wireguard")]
 mod wireguard;
 mod xfrm;

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -11,11 +11,15 @@ mod net_state;
 mod netlink;
 mod query;
 
+#[cfg(feature = "wireguard")]
+pub use crate::conf::{WireguardConf, WireguardPeerConf};
+#[cfg(feature = "wireguard")]
+pub use crate::query::{WireguardInfo, WireguardIpAddress, WireguardPeerInfo};
 pub use crate::{
     conf::{
         AltNameConf, BondConf, BondPortConf, BridgeConf, BridgePortConf,
         DummyConf, IfaceConf, IpAddrConf, IpConf, RouteConf, VethConf,
-        VlanConf, WireguardConf, WireguardPeerConf,
+        VlanConf,
     },
     error::{ErrorKind, NisporError},
     filter::{
@@ -44,7 +48,6 @@ pub use crate::{
         RouteRule, RouteRuleFlag, RouteScope, RouteType, RuleAction, SriovInfo,
         TunInfo, TunMode, TunnelEncapFlag, TunnelEncapType, VethInfo, VfInfo,
         VfLinkState, VfState, VlanInfo, VlanProtocol, VlanQosMapping, VrfInfo,
-        VrfPortInfo, VxlanInfo, WifiInfo, WifiMode, WireguardInfo,
-        WireguardIpAddress, WireguardPeerInfo, XfrmInfo,
+        VrfPortInfo, VxlanInfo, WifiInfo, WifiMode, XfrmInfo,
     },
 };

--- a/src/lib/query/iface.rs
+++ b/src/lib/query/iface.rs
@@ -29,12 +29,14 @@ use super::{
     vxlan::get_vxlan_info,
     xfrm::get_xfrm_info,
 };
+#[cfg(feature = "wireguard")]
+use crate::WireguardInfo;
 use crate::{
     BondInfo, BondPortInfo, BridgeInfo, BridgePortInfo, ErrorKind, EthtoolInfo,
     HsrInfo, IpTunnelInfo, IpVlanInfo, IpoibInfo, Ipv4Info, Ipv6Info,
     MacSecInfo, MacVlanInfo, MacVtapInfo, MptcpAddress, NisporError,
     PciAddress, SriovInfo, TunInfo, VethInfo, VfInfo, VlanInfo, VrfInfo,
-    VrfPortInfo, VxlanInfo, WifiInfo, WireguardInfo, XfrmInfo,
+    VrfPortInfo, VxlanInfo, WifiInfo, XfrmInfo,
 };
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
@@ -311,6 +313,7 @@ pub struct Iface {
     pub ip_vlan: Option<IpVlanInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wifi: Option<WifiInfo>,
+    #[cfg(feature = "wireguard")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub wireguard: Option<WireguardInfo>,
 }

--- a/src/lib/query/inter_ifaces.rs
+++ b/src/lib/query/inter_ifaces.rs
@@ -8,6 +8,8 @@ use rtnetlink::{
     packet_route::{AddressFamily, link::LinkExtentMask},
 };
 
+#[cfg(feature = "wireguard")]
+use super::wireguard::fill_wireguard;
 use super::{
     bond::bond_iface_tidy_up,
     bridge::bridge_iface_tidy_up,
@@ -29,7 +31,6 @@ use super::{
     vrf::vrf_iface_tidy_up,
     vxlan::vxlan_iface_tidy_up,
     wifi::fill_wifi_info,
-    wireguard::fill_wireguard,
     xfrm::xfrm_iface_tidy_up,
 };
 use crate::{EthtoolInfo, Iface, NetStateIfaceFilter, NisporError};
@@ -138,6 +139,7 @@ pub(crate) async fn get_ifaces_with_handle(
         log::warn!("Failed to query WIFI information {e}");
     }
 
+    #[cfg(feature = "wireguard")]
     fill_wireguard(&mut iface_states).await?;
 
     tidy_up(&mut iface_states);

--- a/src/lib/query/mod.rs
+++ b/src/lib/query/mod.rs
@@ -9,6 +9,7 @@ mod iptunnel;
 mod mptcp;
 mod pci;
 mod wifi;
+#[cfg(feature = "wireguard")]
 mod wireguard;
 mod xfrm;
 // Disable `needless_pass_by_ref_mut` check due to upstream issue:
@@ -31,6 +32,10 @@ mod vlan;
 mod vrf;
 mod vxlan;
 
+#[cfg(feature = "wireguard")]
+pub use self::wireguard::{
+    WireguardInfo, WireguardIpAddress, WireguardPeerInfo,
+};
 pub use self::{
     bond::{
         BondAdInfo, BondAdSelect, BondAllPortActive, BondArpValidate,
@@ -77,7 +82,6 @@ pub use self::{
     vrf::{VrfInfo, VrfPortInfo},
     vxlan::VxlanInfo,
     wifi::{WifiInfo, WifiMode},
-    wireguard::{WireguardInfo, WireguardIpAddress, WireguardPeerInfo},
     xfrm::XfrmInfo,
 };
 pub(crate) use self::{


### PR DESCRIPTION
This allows compiles without nl-wireguard rust crate which does not
exist in Fedora build system yet.