### PR TITLE
conf: support applying VRF interface

### DIFF
--- a/src/lib/conf/iface.rs
+++ b/src/lib/conf/iface.rs
@@ -13,7 +13,7 @@ use super::{
 use crate::{
     AltNameConf, BondConf, BondPortConf, BridgeConf, BridgePortConf, DummyConf,
     ErrorKind, Iface, IfaceState, IfaceType, IpConf, NetStateIfaceFilter,
-    NisporError, VethConf, VlanConf, VxlanConf, WireguardConf,
+    NisporError, VethConf, VlanConf, VrfConf, VxlanConf, WireguardConf,
 };
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
@@ -36,6 +36,7 @@ pub struct IfaceConf {
     pub veth: Option<VethConf>,
     pub bridge: Option<BridgeConf>,
     pub vlan: Option<VlanConf>,
+    pub vrf: Option<VrfConf>,
     pub vxlan: Option<VxlanConf>,
     #[serde(alias = "link-aggregation")]
     pub bond: Option<BondConf>,
@@ -175,6 +176,19 @@ async fn gen_link_msg(
                 handle,
                 VlanConf::gen_link_msg_builder(handle, des_iface, cur_iface)
                     .await?,
+                des_iface,
+                cur_iface,
+            )
+            .await?
+        }
+        Some(IfaceType::Vrf) => {
+            // The Linux kernel does not support changing the route table
+            // ID of an existing VRF interface, nispor will not delete and
+            // recreate the VRF interface automatically, the caller should
+            // delete and recreate it when the table ID is changed.
+            apply_base_link_changes(
+                handle,
+                VrfConf::gen_link_msg_builder(des_iface, cur_iface)?,
                 des_iface,
                 cur_iface,
             )

--- a/src/lib/conf/mod.rs
+++ b/src/lib/conf/mod.rs
@@ -14,6 +14,7 @@ mod ip;
 mod route;
 mod veth;
 mod vlan;
+mod vrf;
 mod vxlan;
 mod wireguard;
 
@@ -29,6 +30,7 @@ pub use self::{
     route::RouteConf,
     veth::VethConf,
     vlan::VlanConf,
+    vrf::VrfConf,
     vxlan::VxlanConf,
     wireguard::{WireguardConf, WireguardPeerConf},
 };

--- a/src/lib/conf/vrf.rs
+++ b/src/lib/conf/vrf.rs
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use rtnetlink::{LinkMessageBuilder, LinkVrf, packet_route::link::InfoKind};
+use serde::{Deserialize, Serialize};
+
+use crate::{ErrorKind, Iface, IfaceConf, NisporError};
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+#[non_exhaustive]
+pub struct VrfConf {
+    pub table_id: Option<u32>,
+}
+
+impl VrfConf {
+    pub(crate) fn gen_link_msg_builder(
+        iface: &IfaceConf,
+        cur_iface: Option<&Iface>,
+    ) -> Result<LinkMessageBuilder<LinkVrf>, NisporError> {
+        let mut builder =
+            LinkMessageBuilder::<LinkVrf>::new_with_info_kind(InfoKind::Vrf)
+                .name(iface.name.to_string());
+
+        let Some(table_id) = iface.vrf.as_ref().and_then(|c| c.table_id) else {
+            if cur_iface.is_none() {
+                return Err(NisporError::new(
+                    ErrorKind::InvalidArgument,
+                    format!(
+                        "Need table ID for creating new VRF {}",
+                        iface.name
+                    ),
+                ));
+            }
+            return Ok(builder);
+        };
+
+        if table_id == 0 {
+            return Err(NisporError::new(
+                ErrorKind::InvalidArgument,
+                format!("Invalid VRF table ID 0 for {}", iface.name),
+            ));
+        }
+
+        if let Some(cur_iface) = cur_iface {
+            if cur_iface.vrf.as_ref().map(|v| v.table_id) != Some(table_id) {
+                return Err(NisporError::new(
+                    ErrorKind::InvalidArgument,
+                    format!(
+                        "VRF table ID of {} cannot be changed, please delete \
+                         and recreate the VRF interface",
+                        iface.name
+                    ),
+                ));
+            }
+            // The kernel rejects IFLA_VRF_TABLE on an existing VRF
+            // (changelink is not supported), so skip it when the table ID
+            // is unchanged to keep re-applying the same config a no-op.
+        } else {
+            builder = builder.table_id(table_id);
+        }
+
+        Ok(builder)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rtnetlink::packet_route::link::{
+        InfoData, InfoVrf, LinkAttribute, LinkInfo, LinkMessage,
+    };
+
+    use super::*;
+    use crate::{Iface, IfaceConf, IfaceType, VrfInfo};
+
+    fn vrf_iface_conf(table_id: Option<u32>) -> IfaceConf {
+        IfaceConf {
+            name: "vrf0".to_string(),
+            iface_type: Some(IfaceType::Vrf),
+            vrf: Some(VrfConf { table_id }),
+            ..Default::default()
+        }
+    }
+
+    fn vrf_iface(table_id: u32) -> Iface {
+        Iface {
+            name: "vrf0".to_string(),
+            vrf: Some(VrfInfo {
+                table_id,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn has_vrf_info_data(msg: &LinkMessage) -> bool {
+        msg.attributes.iter().any(|attr| match attr {
+            LinkAttribute::LinkInfo(infos) => infos.iter().any(|info| {
+                matches!(
+                    info,
+                    LinkInfo::Data(InfoData::Vrf(vrf_infos))
+                        if vrf_infos.iter().any(|v| {
+                            matches!(v, InfoVrf::TableId(_))
+                        })
+                )
+            }),
+            _ => false,
+        })
+    }
+
+    #[test]
+    fn new_vrf_includes_table_id() {
+        let msg =
+            VrfConf::gen_link_msg_builder(&vrf_iface_conf(Some(10)), None)
+                .unwrap()
+                .build();
+
+        assert!(has_vrf_info_data(&msg));
+    }
+
+    #[test]
+    fn existing_vrf_with_same_table_id_skips_info_data() {
+        let msg = VrfConf::gen_link_msg_builder(
+            &vrf_iface_conf(Some(10)),
+            Some(&vrf_iface(10)),
+        )
+        .unwrap()
+        .build();
+
+        assert!(!has_vrf_info_data(&msg));
+    }
+
+    #[test]
+    fn existing_vrf_with_different_table_id_rejected() {
+        let err = VrfConf::gen_link_msg_builder(
+            &vrf_iface_conf(Some(20)),
+            Some(&vrf_iface(10)),
+        )
+        .unwrap_err();
+
+        assert!(matches!(err.kind, ErrorKind::InvalidArgument));
+        assert!(err.msg.contains("delete and recreate"));
+    }
+
+    #[test]
+    fn new_vrf_without_table_id_rejected() {
+        let confs = [
+            IfaceConf {
+                name: "vrf0".to_string(),
+                iface_type: Some(IfaceType::Vrf),
+                vrf: None,
+                ..Default::default()
+            },
+            vrf_iface_conf(None),
+        ];
+
+        for conf in confs {
+            let err = VrfConf::gen_link_msg_builder(&conf, None).unwrap_err();
+            assert!(matches!(err.kind, ErrorKind::InvalidArgument));
+        }
+    }
+
+    #[test]
+    fn zero_table_id_rejected() {
+        let err = VrfConf::gen_link_msg_builder(&vrf_iface_conf(Some(0)), None)
+            .unwrap_err();
+
+        assert!(matches!(err.kind, ErrorKind::InvalidArgument));
+    }
+}

--- a/src/lib/integ_tests/vrf.rs
+++ b/src/lib/integ_tests/vrf.rs
@@ -5,7 +5,7 @@ use std::panic;
 use pretty_assertions::assert_eq;
 
 use super::utils::assert_value_match;
-use crate::NetState;
+use crate::{ErrorKind, IfaceState, NetConf, NetState};
 
 const IFACE_NAME: &str = "vrf0";
 
@@ -14,6 +14,37 @@ table-id: 10
 ports:
   - eth1
   - eth2"#;
+
+const VRF_ENV_CREATE_YML: &str = r#"---
+interfaces:
+  - name: vrf0
+    type: vrf
+    vrf:
+      table-id: 10
+  - name: eth1
+    type: veth
+    veth:
+      peer: eth1.ep
+    controller: vrf0
+  - name: eth2
+    type: veth
+    veth:
+      peer: eth2.ep
+    controller: vrf0
+"#;
+
+const VRF_ENV_DELETE_YML: &str = r#"---
+interfaces:
+  - name: vrf0
+    type: vrf
+    state: absent
+  - name: eth1
+    type: veth
+    state: absent
+  - name: eth2
+    type: veth
+    state: absent
+"#;
 
 #[test]
 fn test_get_vrf_iface_yaml() {
@@ -29,12 +60,116 @@ fn with_vrf_iface<T>(test: T)
 where
     T: FnOnce() + panic::UnwindSafe,
 {
-    super::utils::set_network_environment("vrf");
+    let net_conf: NetConf = serde_yaml::from_str(VRF_ENV_CREATE_YML).unwrap();
+    net_conf.apply().unwrap();
 
     let result = panic::catch_unwind(|| {
         test();
     });
 
-    super::utils::clear_network_environment();
+    let net_conf: NetConf = serde_yaml::from_str(VRF_ENV_DELETE_YML).unwrap();
+    net_conf.apply().unwrap();
     assert!(result.is_ok())
+}
+
+const VRF_CREATE_YML: &str = r#"---
+interfaces:
+  - name: vrf0
+    type: vrf
+    vrf:
+      table-id: 10
+  - name: dummy1
+    type: dummy
+    controller: vrf0
+  - name: dummy2
+    type: dummy
+    controller: vrf0
+"#;
+
+const VRF_DELETE_YML: &str = r#"---
+interfaces:
+  - name: vrf0
+    type: vrf
+    state: absent
+  - name: dummy1
+    type: dummy
+    state: absent
+  - name: dummy2
+    type: dummy
+    state: absent
+"#;
+
+const VRF_CHANGE_TABLE_YML: &str = r#"---
+interfaces:
+  - name: vrf0
+    type: vrf
+    vrf:
+      table-id: 20
+"#;
+
+#[test]
+fn test_create_and_delete_vrf() {
+    let net_conf: NetConf = serde_yaml::from_str(VRF_CREATE_YML).unwrap();
+    net_conf.apply().unwrap();
+
+    let result = panic::catch_unwind(|| {
+        let state = NetState::retrieve().unwrap();
+        let vrf0 = &state.ifaces[IFACE_NAME];
+        assert_eq!(vrf0.iface_type, crate::IfaceType::Vrf);
+        assert_eq!(vrf0.state, IfaceState::Up);
+        assert_eq!(vrf0.vrf.as_ref().unwrap().table_id, 10);
+        assert_eq!(
+            vrf0.vrf.as_ref().unwrap().ports,
+            vec!["dummy1".to_string(), "dummy2".to_string()]
+        );
+        assert_eq!(
+            state.ifaces["dummy1"].controller.as_deref(),
+            Some(IFACE_NAME)
+        );
+        assert_eq!(
+            state.ifaces["dummy2"].controller.as_deref(),
+            Some(IFACE_NAME)
+        );
+    });
+
+    let net_conf: NetConf = serde_yaml::from_str(VRF_DELETE_YML).unwrap();
+    net_conf.apply().unwrap();
+    let state = NetState::retrieve().unwrap();
+    assert_eq!(None, state.ifaces.get(IFACE_NAME));
+    assert!(result.is_ok())
+}
+
+#[test]
+fn test_reapply_vrf_conf() {
+    let net_conf: NetConf = serde_yaml::from_str(VRF_CREATE_YML).unwrap();
+    net_conf.apply().unwrap();
+
+    // Re-applying the same configuration must succeed as a no-op.
+    let net_conf: NetConf = serde_yaml::from_str(VRF_CREATE_YML).unwrap();
+    net_conf.apply().unwrap();
+
+    let result = panic::catch_unwind(|| {
+        let state = NetState::retrieve().unwrap();
+        let vrf0 = &state.ifaces[IFACE_NAME];
+        assert_eq!(vrf0.iface_type, crate::IfaceType::Vrf);
+        assert_eq!(vrf0.vrf.as_ref().unwrap().table_id, 10);
+    });
+
+    let net_conf: NetConf = serde_yaml::from_str(VRF_DELETE_YML).unwrap();
+    net_conf.apply().unwrap();
+    assert!(result.is_ok())
+}
+
+#[test]
+fn test_change_vrf_table_id_rejected() {
+    let net_conf: NetConf = serde_yaml::from_str(VRF_CREATE_YML).unwrap();
+    net_conf.apply().unwrap();
+
+    let net_conf: NetConf = serde_yaml::from_str(VRF_CHANGE_TABLE_YML).unwrap();
+    let err = net_conf.apply().unwrap_err();
+    assert!(matches!(err.kind, ErrorKind::InvalidArgument));
+    assert!(err.msg.contains("delete and recreate"));
+
+    let net_conf: NetConf = serde_yaml::from_str(VRF_DELETE_YML).unwrap();
+    net_conf.apply().unwrap();
 }

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -15,7 +15,7 @@ pub use crate::{
     conf::{
         AltNameConf, BondConf, BondPortConf, BridgeConf, BridgePortConf,
         DummyConf, IfaceConf, IpAddrConf, IpConf, RouteConf, VethConf,
-        VlanConf, VxlanConf, WireguardConf, WireguardPeerConf,
+        VlanConf, VrfConf, VxlanConf, WireguardConf, WireguardPeerConf,
     },
     error::{ErrorKind, NisporError},
     filter::{


### PR DESCRIPTION
Introducing support for creating VRF interface:

```yml
interfaces:
- name: vrf0
  type: vrf
  vrf:
    table-id: 10
```

The Linux kernel does not support changing the route table ID of an
existing VRF interface, nispor will not delete and recreate the VRF
interface automatically. The caller should delete and recreate it when
the table ID is changed.

Integration test cases included.