### PR TITLE
conf: expose RouteMultipathConf for external callers

### DIFF
--- a/src/lib/conf/mod.rs
+++ b/src/lib/conf/mod.rs
@@ -27,7 +27,7 @@ pub use self::{
     dummy::DummyConf,
     iface::IfaceConf,
     ip::{IpAddrConf, IpConf},
-    route::RouteConf,
+    route::{RouteConf, RouteMultipathConf},
     veth::VethConf,
     vlan::VlanConf,
     vrf::VrfConf,

--- a/src/lib/conf/route.rs
+++ b/src/lib/conf/route.rs
@@ -24,7 +24,7 @@ pub struct RouteConf {
     pub table: Option<u8>,
     pub protocol: Option<RouteProtocol>,
     /// ECMP(Equal-Cost Multipath Protocol) routes
-    pub multipath: Option<Vec<RouteMulitpathConf>>,
+    pub multipath: Option<Vec<RouteMultipathConf>>,
     /// Pretend the nexthop is directly attached to this link, even if it
     /// does not match any interface prefix
     #[serde(default)]
@@ -164,14 +164,14 @@ async fn apply_route_conf(
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
-pub struct RouteMulitpathConf {
+pub struct RouteMultipathConf {
     /// nexthop address
-    via: Option<String>,
+    pub via: Option<String>,
     /// weight on route path been selected, in the range of 1 - 256
-    weight: Option<u16>,
+    pub weight: Option<u16>,
     /// Output interface
-    iface: Option<String>,
+    pub iface: Option<String>,
     /// Pretend the nexthop is directly attached to this link
     #[serde(default)]
-    flags: Vec<MultipathRouteFlag>,
+    pub flags: Vec<MultipathRouteFlag>,
 }

--- a/src/lib/conf/route.rs
+++ b/src/lib/conf/route.rs
@@ -116,6 +116,14 @@ async fn apply_route_conf(
                 })?;
             }
             if let Some(w) = mpath.weight.as_ref() {
+                if !(1..=256).contains(w) {
+                    let e = NisporError::invalid_argument(format!(
+                        "Invalid ECMP route weight {w}, must be in range \
+                         1..=256"
+                    ));
+                    log::error!("{e}");
+                    return Err(e);
+                }
                 np_builder = np_builder.weight((*w - 1) as u8);
             }
             if let Some(iface) = mpath.iface.as_ref() {

--- a/src/lib/filter/route.rs
+++ b/src/lib/filter/route.rs
@@ -96,7 +96,7 @@ pub(crate) fn should_drop_by_filter(
     if Some(&RouteScope::Universe) == filter.scope.as_ref() {
         route.scope != RouteScope::Universe
     } else {
-        if !has_kernel_filter
+        !has_kernel_filter
             && ((filter.protocol.is_some()
                 && filter.protocol != Some(route.protocol))
                 || (filter.scope.is_some()
@@ -106,9 +106,5 @@ pub(crate) fn should_drop_by_filter(
                 || (filter.table.is_some()
                     && filter.table.as_ref().map(|i| (*i).into())
                         != Some(route.table)))
-        {
-            return true;
-        }
-        false
     }
 }

--- a/src/lib/integ_tests/route.rs
+++ b/src/lib/integ_tests/route.rs
@@ -333,6 +333,58 @@ fn test_add_and_remove_ecmp_route() {
     })
 }
 
+#[test]
+fn test_ecmp_route_weight_zero_invalid() {
+    with_veth_static_ip(|| {
+        let state_str = r#"
+routes:
+- dst: 2001:db8:e::/64
+  multipath:
+    - via: 2001:db8:a::2
+      weight: 0
+      iface: veth1
+"#;
+        let net_conf: NetConf = serde_yaml::from_str(state_str).unwrap();
+        assert!(net_conf.apply().is_err());
+    })
+}
+
+#[test]
+fn test_ecmp_route_weight_256_valid() {
+    with_veth_static_ip(|| {
+        let state_str = r#"
+routes:
+- dst: 2001:db8:e::/64
+  metric: 506
+  protocol: dhcp
+  multipath:
+    - via: 2001:db8:a::2
+      weight: 256
+      iface: veth1
+      flags:
+        - onlink
+"#;
+        let net_conf: NetConf = serde_yaml::from_str(state_str).unwrap();
+        net_conf.apply().unwrap();
+    })
+}
+
+#[test]
+fn test_ecmp_route_weight_257_invalid() {
+    with_veth_static_ip(|| {
+        let state_str = r#"
+routes:
+- dst: 2001:db8:e::/64
+  multipath:
+    - via: 2001:db8:a::2
+      weight: 257
+      iface: veth1
+"#;
+        let net_conf: NetConf = serde_yaml::from_str(state_str).unwrap();
+        assert!(net_conf.apply().is_err());
+    })
+}
+
 const ADD_ONLINK_ROUTE_YML: &str = r#"---
 routes:
 - dst: 203.0.113.0/24

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -14,8 +14,9 @@ mod query;
 pub use crate::{
     conf::{
         AltNameConf, BondConf, BondPortConf, BridgeConf, BridgePortConf,
-        DummyConf, IfaceConf, IpAddrConf, IpConf, RouteConf, VethConf,
-        VlanConf, VrfConf, VxlanConf, WireguardConf, WireguardPeerConf,
+        DummyConf, IfaceConf, IpAddrConf, IpConf, RouteConf,
+        RouteMultipathConf, VethConf, VlanConf, VrfConf, VxlanConf,
+        WireguardConf, WireguardPeerConf,
     },
     error::{ErrorKind, NisporError},
     filter::{


### PR DESCRIPTION
Make the struct fields pub, and export the type from the crate so that callers outside nispor can construct multipath route configs directly.

Also fixes the typo in the struct name (s/Mulit/Multi/).

follow up work which uses this: https://github.com/nmstate/nmstate/pull/3206