### PR TITLE
vlan: fix ingress_qos_map and egress_qos_map apply

### DIFF
--- a/src/lib/conf/vlan.rs
+++ b/src/lib/conf/vlan.rs
@@ -83,29 +83,52 @@ impl VlanConf {
                 builder = builder.flags(flags, flags_mask);
             }
 
-            match (
-                vlan_conf.ingress_qos_map.as_ref(),
-                vlan_conf.egress_qos_map.as_ref(),
-            ) {
-                (Some(ingress), Some(egress)) => {
-                    builder = builder.qos(
-                        ingress.iter().map(|m| m.into()),
-                        egress.iter().map(|m| m.into()),
-                    );
-                }
-                (None, None) => (),
-                (Some(ingress), None) => {
-                    builder = builder.qos(
-                        ingress.iter().map(|m| m.into()),
-                        std::iter::empty(),
-                    );
-                }
-                (None, Some(egress)) => {
-                    builder = builder.qos(
-                        std::iter::empty(),
-                        egress.iter().map(|m| m.into()),
-                    );
-                }
+            let cur_vlan_info = cur_iface.and_then(|i| i.vlan.as_ref());
+
+            let effective_ingress: Vec<VlanQosMapping> =
+                if let Some(desired) = vlan_conf.ingress_qos_map.as_ref() {
+                    let mut result = desired.clone();
+                    // Kernel only sets/overwrites individual entries on
+                    // changelink; to remove an entry we must explicitly
+                    // set its `to` to 0.
+                    if let Some(cur_info) = cur_vlan_info {
+                        for cur_map in &cur_info.ingress_qos_map {
+                            if !desired.iter().any(|d| d.from == cur_map.from) {
+                                result.push(VlanQosMapping {
+                                    from: cur_map.from,
+                                    to: 0,
+                                });
+                            }
+                        }
+                    }
+                    result
+                } else {
+                    Vec::new()
+                };
+
+            let effective_egress: Vec<VlanQosMapping> =
+                if let Some(desired) = vlan_conf.egress_qos_map.as_ref() {
+                    let mut result = desired.clone();
+                    if let Some(cur_info) = cur_vlan_info {
+                        for cur_map in &cur_info.egress_qos_map {
+                            if !desired.iter().any(|d| d.from == cur_map.from) {
+                                result.push(VlanQosMapping {
+                                    from: cur_map.from,
+                                    to: 0,
+                                });
+                            }
+                        }
+                    }
+                    result
+                } else {
+                    Vec::new()
+                };
+
+            if !effective_ingress.is_empty() || !effective_egress.is_empty() {
+                builder = builder.qos(
+                    effective_ingress.iter().map(|m| m.into()),
+                    effective_egress.iter().map(|m| m.into()),
+                );
             }
         }
         Ok(builder)

--- a/src/lib/integ_tests/vlan.rs
+++ b/src/lib/integ_tests/vlan.rs
@@ -50,6 +50,12 @@ interfaces:
       is-loose-binding: false
       is-mvrp: false
       is-bridge-binding: false
+      ingress-qos-map:
+      - from: 4
+        to: 6
+      egress-qos-map:
+      - from: 9
+        to: 3
 "#;
 
 const VLAN_DELETE_YML: &str = r#"---
@@ -97,19 +103,11 @@ is-loose-binding: false
 is-mvrp: false
 is-bridge-binding: false
 ingress-qos-map:
-- from: 2
-  to: 9
-- from: 3
-  to: 8
 - from: 4
-  to: 7
+  to: 6
 egress-qos-map:
-- from: 7
-  to: 4
-- from: 8
-  to: 3
 - from: 9
-  to: 2
+  to: 3
 "#;
 
 #[test]


### PR DESCRIPTION
When deleting certain qos_map from existing VLAN in kernel, we need to
explicitly set `to: 0` because kernel only allows override and append.

Integration test case included.