### PR TITLE
veth: do not fail if veth peer not changed

### DIFF
--- a/src/lib/conf/veth.rs
+++ b/src/lib/conf/veth.rs
@@ -12,15 +12,31 @@ impl VethConf {
         cur_iface: Option<&Iface>,
     ) -> Result<LinkMessageBuilder<LinkVeth>, NisporError> {
         if let Some(veth_conf) = &iface.veth {
-            if cur_iface.as_ref().and_then(|c| c.veth.as_ref()).is_some() {
-                Err(NisporError::new(
-                    ErrorKind::InvalidArgument,
-                    format!(
-                        "Please remove veth section since veth interface {} \
-                         already exists",
-                        iface.name
-                    ),
-                ))
+            if let Some(cur_veth_peer) = cur_iface
+                .as_ref()
+                .and_then(|c| c.veth.as_ref())
+                .map(|v| v.peer.as_str())
+            {
+                if !veth_conf.peer.is_empty()
+                    // When veth peer is creating, the veth peer is a index
+                    // number don't have name yet. In that case we don't fail.
+                    && cur_veth_peer.parse::<i32>().is_err()
+                    && veth_conf.peer.as_str() != cur_veth_peer
+                {
+                    Err(NisporError::new(
+                        ErrorKind::InvalidArgument,
+                        format!(
+                            "Cannot change veth interface {} peer from {} to \
+                             {} without removing a veth first",
+                            iface.name, cur_veth_peer, veth_conf.peer
+                        ),
+                    ))
+                } else {
+                    Ok(LinkMessageBuilder::<LinkVeth>::new_with_info_kind(
+                        InfoKind::Veth,
+                    )
+                    .name(iface.name.to_string()))
+                }
             } else {
                 Ok(LinkVeth::new(iface.name.as_str(), veth_conf.peer.as_str()))
             }


### PR DESCRIPTION
When applying a veth config with veth interface exist, we should
not raise when veth peer not changed.